### PR TITLE
Fix a bug that returning wrong time when starting DST

### DIFF
--- a/js/lib/GregorianDate.js
+++ b/js/lib/GregorianDate.js
@@ -161,7 +161,11 @@ var GregorianDate = function(params) {
 				// in the overlap time at the end of DST. Do you mean the daylight 1:30am or the standard 1:30am? In this
 				// case, use the ilib calculations below, which can distinguish between the two properly
 				var d = new Date(this.year, this.month-1, this.day, this.hour, this.minute, this.second, this.millisecond);
+				var hBefore = new Date(this.year, this.month-1, this.day, this.hour - 1, this.minute, this.second, this.millisecond);
 				this.offset = -d.getTimezoneOffset() / 1440;
+				if (d.getTimezoneOffset() < hBefore.getTimezoneOffset()) {
+					var startOffset = -hBefore.getTimezoneOffset() / 1440;
+				}
 			} else {
 				if (!this.tz) {
 					this.tz = new TimeZone({id: this.timezone});
@@ -171,7 +175,11 @@ var GregorianDate = function(params) {
 				// what the offset is at that point in the year
 				this.offset = this.tz._getOffsetMillisWallTime(this) / 86400000;
 			}
-			if (this.offset !== 0) {
+			if (typeof(startOffset) !== 'undefined') {
+				this.rd = this.newRd({
+					rd: this.rd.getRataDie() - startOffset
+				});
+			} else if (this.offset !== 0) {
 				this.rd = this.newRd({
 					rd: this.rd.getRataDie() - this.offset
 				});

--- a/js/test/date/nodeunit/testdate.js
+++ b/js/test/date/nodeunit/testdate.js
@@ -1,6 +1,6 @@
 /*
  * testdate.js - test the date object
- * 
+ *
  * Copyright © 2012-2015,2017, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -40,25 +40,25 @@ module.exports.testdate = {
     testDateConstructor: function(test) {
         test.expect(1);
         var gd = DateFactory();
-        
+
         test.ok(gd !== null);
         test.done();
     },
-    
+
     testDateConstructorFull: function(test) {
         test.expect(8);
         var gd = DateFactory({
-            year: 2011, 
-            month: 9, 
-            day: 23, 
-            hour: 16, 
-            minute: 7, 
-            second: 12, 
-            millisecond: 123    
+            year: 2011,
+            month: 9,
+            day: 23,
+            hour: 16,
+            minute: 7,
+            second: 12,
+            millisecond: 123
         });
-        
+
         test.ok(gd !== null);
-        
+
         test.equal(gd.getYears(), 2011);
         test.equal(gd.getMonths(), 9);
         test.equal(gd.getDays(), 23);
@@ -68,206 +68,206 @@ module.exports.testdate = {
         test.equal(gd.getMilliseconds(), 123);
         test.done();
     },
-    
+
     testDateSetYears: function(test) {
         test.expect(2);
         var gd = DateFactory();
-        
+
         test.ok(gd !== null);
-        
+
         gd.setYears(123);
-        
+
         test.equal(gd.getYears(), 123);
         test.done();
     },
-    
+
     testDateSetMonths: function(test) {
         test.expect(2);
         var gd = DateFactory();
-        
+
         test.ok(gd !== null);
-        
+
         gd.setMonths(7);
-        
+
         test.equal(gd.getMonths(), 7);
         test.done();
     },
-    
+
     testDateSetDays: function(test) {
         test.expect(2);
         var gd = DateFactory();
-        
+
         test.ok(gd !== null);
-        
+
         gd.setDays(12);
-        
+
         test.equal(gd.getDays(), 12);
         test.done();
     },
-    
+
     testDateSetHours: function(test) {
         test.expect(2);
         var gd = DateFactory();
-        
+
         test.ok(gd !== null);
-        
+
         gd.setHours(12);
-        
+
         test.equal(gd.getHours(), 12);
         test.done();
     },
-    
+
     testDateSetMinutes: function(test) {
         test.expect(2);
         var gd = DateFactory();
-        
+
         test.ok(gd !== null);
-        
+
         gd.setMinutes(13);
-        
+
         test.equal(gd.getMinutes(), 13);
         test.done();
     },
-    
+
     testDateSetSeconds: function(test) {
         test.expect(2);
         var gd = DateFactory();
-        
+
         test.ok(gd !== null);
-        
+
         gd.setSeconds(23);
-        
+
         test.equal(gd.getSeconds(), 23);
         test.done();
     },
-    
+
     testDateSetMilliseconds: function(test) {
         test.expect(2);
         var gd = DateFactory();
-        
+
         test.ok(gd !== null);
-        
+
         gd.setMilliseconds(123);
-        
+
         test.equal(gd.getMilliseconds(), 123);
         test.done();
     },
-    
-    
+
+
     testDateFactoryRightType: function(test) {
         test.expect(2);
         var date = DateFactory({
             type: "gregorian"
         });
-        
+
         test.ok(date !== null);
         test.equal(date.getCalendar(), "gregorian");
         test.done();
     },
-    
+
     testDateFactoryDefaultGregorian: function(test) {
         test.expect(2);
         var date = DateFactory();
-        
+
         test.ok(date !== null);
         test.equal(date.getCalendar(), "gregorian");
         test.done();
     },
-    
+
     testDateFactoryNonGregorian: function(test) {
         test.expect(2);
         var date = DateFactory({
             type: "hebrew"
         });
-        
+
         test.ok(date !== null);
         test.equal(date.getCalendar(), "hebrew");
         test.done();
     },
-    
+
     testDateFactoryNonGregorianWithCalendar: function(test) {
         test.expect(2);
         var date = DateFactory({
             calendar: "hebrew"
         });
-        
+
         test.ok(date !== null);
         test.equal(date.getCalendar(), "hebrew");
         test.done();
     },
-    
+
     testDateFactoryBogus: function(test) {
         test.expect(1);
         var date = DateFactory({
             type: "asdf"
         });
-        
+
         test.ok(typeof(date) === "undefined");
         test.done();
     },
-    
+
     testDateToIlibUndefined: function(test) {
         test.expect(1);
         var date = DateFactory._dateToIlib();
-        
+
         test.ok(typeof(date) === "undefined");
         test.done();
     },
-    
+
     testDateToIlibNull: function(test) {
         test.expect(1);
         var date = DateFactory._dateToIlib(null);
-        
+
         test.ok(date === null);
         test.done();
     },
-    
+
     testDateToIlibDateWithDate: function(test) {
         test.expect(4);
         var d = new Date();
         var date = DateFactory._dateToIlib(d);
-        
+
         test.equal(typeof(date), "object");
         test.ok(typeof(typeof(date.cal)) !== "undefined");
         test.equal(date.cal.type, "gregorian");
         test.equal(date.getTime(), d.getTime());
         test.done();
     },
-    
+
     testDateToIlibDateWithIlibDate: function(test) {
         test.expect(4);
         var d = new GregorianDate();
         var date = DateFactory._dateToIlib(d);
-        
+
         test.equal(typeof(date), "object");
         test.ok(typeof(typeof(date.cal)) !== "undefined");
         test.equal(date.cal.type, "gregorian");
         test.equal(date.getTime(), d.getTime());
         test.done();
     },
-    
+
     testDateToIlibDateWithNumber: function(test) {
         test.expect(4);
         var date = DateFactory._dateToIlib(1000);
-        
+
         test.equal(typeof(date), "object");
         test.ok(typeof(typeof(date.cal)) !== "undefined");
         test.equal(date.cal.type, "gregorian");
         test.equal(date.getTime(), 1000);
         test.done();
     },
-    
+
     testDateToIlibDateWithString: function(test) {
         test.expect(4);
         var date = DateFactory._dateToIlib("Wed Mar 05 2014 14:18:12 GMT-0800");
-        
+
         test.equal(typeof(date), "object");
         test.ok(typeof(typeof(date.cal)) !== "undefined");
         test.equal(date.cal.type, "gregorian");
         test.equal(date.getTime(), 1394057892000);
         test.done();
     },
-    
+
     testDateToIlibDateWithGenericObject: function(test) {
         test.expect(8);
         var d = {
@@ -278,7 +278,7 @@ module.exports.testdate = {
             minute: 24
         };
         var date = DateFactory._dateToIlib(d);
-        
+
         test.equal(typeof(date), "object");
         test.ok(typeof(typeof(date.cal)) !== "undefined");
         test.equal(date.cal.type, "gregorian");
@@ -286,10 +286,10 @@ module.exports.testdate = {
         test.equal(date.month, 8);
         test.equal(date.day, 23);
         test.equal(date.hour, 8);
-        test.equal(date.minute, 24);    
+        test.equal(date.minute, 24);
         test.done();
     },
-    
+
     testDateToIlibDateWithBogusObject: function(test) {
         test.expect(9);
         var d = {
@@ -298,7 +298,7 @@ module.exports.testdate = {
         };
         var now = new Date();
         var date = DateFactory._dateToIlib(d);
-        
+
         test.equal(typeof(date), "object");
         test.ok(typeof(typeof(date.cal)) !== "undefined");
         test.equal(date.cal.type, "gregorian");
@@ -310,7 +310,7 @@ module.exports.testdate = {
         test.ok(date.second - now.getSeconds() <= 1);
         test.done();
     },
-    
+
     testDateToIlibDate: function(test) {
         test.expect(1);
         var datMyBday = new Date("Fri Aug 13 1982 13:37:35 GMT-0700");
@@ -327,7 +327,7 @@ module.exports.testdate = {
         test.equal(fmt.format(DateFactory._dateToIlib(datMyBday)), fmt.format(ildMyBday));
         test.done();
     },
-    
+
     testDateToIlibString: function(test) {
         test.expect(1);
         var strMyBday = "Fri Aug 13 1982 13:37:35 GMT-0700";
@@ -344,7 +344,7 @@ module.exports.testdate = {
         test.equal(fmt.format(DateFactory._dateToIlib(strMyBday)), fmt.format(ildMyBday));
         test.done();
     },
-    
+
     testDateToIlibInteger: function(test) {
         test.expect(1);
         var intMyBday = 1234657890000;
@@ -353,14 +353,14 @@ module.exports.testdate = {
         test.equal(fmt.format(DateFactory._dateToIlib(intMyBday)), fmt.format(ildMyBday));
         test.done();
     },
-    
+
     testDateToIlibIlibDate: function(test) {
         test.expect(1);
         var ildMyBday = DateFactory({unixtime: 1234657890000});
         test.deepEqual(DateFactory._dateToIlib(ildMyBday), ildMyBday);
         test.done();
     },
-    
+
     testDateGetJSDateBeyond32Bits: function(test) {
         test.expect(4);
         var d = DateFactory({
@@ -368,14 +368,78 @@ module.exports.testdate = {
             month: 1,
             day: 1
         });
-        
+
         var jsd = d.getJSDate();
-        
+
         test.ok(typeof(jsd) !== "undefined");
         test.equal(jsd.getFullYear(), 2040);
         test.equal(jsd.getMonth(), 0);
         test.equal(jsd.getDate(), 1);
         test.done();
-    }
-    
+    },
+    testDstStartBoundary_Azores: function(test) {
+        test.expect(1);
+        var boundaryiLib = DateFactory({
+            year: 2019,
+            month: 3,
+            day: 31,
+            hour: 0,
+            minute: 0,
+            second: 0,
+            timezone: "Atlantic/Azores"
+        });
+        // we can't set time zone to Date object, so compare with constant value
+        // 1553994000000: new Date(2019, 2, 31, 0, 0, 0).getTime() with Azores local time
+        test.equal(boundaryiLib.getTimeExtended(), 1553994000000);
+        test.done();
+    },
+    testDstEndBoundary_Azores: function(test) {
+        test.expect(1);
+        var boundaryiLib = DateFactory({
+            year: 2019,
+            month: 10,
+            day: 27,
+            hour: 1,
+            minute: 0,
+            second: 0,
+            timezone: "Atlantic/Azores"
+        });
+        var boundaryEs = new Date(2019, 9, 27, 1, 0, 0);
+        // we can't set time zone to Date object, so compare with constant value
+        // 1572141600000: new Date(2019, 9, 27, 1, 0, 0).getTime() with Azores local time
+        test.equal(boundaryiLib.getTimeExtended(), 1572141600000);
+        test.done();
+    }/*,
+    testDstStartBoundary_Windhoek: function(test) {
+        test.expect(1);
+        var boundaryiLib = DateFactory({
+            year: 2016,
+            month: 9,
+            day: 4,
+            hour: 2,
+            minute: 0,
+            second: 0,
+            timezone: "Africa/Windhoek"
+        });
+        // we can't set time zone to Date object, so compare with constant value
+        // 1472950800000: new Date(2016, 8, 4, 2, 0, 0).getTime() with Windhoek local time
+        test.equal(boundaryiLib.getTimeExtended(), 1472950800000);
+        test.done();
+    },
+    testDstEndBoundary_Windhoek: function(test) {
+        test.expect(1);
+        var boundaryiLib = DateFactory({
+            year: 2016,
+            month: 4,
+            day: 3,
+            hour: 2,
+            minute: 0,
+            second: 0,
+            timezone: "Africa/Windhoek"
+        });
+        // we can't set time zone to Date object, so compare with constant value
+        // 1459645200000: new Date(2016, 3, 3, 2, 0, 0).getTime() with Windhoek local time
+        test.equal(boundaryiLib.getTimeExtended(), 1459645200000);
+        test.done();
+    }*/
 };


### PR DESCRIPTION
Fix a bug that returning wrong time when starting DST
- Align with the way to applying DST in javascript native engine when it is started on starting boundary time. 

more details: https://github.com/iLib-js/iLib/issues/62