### PR TITLE
Locale used to throw an exception if you called it with non-string arguments  

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -12,6 +12,8 @@ Bug Fixes:
 * Removed duplicate entries in various locale json data files
 * Removed an exception that was thrown when the address formatter was instantiated without
 any arguments
+* Fixed a bug where the Locale constructor would throw an exception if any of the arguments
+was a non-string. Now it does not throw. Instead, it just ignores the argument.
 
 Build 002
 -------

--- a/js/lib/Locale.js
+++ b/js/lib/Locale.js
@@ -111,25 +111,25 @@ var Locale = function(language, region, variant, script) {
 	        this.variant = spec.variant || undefined;
 		}
 	} else {
-		if (language) {
+		if (language && typeof(language) === "string") {
 			language = language.trim();
 			this.language = language.length > 0 ? language.toLowerCase() : undefined;
 		} else {
 			this.language = undefined;
 		}
-		if (region) {
+		if (region && typeof(region) === "string") {
 			region = region.trim();
 			this.region = region.length > 0 ? region.toUpperCase() : undefined;
 		} else {
 			this.region = undefined;
 		}
-		if (variant) {
+		if (variant && typeof(variant) === "string") {
 			variant = variant.trim();
 			this.variant = variant.length > 0 ? variant : undefined;
 		} else {
 			this.variant = undefined;
 		}
-		if (script) {
+		if (script && typeof(script) === "string") {
 			script = script.trim();
 			this.script = script.length > 0 ? script : undefined;
 		} else {

--- a/js/test/root/nodeunit/testlocale.js
+++ b/js/test/root/nodeunit/testlocale.js
@@ -764,5 +764,34 @@ module.exports.testlocale = {
         var loc = new Locale("Hans-CN");
         test.equal(loc.getLangSpec(), "");
         test.done();
+    },
+    
+    testLocaleConstructorCalledWithNonStrings: function(test) {
+        test.expect(8);
+        
+        function a(a) { return a; }
+        
+        try {
+            var loc = new Locale(true, true, false, true);
+            test.equal(loc.getLangSpec(), "");
+            var loc = new Locale(a, a, a, a);
+            test.equal(loc.getSpec(), "");
+            var loc = new Locale(4, 4, 4, 4);
+            test.equal(loc.getSpec(), "");
+            var loc = new Locale({}, {}, {}, {});
+            test.equal(loc.getSpec(), "");
+
+            var loc = new Locale(true);
+            test.equal(loc.getSpec(), "");
+            var loc = new Locale(a);
+            test.equal(loc.getSpec(), "");
+            var loc = new Locale(4);
+            test.equal(loc.getSpec(), "");
+            var loc = new Locale({});
+            test.equal(loc.getSpec(), "");
+        } catch (e) {
+            test.fail();
+        }
+        test.done();
     }
 };


### PR DESCRIPTION
Now it is fixed of course!