### PR TITLE
Fixes for the unit test system

### DIFF
--- a/js/build.xml
+++ b/js/build.xml
@@ -1308,15 +1308,15 @@ limitations under the License.
 	</target>
 	
 	<target name="test.remote" depends="prepare,assemble.unittest" description="Run a remote server to test ilib in remote browsers">
-	    <exec osfamily="unix" resultproperty="uglify.result" errorproperty="uglify.error" executable="node" dir="${build.base}/.." failifexecutionfails="true">
+	    <exec osfamily="unix" resultproperty="uglify.result" errorproperty="uglify.error" executable="node" dir="${build.base}" failifexecutionfails="true">
 			<arg value="node_modules/http-server/bin/http-server"/>
 			<arg value="-p"/>
 			<arg value="9090"/>
 		</exec>
-		<exec osfamily="mac" resultproperty="uglify.result" errorproperty="uglify.error" executable="node" dir="${build.base}/.." failifexecutionfails="true">
+		<exec osfamily="mac" resultproperty="uglify.result" errorproperty="uglify.error" executable="node" dir="${build.base}" failifexecutionfails="true">
 			<arg value="node_modules/http-server/bin/http-server"/>
 		</exec>
-		<exec osfamily="windows" resultproperty="uglify.result" errorproperty="uglify.error" executable="node.exe" dir="${build.base}/.." failifexecutionfails="true">
+		<exec osfamily="windows" resultproperty="uglify.result" errorproperty="uglify.error" executable="node.exe" dir="${build.base}" failifexecutionfails="true">
 			<arg value="node_modules/http-server/bin/http-server"/>
 		</exec>
 	</target>

--- a/js/test/testRunner.js
+++ b/js/test/testRunner.js
@@ -148,7 +148,10 @@ for (var i = 0; i < suite.length; i++) {
     console.log("Adding suite: " + suite[i]);
     suites = require("./" + path.join(suite[i], "nodeunit/testSuiteFiles.js")).files.forEach(function(file) {
         var test = require("./" + path.join(suite[i], "nodeunit", file));
-        modules[suite[i]] = test;
+        if (!modules[suite[i]]) modules[suite[i]] = {};
+        for (var t in test) {
+            modules[suite[i]][t] = test[t];
+        }
     });
 }
 


### PR DESCRIPTION
- The command-line nodeunit test runner was not running all the tests. It was only running the last one for each category.
- The web nodeunit runner had the wrong directory, and wouldn't run because of it.