### PR TITLE
New redenominated Dobra symbol STN

### DIFF
--- a/js/data/locale/currency.json
+++ b/js/data/locale/currency.json
@@ -640,6 +640,11 @@
         "sign": "£"
     },
     "STD": {
+        "name": "São Tomé & Príncipe Dobra (1977-2017)",
+        "decimals": 0,
+        "sign": "Db"
+    },
+    "STN": {
         "name": "São Tomé & Príncipe Dobra",
         "decimals": 0,
         "sign": "Db"


### PR DESCRIPTION
This is for the country Sao Tome and Principe, an island group in the Atlantic.