### PR TITLE
Fix bug of time formatter

### DIFF
--- a/js/lib/DateFmt.js
+++ b/js/lib/DateFmt.js
@@ -1261,7 +1261,7 @@ DateFmt.prototype = {
 					str += JSUtils.pad(date.minute || "0", 2);
 					break;
 				case 's':
-					str += (date.minute || "0");
+					str += (date.second || "0");
 					break;
 				case 'ss':
 					str += JSUtils.pad(date.second || "0", 2);

--- a/js/test/date/test/testdatefmt.js
+++ b/js/test/date/test/testdatefmt.js
@@ -3155,3 +3155,10 @@ function testDateFmtGetMeridiemsRange_with_wrong_locale() {
     // if locale is specified wrong value, DateFmt takes default locale.
     assertTrue("getMeridiemsRange should return length value greater than 0", mdRange.length > 0);
 };
+
+function testDateFmtTimeTemplate_mms() {
+    var fmt = new DateFmt({clock: "24", template: "mm:s"});
+    assertNotNull(fmt);
+
+    assertEquals("00:9", fmt.format({minute: 0, second: 9}).toString());
+};

--- a/js/test/date/test/testdatefmt_ko_KR.js
+++ b/js/test/date/test/testdatefmt_ko_KR.js
@@ -778,7 +778,7 @@ function testDateFmtShortTimeComponentsS_ko_KR() {
 		second: 37,
 		millisecond: 0
 	});
-    assertEquals("45", fmt.format(date));
+    assertEquals("37", fmt.format(date));
 }
 
 function testDateFmtShortTimeComponentsM_ko_KR() {
@@ -1003,7 +1003,7 @@ function testDateFmtFullTimeComponentsS_ko_KR() {
 		second: 37,
 		millisecond: 0
 	});
-    assertEquals("45", fmt.format(date));
+    assertEquals("37", fmt.format(date));
 }
 
 function testDateFmtFullTimeComponentsM_ko_KR() {


### PR DESCRIPTION
When formatting 'mm:s' template(especially, via duration formatter using clock style), the time is formatted using minute, not second.
I fixed to use second for fomatting 'mm:s' template, and add unit test case for this.