### PR TITLE
Country class is newly added

### DIFF
--- a/js/lib/Country.js
+++ b/js/lib/Country.js
@@ -1,0 +1,224 @@
+/*
+ * Country.js - Country class to get country name corresponding to country code in locale assigned
+ * 
+ * Copyright © 2017, LGE
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// !depends ilib.js Utils.js Locale.js LocaleInfo.js ResBundle.js
+
+// !data ctrynames
+
+var ilib = require("./ilib.js");
+var Utils = require("./Utils.js");
+var Locale = require("./Locale.js");
+var LocaleInfo = require("./LocaleInfo.js");
+var ResBundle = require("./ResBundle.js");
+
+/**
+ * @class
+ * Create a new country information instance. Instances of this class encode 
+ * information about country name.<p>
+ * 
+ * The options can contain any of the following properties:
+ * 
+ * <ul>
+ * <li><i>locale</i> - specify the locale for this instance. Country names are provided 
+ * in the language of this locale.
+ *
+ * <li><i>onLoad</i> - a callback function to call when the country name data is fully 
+ * loaded. When the onLoad option is given, this class will attempt to
+ * load any missing locale data using the ilib loader callback.
+ * When the constructor is done (even if the data is already preassembled), the 
+ * onLoad function is called with the current instance as a parameter, so this
+ * callback can be used with preassembled or dynamic loading or a mix of the two. 
+ *
+ * <li><i>sync</i> - tell whether to load any missing locale data synchronously or 
+ * asynchronously. If this option is given as "false", then the "onLoad"
+ * callback must be given, as the instance returned from this constructor will
+ * not be usable for a while.
+ *
+ * <li><i>loadParams</i> - an object containing parameters to pass to the 
+ * loader callback function when locale data is missing. The parameters are not
+ * interpretted or modified in any way. They are simply passed along. The object 
+ * may contain any property/value pairs as long as the calling code is in
+ * agreement with the loader callback function as to what those parameters mean.
+ * </ul>
+ * 
+ * If the locale is not set, the default locale(en-US) will be used.<p>
+ * 
+ * @constructor
+ * @param options {Object} a set of properties to govern how this instance is constructed.
+ */
+var Country = function (options) {
+	var sync = true,
+	    loadParams = undefined,
+	    locale, localeinfo;
+
+	if (options) {
+		if (options.locale) {
+			this.locale = (typeof(options.locale) === 'string') ? new Locale(options.locale) : options.locale;
+		}
+		if (typeof(options.sync) !== 'undefined') {
+			sync = options.sync;
+		}
+		if (options.loadParams) {
+			loadParams = options.loadParams;
+		}
+	}
+
+	this.locale = this.locale || new Locale();
+	localeinfo = new LocaleInfo(this.locale);
+	
+	if(localeinfo.getRegionName() === undefined) {
+		locale = 'en-US';
+	} else {
+		locale = this.locale;
+	}
+	
+	if (!this.countryToCode) {
+		Utils.loadData({
+			name: "ctrynames.json",
+			object: Country, 
+			locale: locale,
+			sync: sync, 
+			loadParams: loadParams, 
+			callback: ilib.bind(this, function(countries) {
+				this.countryToCode = countries;
+				this._loadLocinfo(options && options.onLoad);
+			})
+		});
+	} else {
+		this._loadLocinfo(options && options.onLoad);
+	}
+};
+
+/**
+ * Return an array of the ids for all ISO 3166-1 alpha-2 code that
+ * this copy of ilib knows about.
+ * 
+ * @static
+ * @return {Object} an object of country code that this copy of ilib knows about.
+ */
+Country.getAvailableCode = function() {
+	var ret = [],
+		country,
+		countries = new ResBundle({
+			name: "ctrynames"
+		}).getResObj();
+	
+	for (country in countries) {
+		if (country && countries[country]) {
+			ret.push(countries[country]);
+		}
+	}		
+	
+	return ret;
+};
+
+/**
+ * Return an array of country names that this copy of ilib knows about.
+ * 
+ * @static
+ * @return {Object} an object of country code that this copy of ilib knows about.
+ */
+Country.getAvailableCountry = function() {
+	var ret = [],
+		country,
+		countries = new ResBundle({
+			name: "ctrynames"
+		}).getResObj();
+	
+	for (country in countries) {
+		if (country && countries[country]) {
+			ret.push(country);
+		}
+	}
+	
+	return ret;
+};
+
+Country.prototype = {
+	/**
+	 * @private
+	 */
+	_loadLocinfo: function(onLoad) {
+		new LocaleInfo(this.locale, {
+			onLoad: ilib.bind(this, function (li) {
+				var temp = this.countryToCode,
+				    ctry;
+
+				this.codeToCountry = {};
+				this.locinfo = li;
+
+				for (ctry in temp) {
+					if (ctry && temp[ctry]) {
+						this.codeToCountry[temp[ctry]] = ctry;
+					}
+				}		
+
+				if (typeof(onLoad) === 'function') {
+					onLoad(this);
+				}
+			})
+		});
+	},
+	
+	/**
+	 * Return the country code corresponding to the country name given.
+	 * If the country name is given, but it is not found in the list of known countries, this
+	 * method will throw an exception.
+	 * @param {string} ctryname The country name in the language of the locale of this instance
+	 * @return {string} the country code corresponding to the country name
+	 * @throws "Country xx is unknown" when the given country name is not in the list of 
+	 * known country names. xx is replaced with the requested country name.
+	 */
+	getCode: function (ctryname) {
+		if (!this.countryToCode[ctryname]) {
+			throw "Country " + ctryname + " is unknown";
+		}
+		return this.countryToCode[ctryname];
+	},
+	
+	/**
+	 * Return the country name corresponding to the country code given.
+	 * If the code is given, but it is not found in the list of known countries, this
+	 * method will throw an exception.
+	 * @param {string} code The country code to get the country name
+	 * @return {string} the country name in the language of the locale of this instance
+	 * @throws "Country xx is unknown" when the given country code is not in the list of 
+	 * known country codes. xx is replaced with the requested country code.
+	 */
+	getName: function (code) {
+		if (!this.codeToCountry[code]) {
+			throw "Country " + code + " is unknown";
+		}
+		return this.codeToCountry[code];
+	},
+	
+	/**
+	 * Return the locale for this country. If the options to the constructor 
+	 * included a locale property in order to find the country that is appropriate
+	 * for that locale, then the locale is returned here. If the options did not
+	 * include a locale, then this method returns undefined.
+	 * @return {Locale} the locale used in the constructor of this instance,
+	 * or undefined if no locale was given in the constructor
+	 */
+	getLocale: function () {
+		return this.locale;
+	}
+};
+
+module.exports = Country;

