### PR TITLE
Fix the build scripts to make a real build.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -63,7 +63,7 @@ limitations under the License.
 		<delete dir="${build.export}"/>
 	</target>
 
-	<target name="dist" description="Build the distribution package.">
+	<target name="dist" depends="all" description="Build the distribution package.">
 		<mkdir dir="${build.dist}" description="Dir to contain all the distribution outputs"/>
 		<iterate target="export"/>
 		<zip destfile="${build.dist}/ilib-${version}.zip"

--- a/js/build.xml
+++ b/js/build.xml
@@ -904,7 +904,6 @@ limitations under the License.
 			<jvmarg value="-Djsdoc.dir=${JSDOCDIR}"/>
 			<jvmarg value="-Djsdoc.template.dir=${JSDOCDIR}/templates/jsdoc"/>
 			<jvmarg value="-Xmx1024m"/>
-			<jvmarg value="-XX:MaxPermSize=96m"/>
 			<arg value="${JSDOCDIR}/app/run.js"/>
 			<arg value="--directory=${build.jsdoc}"/>
 			<arg value="--recurse=100"/>


### PR DESCRIPTION
"ant dist" did not work properly because the dependencies were not built first, and "ant doc" did not work with Java 8 because a VM argument was no longer supported.