### PR TITLE
Fix iLib build failures

### DIFF
--- a/js/build.xml
+++ b/js/build.xml
@@ -1138,8 +1138,8 @@ limitations under the License.
 		<uptodate
                 property="package.json.not.needed"
                 targetfile="${build.base}/package.json">
-			<srcfiles dir="${build.base}" file="package.json.template" />
-			<srcfiles dir="${build.base}/.." file="build.properties" />
+			<srcfiles dir="${build.base}" includes="package.json.template" />
+			<srcfiles dir="${build.base}/.." includes="build.properties" />
 		</uptodate>
 	</target>
 	<target name="update.package.json" depends="testpackagejson" unless="package.json.not.needed"


### PR DESCRIPTION
I'm not sure if a  build fails occurs only my machine or not. But During ant build, it fails with the error message below:

`
/home/goun/Source/opensource_iLib/develop/js/build.xml:1140: you can only specify one of the dir and file attributes`

so I replaced with 'includes' instead of 'file' attribute
