### PR TITLE
Remove newDateInstance() in *Cals.js which makes dependency error

### DIFF
--- a/js/lib/CopticCal.js
+++ b/js/lib/CopticCal.js
@@ -43,18 +43,6 @@ CopticCal.prototype = new EthiopicCal();
 CopticCal.prototype.parent = EthiopicCal;
 CopticCal.prototype.constructor = CopticCal;
 
-/**
- * Return a date instance for this calendar type using the given
- * options.
- * @param {Object} options options controlling the construction of 
- * the date instance
- * @return {IDate} a date appropriate for this calendar type
- * @deprecated Since 11.0.5. Use DateFactory({calendar: cal.getType(), ...}) instead
- */
-CopticCal.prototype.newDateInstance = function (options) {
-	var CopticDate = require("./CopticDate.js");
-	return new CopticDate(options);
-};
 
 /* register this calendar for the factory method */
 Calendar._constructors["coptic"] = CopticCal;

--- a/js/lib/EthiopicCal.js
+++ b/js/lib/EthiopicCal.js
@@ -113,18 +113,6 @@ EthiopicCal.prototype.getType = function() {
 	return this.type;
 };
 
-/**
- * Return a date instance for this calendar type using the given
- * options.
- * @param {Object} options options controlling the construction of 
- * the date instance
- * @return {IDate} a date appropriate for this calendar type
- * @deprecated Since 11.0.5. Use DateFactory({calendar: cal.getType(), ...}) instead
- */
-EthiopicCal.prototype.newDateInstance = function (options) {
-	var EthiopicDate = require("./EthiopicDate.js");
-	return new EthiopicDate(options);
-};
 
 /* register this calendar for the factory method */
 Calendar._constructors["ethiopic"] = EthiopicCal;

--- a/js/lib/GregorianCal.js
+++ b/js/lib/GregorianCal.js
@@ -113,19 +113,6 @@ GregorianCal.prototype.getType = function() {
 	return this.type;
 };
 
-/**
- * Return a date instance for this calendar type using the given
- * options.
- * @param {Object} options options controlling the construction of 
- * the date instance
- * @return {IDate} a date appropriate for this calendar type
- * @deprecated Since 11.0.5. Use DateFactory({calendar: cal.getType(), ...}) instead
- */
-GregorianCal.prototype.newDateInstance = function (options) {
-	var GregorianDate = require("./GregorianDate.js");
-	return new GregorianDate(options);
-};
-
 /* register this calendar for the factory method */
 Calendar._constructors["gregorian"] = GregorianCal;
 

--- a/js/lib/HanCal.js
+++ b/js/lib/HanCal.js
@@ -330,18 +330,6 @@ HanCal.prototype.getType = function() {
 	return this.type;
 };
 
-/**
- * Return a date instance for this calendar type using the given
- * options.
- * @param {Object} options options controlling the construction of 
- * the date instance
- * @return {HanDate} a date appropriate for this calendar type
- * @deprecated Since 11.0.5. Use DateFactory({calendar: cal.getType(), ...}) instead
- */
-HanCal.prototype.newDateInstance = function (options) {
-	var HanDate = require("./HanDate.js");
-	return new HanDate(options);
-};
 
 /* register this calendar for the factory method */
 Calendar._constructors["han"] = HanCal;

--- a/js/lib/HebrewCal.js
+++ b/js/lib/HebrewCal.js
@@ -218,18 +218,6 @@ HebrewCal.prototype.getType = function() {
 	return this.type;
 };
 
-/**
- * Return a date instance for this calendar type using the given
- * options.
- * @param {Object} options options controlling the construction of 
- * the date instance
- * @returns {HebrewDate} a date appropriate for this calendar type
- * @deprecated Since 11.0.5. Use DateFactory({calendar: cal.getType(), ...}) instead
- */
-HebrewCal.prototype.newDateInstance = function (options) {
-	var HebrewDate = require("./HebrewDate.js");
-	return new HebrewDate(options);
-};
 
 /*register this calendar for the factory method */
 Calendar._constructors["hebrew"] = HebrewCal;

--- a/js/lib/IslamicCal.js
+++ b/js/lib/IslamicCal.js
@@ -120,18 +120,6 @@ IslamicCal.prototype.getType = function() {
 	return this.type;
 };
 
