### PR TITLE
Fix name parsing and formatting for English for Hong Kong

### DIFF
--- a/js/lib/Name.js
+++ b/js/lib/Name.js
@@ -166,7 +166,7 @@ var Name = function (name, options) {
 						loadParams: this.loadParams, 
 						callback: ilib.bind(this, function (info) {
 							if (!info) {
-								info = Name.defaultInfo;
+								info = Name.defaultInfo[this.style || "western"];
 								var spec = this.locale.getSpec().replace(/-/g, "_");
 								ilib.data.cache.Name[spec] = info;
 							}
@@ -240,75 +240,96 @@ var Name = function (name, options) {
 	}));
 };
 
-Name.defaultInfo = ilib.data.name ||  {
-	"components": {
-		"short": "gf",
-		"medium": "gmf",
-		"long": "pgmf",
-		"full": "pgmfs",
-		"formal_short": "hf",
-		"formal_long": "hgf"
+Name.defaultInfo = {
+	"western": ilib.data.name || {
+		"components": {
+			"short": "gf",
+			"medium": "gmf",
+			"long": "pgmf",
+			"full": "pgmfs",
+			"formal_short": "hf",
+			"formal_long": "hgf"
+		},
+		"format": "{prefix} {givenName} {middleName} {familyName}{suffix}",
+		"sortByHeadWord": false,
+		"nameStyle": "western",
+		"conjunctions": {
+			"and1": "and",
+			"and2": "and",
+			"or1": "or",
+			"or2": "or"
+		},
+		"auxillaries": {
+			"von": 1,
+			"von der": 1,
+			"von den": 1,
+			"van": 1,
+			"van der": 1,
+			"van de": 1,
+			"van den": 1,
+			"de": 1,
+			"di": 1,
+			"la": 1,
+			"lo": 1,
+			"des": 1,
+			"le": 1,
+			"les": 1,
+			"du": 1,
+			"de la": 1,
+			"del": 1,
+			"de los": 1,
+			"de las": 1
+		},
+		"prefixes": [
+	        "doctor",
+	        "dr",
+	        "mr",
+	        "mrs",
+	        "ms",
+	        "mister",
+	        "madame",
+	        "madamoiselle",
+	        "miss",
+	        "monsieur",
+	        "señor",
+	        "señora",
+	        "señorita"
+		],
+		"suffixes": [
+	        ",",
+	        "junior",
+	        "jr",
+	        "senior",
+	        "sr",
+	        "i",
+	        "ii",
+	        "iii",
+	        "esq",
+	        "phd",
+	        "md"
+		],
+	    "patronymicName":[ ],
+	    "familyNames":[ ]
 	},
-	"format": "{prefix} {givenName} {middleName} {familyName}{suffix}",
-	"sortByHeadWord": false,
-	"nameStyle": "western",
-	"conjunctions": {
-		"and1": "and",
-		"and2": "and",
-		"or1": "or",
-		"or2": "or"
-	},
-	"auxillaries": {
-		"von": 1,
-		"von der": 1,
-		"von den": 1,
-		"van": 1,
-		"van der": 1,
-		"van de": 1,
-		"van den": 1,
-		"de": 1,
-		"di": 1,
-		"la": 1,
-		"lo": 1,
-		"des": 1,
-		"le": 1,
-		"les": 1,
-		"du": 1,
-		"de la": 1,
-		"del": 1,
-		"de los": 1,
-		"de las": 1
-	},
-	"prefixes": [
-        "doctor",
-        "dr",
-        "mr",
-        "mrs",
-        "ms",
-        "mister",
-        "madame",
-        "madamoiselle",
-        "miss",
-        "monsieur",
-        "señor",
-        "señora",
-        "señorita"
-	],
-	"suffixes": [
-        ",",
-        "junior",
-        "jr",
-        "senior",
-        "sr",
-        "i",
-        "ii",
-        "iii",
-        "esq",
-        "phd",
-        "md"
-	],
-    "patronymicName":[ ],
-    "familyNames":[ ]
+	"asian": {
+		"components": {
+			"short": "gf",
+			"medium": "gmf",
+			"long": "hgmf",
+			"full": "hgmf",
+			"formal_short": "hf",
+			"formal_long": "hgf"
+		},
+		"format": "{prefix}{familyName}{middleName}{givenName}{suffix}",
+		"nameStyle": "asian",
+		"sortByHeadWord": false,
+		"conjunctions": {},
+		"auxillaries": {},
+		"prefixes": [],
+		"suffixes": [],
+	    "patronymicName":[],
+	    "familyNames":[]
+	}
 };
 
 /**
@@ -410,10 +431,10 @@ Name.prototype = {
             }
 
             this.isAsianName = Name._isAsianName(name, currentLanguage);
-            if (this.info.nameStyle === "asian" || this.info.order === "fmg" || this.info.order === "fgm") {
-                info = this.isAsianName ? this.info : ilib.data.name;
+            if (this.info.nameStyle === "asian") {
+                info = this.isAsianName ? this.info : Name.defaultInfo.western;
             } else {
-                info = this.isAsianName ? ilib.data.name : this.info;
+                info = this.isAsianName ? Name.defaultInfo.asian : this.info;
             }
 
             if (this.isAsianName) {
@@ -982,7 +1003,7 @@ Name.prototype = {
                     if (conjunctionIndex + 2 < parts.length - 1) {
                         this.middleName = parts.slice(conjunctionIndex + 2, parts.length - conjunctionIndex - 3);
                     }
-                } else if (this.order == "fgm") {
+                } else if (this.info.order == "fgm") {
                     this.familyName = parts.slice(0, conjunctionIndex + 2);
                     if (conjunctionIndex + 1 < parts.length - 1) {
                         this.middleName = parts.splice(parts.length - 1, 1);
@@ -991,11 +1012,13 @@ Name.prototype = {
                         }
                     }
                 }
+            } else if (this.info.order === "fgm") {
+                this.givenName = parts[1];
+                this.middleName = parts.slice(2);
+                this.familyName = parts[0];
             } else {
                 this.givenName = parts[0];
-
                 this.middleName = parts.slice(1, parts.length - 1);
-
                 this.familyName = parts[parts.length - 1];
             }
         }

--- a/js/test/name/nodeunit/testname_en.js
+++ b/js/test/name/nodeunit/testname_en.js
@@ -351,7 +351,40 @@ module.exports.testname_en = {
         test.contains(parsed, expected);
         test.done();
     },
-    
+
+    testENHKNormal: function(test) {
+        test.expect(2);
+        var parsed = new Name("Chan Ho Yun", {locale: 'en-HK'});
+        test.ok(typeof(parsed) !== "undefined");
+        
+        // name in English in Hong Kong are written with Asian order, much like Hungarian
+        var expected = {
+            givenName: "Ho",
+            middleName: "Yun",
+            familyName: "Chan"
+        };
+        
+        test.contains(parsed, expected);
+        test.done();
+    },
+
+    testENHKWithPrefix: function(test) {
+        test.expect(2);
+        var parsed = new Name("Dr Chan Ho Yun", {locale: 'en-HK'});
+        test.ok(typeof(parsed) !== "undefined");
+        
+        // name in English in Hong Kong are written with Asian order, much like Hungarian
+        var expected = {
+        	prefix: "Dr",
+            givenName: "Ho",
+            middleName: "Yun",
+            familyName: "Chan"
+        };
+        
+        test.contains(parsed, expected);
+        test.done();
+    },
+
     /*
      * Format tests
      */
@@ -623,6 +656,66 @@ module.exports.testname_en = {
         
         test.equal(formatted, expected);
         test.done();
+    },
+
+    testENHKRegular: function(test) {
+        test.expect(2);
+        var name = new Name({
+            honorific: "Dr",
+            givenName: "Min Kee",
+            middleName: "John",
+            familyName: "Fan",
+            suffix: null
+        });
+        
+        var fmt = new NameFmt({style: "medium", locale: 'en-HK'});
+        var formatted = fmt.format(name);
+        test.ok(typeof(formatted) !== "undefined");
+        
+        // English names in Hong Kong are formatted with family name first, much like Hungarian
+        var expected = "Fan Min Kee";
+        
+        test.equal(formatted, expected);
+        test.done();
+    },
+
+    testENHKFormatFormalShort: function(test) {
+        test.expect(2);
+        var name = new Name({
+            honorific: "Dr",
+            givenName: "Min Kee",
+            middleName: "John",
+            familyName: "Fan",
+            suffix: null
+        });
+        
+        var fmt = new NameFmt({style: "formal_short", locale: 'en-HK'});
+        var formatted = fmt.format(name);
+        test.ok(typeof(formatted) !== "undefined");
+        
+        var expected = "Dr Fan";
+        
+        test.equal(formatted, expected);
+        test.done();
+    },
+
+    testENHKFormatFormalLong: function(test) {
+        test.expect(2);
+        var name = new Name({
+            honorific: "Dr",
+            givenName: "Min Kee",
+            middleName: "John",
+            familyName: "Fan",
+            suffix: null
+        });
+        
+        var fmt = new NameFmt({style: "formal_long", locale: 'en-HK'});
+        var formatted = fmt.format(name);
+        test.ok(typeof(formatted) !== "undefined");
+        
+        var expected = "Dr Fan Min Kee";
+        
+        test.equal(formatted, expected);
+        test.done();
     }
-    
 };

--- a/js/test/name/nodeunit/testname_en.js
+++ b/js/test/name/nodeunit/testname_en.js
@@ -668,7 +668,7 @@ module.exports.testname_en = {
             suffix: null
         });
         
-        var fmt = new NameFmt({style: "medium", locale: 'en-HK'});
+        var fmt = new NameFmt({style: "short", locale: 'en-HK'});
         var formatted = fmt.format(name);
         test.ok(typeof(formatted) !== "undefined");
         


### PR DESCRIPTION
Apparently, even in English, they use the pattern:
    
> honorific family given middle
    
like they would in Chinese, only written in Latin letters. Example:
    
> Dr. Cheng Ho Min