### PR TITLE
Fix Opera browser variation

### DIFF
--- a/js/lib/ilib.js
+++ b/js/lib/ilib.js
@@ -157,7 +157,7 @@ ilib._getBrowser = function () {
 			if (navigator.userAgent.indexOf("Firefox") > -1) {
 				browser = "firefox";
 			}
-			if (navigator.userAgent.indexOf("Opera") > -1) {
+			if (navigator.userAgent.search(/Opera|OPR/) > -1 ) {
 				browser = "opera";
 			}
 			if (navigator.userAgent.indexOf("Chrome") > -1) {


### PR DESCRIPTION
In order to filter Opera browser, We need to check 'OPR' text in navigator.userAgent value.

Here's example:
* Mozilla/5.0 (Linux; Android 5.1; LG-F500L Build/LMY47D) AppleWebKit/537.36(KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36 OPR/42.7.2246.114996
* Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.133 Safari/537.36 OPR/44.0.2510.1449