-/**
- * Return a date instance for this calendar type using the given
- * options.
- * @param {Object} options options controlling the construction of 
- * the date instance
- * @return {IslamicDate} a date appropriate for this calendar type
- * @deprecated Since 11.0.5. Use DateFactory({calendar: cal.getType(), ...}) instead
- */
-IslamicCal.prototype.newDateInstance = function (options) {
-	var IslamicDate = require("./IslamicDate.js");
-	return new IslamicDate(options);
-};
 
 /*register this calendar for the factory method */
 Calendar._constructors["islamic"] = IslamicCal;

--- a/js/lib/JulianCal.js
+++ b/js/lib/JulianCal.js
@@ -146,18 +146,6 @@ JulianCal.prototype.getType = function() {
 	return this.type;
 };
 
-/**
- * Return a date instance for this calendar type using the given
- * options.
- * @param {Object} options options controlling the construction of 
- * the date instance
- * @return {IDate} a date appropriate for this calendar type
- * @deprecated Since 11.0.5. Use DateFactory({calendar: cal.getType(), ...}) instead
- */
-JulianCal.prototype.newDateInstance = function (options) {
-	var JulianDate = require("./JulianDate.js");
-	return new JulianDate(options);
-};
 
 /* register this calendar for the factory method */
 Calendar._constructors["julian"] = JulianCal;

--- a/js/lib/PersianAlgoCal.js
+++ b/js/lib/PersianAlgoCal.js
@@ -122,18 +122,6 @@ PersianAlgoCal.prototype.getType = function() {
 	return this.type;
 };
 
-/**
- * Return a date instance for this calendar type using the given
- * options.
- * @param {Object} options options controlling the construction of 
- * the date instance
- * @return {IDate} a date appropriate for this calendar type
- * @deprecated Since 11.0.5. Use DateFactory({calendar: cal.getType(), ...}) instead
- */
-PersianAlgoCal.prototype.newDateInstance = function (options) {
-	var PersianAlgoDate = require("./PersianAlgoDate.js");
-	return new PersianAlgoDate(options);
-};
 
 /* register this calendar for the factory method */
 Calendar._constructors["persian-algo"] = PersianAlgoCal;

--- a/js/lib/PersianCal.js
+++ b/js/lib/PersianCal.js
@@ -138,19 +138,6 @@ PersianCal.prototype.getType = function() {
 	return this.type;
 };
 
-/**
- * Return a date instance for this calendar type using the given
- * options.
- * @param {Object} options options controlling the construction of 
- * the date instance
- * @return {IDate} a date appropriate for this calendar type
- * @deprecated Since 11.0.5. Use DateFactory({calendar: cal.getType(), ...}) instead
- */
-PersianCal.prototype.newDateInstance = function (options) {
-	var PersianDate = require("./PersianDate.js");
-	return new PersianDate(options);
-};
-
 /* register this calendar for the factory method */
 Calendar._constructors["persian"] = PersianCal;
 

--- a/js/lib/ThaiSolarCal.js
+++ b/js/lib/ThaiSolarCal.js
@@ -55,18 +55,6 @@ ThaiSolarCal.prototype.isLeapYear = function(year) {
 	return (MathUtils.mod(y, 4) === 0 && centuries !== 100 && centuries !== 200 && centuries !== 300);
 };
 
-/**
- * Return a date instance for this calendar type using the given
- * options.
- * @param {Object} options options controlling the construction of
- * the date instance
- * @return {IDate} a date appropriate for this calendar type
- * @deprecated Since 11.0.5. Use DateFactory({calendar: cal.getType(), ...}) instead
- */
-ThaiSolarCal.prototype.newDateInstance = function (options) {
-	var ThaiSolarDate = require("./ThaiSolarDate.js");
-	return new ThaiSolarDate(options);
-};
 
 /* register this calendar for the factory method */
 Calendar._constructors["thaisolar"] = ThaiSolarCal;


### PR DESCRIPTION
Remove deprecated APIs
newDateInstance() in *Cals.js which makes dependency error during enyo packaging process. 
In detail, Please see https://github.com/enyojs/iLib/pull/34

