### PR TITLE
Add filereader-webos.pro and ILib.qml file to master

### DIFF
--- a/qt/FileReader/ILib.qml
+++ b/qt/FileReader/ILib.qml
@@ -1,0 +1,11 @@
+import QtQuick 2.0
+import iLib 1.0 as I
+import "/usr/share/javascript/ilib/lib/ilib-qt.js" as QtILib
+
+QtObject {
+    readonly property var require: {
+        console.log('ILib require initialized');
+        QtILib.ilib.setLoaderCallback(new QtILib.QmlLoader(I.FileReader));
+        return QtILib.require;
+    }
+}

--- a/qt/FileReader/filereader-webos.pro
+++ b/qt/FileReader/filereader-webos.pro
@@ -1,0 +1,37 @@
+TEMPLATE = lib
+CONFIG += qt plugin
+TARGET = $$qtLibraryTarget(FileReader)
+
+QT += qml quick
+
+uri = com.jedlsoft.filesystem
+
+# Input
+SOURCES += \
+    filereader_plugin.cpp \
+    filereader.cpp
+
+HEADERS += \
+    filereader_plugin.h \
+    filereader.h
+
+MOC_DIR = .moc
+OBJECTS_DIR = .obj
+
+
+!defined(WEBOS_INSTALL_QML, var) {
+	instbase = $$[QT_INSTALL_QML]
+} else {
+	instbase = $$WEBOS_INSTALL_QML
+}
+
+target.path = $$instbase/iLib
+
+INSTALLS += target
+
+qmldir.base = $$_PRO_FILE_PWD_
+qmldir.files = qmldir ILib.qml
+qmldir.path = $$instbase/iLib
+qmldir.extra = cp $$PWD/qmldir.webos $$PWD/qmldir
+ 
+INSTALLS += qmldir


### PR DESCRIPTION
Same changes is already approved and  merged to development branch https://github.com/iLib-js/iLib/pull/61
but In order to test if qt builds properly for webOS platform. I need to integrate this change into master branch **ASAP**. so I'm creating the same PR to apply `master` branch. 