### PR TITLE
Add the Locale.getLangSpec() method

### DIFF
--- a/doc/ReleaseNotes.md
+++ b/doc/ReleaseNotes.md
@@ -10,6 +10,8 @@ New Features:
 selectors for year, month, and date should appear in to be correct for the given locale.
 * The getString and getStringJS methods of the ResBundle class both now take either a string or an array parameter
 to translate. When an array is given, every string in the array is translated.
+* Added locale.getLangSpec() method to return the language and the optional script of the locale which will give you what the
+written language is of the locale regardless of region or variant
 
 Build 000
 -------

--- a/js/lib/Locale.js
+++ b/js/lib/Locale.js
@@ -69,7 +69,7 @@ var JSUtils = require("./JSUtils.js");
  * @param {string=} script the ISO 15924 code of the script for this locale, if any
  */
 var Locale = function(language, region, variant, script) {
-	if (typeof(region) === 'undefined') {
+    if (typeof(region) === 'undefined') {
 		var spec = language || ilib.getLocale();
 		if (typeof(spec) === 'string') {
 			var parts = spec.split('-');
@@ -804,18 +804,18 @@ Locale.prototype = {
 	
 	/**
 	 * Return the language locale specifier. This includes the
-	 * language and optionally the script. This can be
-	 * used to see whether the written language of locales
-	 * match each other regardless of region or variant.
+	 * language and the script if it is available. This can be
+	 * used to see whether the written language of two locales
+	 * match each other regardless of the region or variant.
 	 * 
 	 * @return {string} the language locale specifier
 	 */
 	getLangSpec: function() {
 	    var spec = this.language;
-	    if (this.script) {
+	    if (spec && this.script) {
 	        spec += "-" + this.script;
 	    }
-	    return spec;
+	    return spec || "";
 	},
 	
 	/**

--- a/js/lib/Locale.js
+++ b/js/lib/Locale.js
@@ -798,7 +798,24 @@ Locale.prototype = {
 	 * @return {string} the locale specifier
 	 */
 	getSpec: function() {
+	    if (!this.spec) this._genSpec();
 		return this.spec;
+	},
+	
+	/**
+	 * Return the language locale specifier. This includes the
+	 * language and optionally the script. This can be
+	 * used to see whether the written language of locales
+	 * match each other regardless of region or variant.
+	 * 
+	 * @return {string} the language locale specifier
+	 */
+	getLangSpec: function() {
+	    var spec = this.language;
+	    if (this.script) {
+	        spec += "-" + this.script;
+	    }
+	    return spec;
 	},
 	
 	/**

--- a/js/test/root/nodeunit/testlocale.js
+++ b/js/test/root/nodeunit/testlocale.js
@@ -704,6 +704,65 @@ module.exports.testlocale = {
             test.ok(locales.length > 0);
             test.done();
         });
-    }
+    },
+       
+    testLocaleGetLanguageSpecSimple: function(test) {
+        test.expect(2);
+        
+        test.ok(loc !== null);
+        
+        var loc = new Locale("en");
+        test.equal(loc.getLangSpec(), "en");
+        test.done();
+    },
     
+    testLocaleGetLanguageSpecLeaveOutRegionAndVariant: function(test) {
+        test.expect(2);
+        
+        test.ok(loc !== null);
+        
+        var loc = new Locale("en-US-MILITARY");
+        test.equal(loc.getLangSpec(), "en");
+        test.done();
+    },
+
+    testLocaleGetLanguageSpecIncludeScript: function(test) {
+        test.expect(2);
+        
+        test.ok(loc !== null);
+        
+        var loc = new Locale("zh-Hans");
+        test.equal(loc.getLangSpec(), "zh-Hans");
+        test.done();
+    },
+
+    testLocaleGetLanguageSpecIncludeScriptButNotOthers: function(test) {
+        test.expect(2);
+        
+        test.ok(loc !== null);
+        
+        var loc = new Locale("zh-Hans-CN-GOVT");
+        test.equal(loc.getLangSpec(), "zh-Hans");
+        test.done();
+    },
+
+    testLocaleGetLanguageSpecLanguageAndScriptMissing: function(test) {
+        test.expect(2);
+        
+        test.ok(loc !== null);
+        
+        var loc = new Locale("CN");
+        test.equal(loc.getLangSpec(), "");
+        test.done();
+    },
+
+    testLocaleGetLanguageSpecNoScriptWithoutLanguage: function(test) {
+        test.expect(2);
+        
+        test.ok(loc !== null);
+        
+        var loc = new Locale("Hans-CN");
+        test.equal(loc.getLangSpec(), "");
+        test.done();
+    }
 };


### PR DESCRIPTION
Makes it slightly more useful. Now you can get a string representing the written language for the locale.