### PR TITLE
Fix ilib platform detection code for avoiding conflict with enact

### DIFF
--- a/js/lib/ilib.js
+++ b/js/lib/ilib.js
@@ -129,7 +129,7 @@ ilib._getPlatform = function () {
     		}
     	} catch (e) {}
     	
-        if (typeof(process) !== 'undefined' && typeof(module) !== 'undefined') {
+        if (typeof(process) !== 'undefined' && process.versions && process.versions.node && typeof(module) !== 'undefined') {
             ilib._platform = "nodejs";
         } else if (typeof(Qt) !== 'undefined') {
         	ilib._platform = "qt";


### PR DESCRIPTION
Related PR : https://github.com/enyojs/iLib/pull/94

Fix nodejs platform detection code, in order to avoid conflict Enact packaging process.
Passed all of ilib unitest on my machine, both nodejs(v6.10.0)  and browser.
