### PR TITLE
Return a date component string for UI builders 

### DIFF
--- a/doc/ReleaseNotes.md
+++ b/doc/ReleaseNotes.md
@@ -1,5 +1,13 @@
-Release Notes for Version 13.0
+Release Notes for Version 13.1
 =============================
+
+Build 001
+-------
+
+New Features:
+
+* Added DateFmt.getDateComponentOrder() to aid date input selector widget developers in determining what order the date input
+selectors for year, month, and date should appear in to be correct for the given locale.
 
 Build 000
 -------

--- a/js/lib/DateFmt.js
+++ b/js/lib/DateFmt.js
@@ -699,6 +699,13 @@ DateFmt.prototype = {
 					this.template = this._getFormat(this.formats.time[this.clock], this.timeComponents, this.length);
 					break;
 			}
+			
+			// calculate what order the components appear in for this locale
+			this.componentOrder = this._getFormat(this.formats.date, "dmy", "l").
+			    replace(/[^dMy]/g, "").
+			    replace(/y+/, "y").
+			    replace(/d+/, "d").
+			    replace(/M+/, "m");
 		} else {
 			throw "No formats available for calendar " + this.calName + " in locale " + this.locale.toString();
 		}
@@ -923,7 +930,7 @@ DateFmt.prototype = {
 	 * @return {String} a string giving the date component order
 	 */
 	getDateComponentOrder: function() {
-		
+	    return this.componentOrder;
 	},
 	
 	/**

--- a/js/lib/DateFmt.js
+++ b/js/lib/DateFmt.js
@@ -903,6 +903,30 @@ DateFmt.prototype = {
 	},
 	
 	/**
+	 * Return the order of the year, month, and date components for the current locale.<p>
+	 * 
+	 * When implementing a date input widget in a UI, it would be useful to know what
+	 * order to put the year, month, and date input fields so that it conforms to the
+	 * user expectations for the locale. This method gives that order by returning a
+	 * string that has a single "y", "m", and "d" character in it in the correct
+	 * order.<p>
+	 * 
+	 * For example, the return value "ymd" means that this locale formats the year first,
+	 * the month second, and the date third, and "mdy" means that the month is first,
+	 * the date is second, and the year is third. Four of the 6 possible permutations
+	 * of the three letters have at least one locale that uses that ordering, though some
+	 * combinations are far more likely than others. The ones that are not used by any 
+	 * locales are "dym" and "myd", though new locales are still being added to 
+	 * CLDR frequently, and possible orderings cannot be predicted. Your code should 
+	 * support all 6 possibilities, just in case.
+	 * 
+	 * @return {String} a string giving the date component order
+	 */
+	getDateComponentOrder: function() {
+		
+	},
+	
+	/**
 	 * Return the type of this formatter. The type is a string that has one of the following
 	 * values: "time", "date", "datetime".
 	 * @return {string} the type of the formatter

--- a/js/test/date/nodeunit/testdatefmt.js
+++ b/js/test/date/nodeunit/testdatefmt.js
@@ -3682,5 +3682,65 @@ module.exports.testdatefmt = {
     
         test.equal(fmt.format({minute: 0, second: 9}).toString(), "00:9");
         test.done();
+    },
+    
+    testDateFmtGetDateComponentOrderEN: function(test) {
+    	test.expect(2);
+    	
+    	var fmt = new DateFmt({locale: "en"})
+        test.ok(fmt !== null);
+    
+        test.equal(fmt.getDateComponentOrder(), "dmy");
+        test.done();
+    },
+    
+    testDateFmtGetDateComponentOrderENGB: function(test) {
+    	test.expect(2);
+    	
+    	var fmt = new DateFmt({locale: "en-GB"})
+        test.ok(fmt !== null);
+    
+        test.equal(fmt.getDateComponentOrder(), "dmy");
+        test.done();
+    },
+   
+    testDateFmtGetDateComponentOrderENUS: function(test) {
+    	test.expect(2);
+    	
+    	var fmt = new DateFmt({locale: "en-US"})
+        test.ok(fmt !== null);
+    
+        test.equal(fmt.getDateComponentOrder(), "mdy");
+        test.done();
+    },
+
+    testDateFmtGetDateComponentOrderDE: function(test) {
+    	test.expect(2);
+    	
+    	var fmt = new DateFmt({locale: "de-DE"})
+        test.ok(fmt !== null);
+    
+        test.equal(fmt.getDateComponentOrder(), "dmy");
+        test.done();
+    },
+
+    testDateFmtGetDateComponentOrderAK: function(test) {
+    	test.expect(2);
+    	
+    	var fmt = new DateFmt({locale: "ak-GH"})
+        test.ok(fmt !== null);
+    
+        test.equal(fmt.getDateComponentOrder(), "ymd");
+        test.done();
+    },
+
+    testDateFmtGetDateComponentOrderLV: function(test) {
+    	test.expect(2);
+    	
+    	var fmt = new DateFmt({locale: "lv-LV"})
+        test.ok(fmt !== null);
+    
+        test.equal(fmt.getDateComponentOrder(), "ydm");
+        test.done();
     }
 };

--- a/js/test/date/nodeunit/testdatefmt.js
+++ b/js/test/date/nodeunit/testdatefmt.js
@@ -3690,7 +3690,7 @@ module.exports.testdatefmt = {
     	var fmt = new DateFmt({locale: "en"})
         test.ok(fmt !== null);
     
-        test.equal(fmt.getDateComponentOrder(), "dmy");
+        test.equal(fmt.getDateComponentOrder(), "mdy");
         test.done();
     },
     


### PR DESCRIPTION
Added a method getDateComponentOrder() to the date formatter class to aid UI widget developers. This returns a three-letter string like "ymd" which gives the order of the components needed when making a date selector widget. The developer can then use this to put the UI components for year, month, and date in the correct order.

The developer can combine this call with calls like DateFmt.getMonthsOfYear() to get the names of all the months, and methods of the Calendar class to get the number of months, and the lengths of each month in a particular year.