### PR TITLE
Fix the ctype unit tests

### DIFF
--- a/js/test/ctype/test/testctype.js
+++ b/js/test/ctype/test/testctype.js
@@ -37,7 +37,7 @@ var Currency = require("./../lib/Currency.js");
 var CType = require("./../lib/CType.js");
 var IString = require("./../lib/IString.js");
 
-function setUp() {
+if (ilib.isDynData()) {
 	// now load the data
 	isAlnum._init(true);	
 	isAlpha._init(true);


### PR DESCRIPTION
Preload the dynamic data based on the results of ilib.isDynData() instead
of using the setUp() method of the test framework, which doesn't seem
to work correctly in this case.