### PR TITLE
Add filereader-weboa.pro file for webos platform

### DIFF
--- a/qt/FileReader/ILib.qml
+++ b/qt/FileReader/ILib.qml
@@ -1,0 +1,11 @@
+import QtQuick 2.0
+import iLib 1.0 as I
+import "/usr/share/javascript/ilib/lib/ilib-qt.js" as QtILib
+
+QtObject {
+    readonly property var require: {
+        console.log('ILib require initialized');
+        QtILib.ilib.setLoaderCallback(new QtILib.QmlLoader(I.FileReader));
+        return QtILib.require;
+    }
+}

--- a/qt/FileReader/filereader-webos.pro
+++ b/qt/FileReader/filereader-webos.pro
@@ -1,0 +1,37 @@
+TEMPLATE = lib
+CONFIG += qt plugin
+TARGET = $$qtLibraryTarget(FileReader)
+
+QT += qml quick
+
+uri = com.jedlsoft.filesystem
+
+# Input
+SOURCES += \
+    filereader_plugin.cpp \
+    filereader.cpp
+
+HEADERS += \
+    filereader_plugin.h \
+    filereader.h
+
+MOC_DIR = .moc
+OBJECTS_DIR = .obj
+
+
+!defined(WEBOS_INSTALL_QML, var) {
+	instbase = $$[QT_INSTALL_QML]
+} else {
+	instbase = $$WEBOS_INSTALL_QML
+}
+
+target.path = $$instbase/iLib
+
+INSTALLS += target
+
+qmldir.base = $$_PRO_FILE_PWD_
+qmldir.files = qmldir ILib.qml
+qmldir.path = $$instbase/iLib
+qmldir.extra = cp $$PWD/qmldir.webos $$PWD/qmldir
+ 
+INSTALLS += qmldir


### PR DESCRIPTION
Add ILib.qml files which could be an example for QML developer.
Add filereader-webos.pro file for webOS platform. Current version .pro file is installed libFileReader.so file to `/usr/lib/qt5/qml/com/jedlsoft/filesystetem/*`
I think this directory should be generic such as `/usr/lib/qt5/qml/iLib/*` something like that.

It could be integrated to existing filereader.pro file but I need to get consensus. 
so I'm adding filereader-webos.pro file instead. 