--- a/js/lib/Country.js
+++ b/js/lib/Country.js
@@ -82,7 +82,7 @@ var Country = function (options) {
 	this.locale = this.locale || new Locale();
 	localeinfo = new LocaleInfo(this.locale);
 	
-	if(localeinfo.getRegionName() === undefined) {
+	if (localeinfo.getRegionName() === undefined) {
 		locale = 'en-US';
 	} else {
 		locale = this.locale;

--- a/js/lib/ilib-full-inc.js
+++ b/js/lib/ilib-full-inc.js
@@ -109,4 +109,5 @@ CharmapTable.js
 UTF8.js
 UTF16BE.js
 UTF16LE.js
+Country.js
 */

--- a/js/lib/ilib-ut-inc.js
+++ b/js/lib/ilib-ut-inc.js
@@ -104,6 +104,7 @@ FuelConsumptionUnit.js
 VolumeUnit.js	
 EnergyUnit.js
 Charset.js
+Country.js
 */
 
 /* !data

--- a/js/test/root/test/testCountry.html
+++ b/js/test/root/test/testCountry.html
@@ -1,0 +1,27 @@
+<!--
+testCountry.html - Test the country information object.
+
+Copyright © 2017, LGE
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<html>
+<head>
+<script type="text/javascript" src="../../../../tools/jsunit/app/jsUnitCore.js"></script>
+<script language="JavaScript" src="../../../output/js/ilib-ut.js"></script>
+<script language="JavaScript" src="../../../lib/ilib-stubs-map.js"></script>
+<script language="JavaScript" src="testcountry.js"></script>
+</head>
+</html>

--- a/js/test/root/test/testCountryCompiled.html
+++ b/js/test/root/test/testCountryCompiled.html
@@ -1,0 +1,27 @@
+<!--
+testCountryCompiled.html - Test the country information object.
+
+Copyright © 2017, LGE
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<html>
+<head>
+<script type="text/javascript" src="../../../../tools/jsunit/app/jsUnitCore.js"></script>
+<script language="JavaScript" src="../../../output/js/ilib-ut-compiled.js"></script>
+<script language="JavaScript" src="../../../lib/ilib-stubs-map.js"></script>
+<script language="JavaScript" src="testcountry.js"></script>
+</head>
+</html>

--- a/js/test/root/test/testRootDyn.html
+++ b/js/test/root/test/testRootDyn.html
@@ -38,5 +38,6 @@ if (ilib._getPlatform() === "browser" && ilib._getBrowser() === "opera") {
 <script language="JavaScript" src="testresources.js"></script>
 <script language="JavaScript" src="testscriptinfo.js"></script>
 <script language="JavaScript" src="testcharset.js"></script>
+<script language="JavaScript" src="testcountry.js"></script>
 </head>
 </html>

--- a/js/test/root/test/testSuite.html
+++ b/js/test/root/test/testSuite.html
@@ -36,6 +36,7 @@ function suite() {
     s.addTestPage(dir + "testGlobal.html");
     s.addTestPage(dir + "testScriptInfo.html");
     s.addTestPage(dir + "testCharset.html");
+    s.addTestPage(dir + "testCountry.html");
 
     s.addTestPage(dir + "testLocaleCompiled.html");
     s.addTestPage(dir + "testLocaleInfoCompiled.html");
@@ -44,6 +45,7 @@ function suite() {
     s.addTestPage(dir + "testGlobalCompiled.html");
     s.addTestPage(dir + "testScriptInfoCompiled.html");
     s.addTestPage(dir + "testCharsetCompiled.html");
+    s.addTestPage(dir + "testCountryCompiled.html");
 
     return s;
 }

--- a/js/test/root/test/testSuite.js
+++ b/js/test/root/test/testSuite.js
@@ -38,7 +38,8 @@ function suite() {
 		"testscriptinfo.js",
 		"teststrings.js",
 		"testlocalematch.js",
-		"testcharset.js"
+		"testcharset.js",
+		"testcountry.js"
 	];
 
     suites.forEach(function (path) {

--- a/js/test/root/test/testcountry.js
+++ b/js/test/root/test/testcountry.js
@@ -1,0 +1,134 @@
+/*
+ * testcountry.js - test the country routines
+ *
+ * Copyright © 2017, LGE
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Country = require("./../lib/Country.js");
+
+function testCountryConstructorEmpty() {
+    var ctry = new Country();
+
+    assertNotNull(ctry);
+}
+
+function testCountryDefaultLocale() {
+    var ctry = new Country();
+    assertNotNull(ctry);
+
+    var locale = ctry.getLocale();
+    assertNotUndefined(locale);
+    assertEquals("en-US", locale.toString());
+}
+
+function testCountryWrongLocale() {
+    var ctry = new Country({
+        locale: "abc-YZ"
+    });
+    assertNotNull(ctry);
+
+    assertEquals("Congo - Kinshasa", ctry.getName("CD"));
+    assertEquals("CD", ctry.getCode("Congo - Kinshasa"));
+    var locale = ctry.getLocale();
+    assertNotUndefined(locale);
+    assertEquals("abc-YZ", locale.toString());
+}
+
+function testCountryLocale1() {
+    var ctry = new Country({
+        locale: "ko-KR"
+    });
+    assertNotNull(ctry);
+
+    assertEquals("콩고-킨샤사", ctry.getName("CD"));
+    assertEquals("CD", ctry.getCode("콩고-킨샤사"));
+    var locale = ctry.getLocale();
+    assertEquals("ko-KR", locale.toString());
+}
+
+function testCountryLocale2() {
+    var ctry = new Country({
+        locale: "en-US"
+    });
+    assertNotNull(ctry);
+
+    assertEquals("Congo - Kinshasa", ctry.getName("CD"));
+    assertEquals("CD", ctry.getCode("Congo - Kinshasa"));
+    var locale = ctry.getLocale();
+    assertEquals("en-US", locale.toString());
+}
+
+function testCountryLocale3() {
+    var ctry = new Country({
+        locale: "zh-Hans-CN"
+    });
+    assertNotNull(ctry);
+
+    assertEquals("刚果（金）", ctry.getName("CD"));
+    assertEquals("CD", ctry.getCode("刚果（金）"));
+    var locale = ctry.getLocale();
+    assertEquals("zh-Hans-CN", locale.toString());
+}
+
+function testCountryLocale4() {
+    var ctry = new Country({
+        locale: "ja-JP"
+    });
+    assertNotNull(ctry);
+
+    assertEquals("コンゴ民主共和国(キンシャサ)", ctry.getName("CD"));
+    assertEquals("CD", ctry.getCode("コンゴ民主共和国(キンシャサ)"));
+    var locale = ctry.getLocale();
+    assertEquals("ja-JP", locale.toString());
+}
+
+function testCountryGetByCodeUnknown() {
+    try {
+        var ctry = new Country();
+        ctry.getName('xxx');
+    } catch (e) {
+        assertEquals("Country xxx is unknown", e);
+    }
+}
+
+function testCountryGetByNameUnknown() {
+    try {
+        var ctry = new Country();
+        ctry.getCode('xxx');
+    } catch (e) {
+        assertEquals("Country xxx is unknown", e);
+    }
+}
+
+function testCountryAsync() {
+    var callbackCalled = false;
+    new Country({
+        locale: "ja-JP",
+        sync: false,
+        onLoad: function (ctry) {
+            assertNotNull(ctry);
+
+            assertEquals("日本", ctry.getName("JP"));
+            assertEquals("JP", ctry.getCode("日本"));
+            var locale = ctry.getLocale();
+            assertEquals("ja-JP", locale.toString());
+
+            callbackCalled = true;
+        }
+    });
+
+    assertTrue(callbackCalled);
+}


### PR DESCRIPTION
Country class is newly added because there is the requirement about using information of `ctrynames.json` files.

# Usage
### `Country.getAvailableCode `
Return lists of ISO 3166-1 alpha-2 code that is available for `getName` method.
### `Country.getAvailableCountry`
Return lists of country names that is available for `getCode` method.
### `getName`
Return the country name corresponding to the country code given. If the code is given, but it is not found in the list of known countries, this method will throw an exception.
### `getCode`
Return the country code corresponding to the country name given.
If the country name is given, but it is not found in the list of known countries, this method will throw an exception.

**_Note._** When using `Constructor` with locale not supported, `Country` class makes instance with default locale `en-US`.



