### PR TITLE
Emergency patch: ilib 13.1.0 in npm was broken!

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version=13.1.0
+version=13.1.1

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -1,8 +1,20 @@
 Release Notes for Version 13.0
 =============================
 
+Build 003
+-------
+
+Published as version 13.1.1 to follow the semver rules
+ 
+Bug Fixes:
+
+* Build system was broken and the compressed js files did not make it into ilib 13.1.0 in npm, making it a 
+useless release! This is fixed now. There are no code changes between 13.1.0 and 13.1.1, only build fixes.
+
 Build 001
 -------
+
+Published as version 13.1.0
 
 New Features:
 
@@ -36,6 +48,8 @@ and new unit tests prove that the async operation is actually working correctly.
 
 Build 000
 -------
+
+Published as version 13.0.0
 
 New Features:
 

--- a/js/build.properties
+++ b/js/build.properties
@@ -15,3 +15,4 @@
 # 
 JSDOCDIR=${basedir}/../tools/jsdoc_toolkit-2.4.0/jsdoc-toolkit
 CLOSURECOMP=${basedir}/../tools/google-closure-compiler.r20150920
+uglify.location=${basedir}/../node_modules/uglify-js

--- a/js/build.xml
+++ b/js/build.xml
@@ -472,7 +472,7 @@ limitations under the License.
 			</sources>
 		</jscomp>
 	</target>
-	<target name="assemble.dynamic" depends="prepare,gen.manifest.locale,install.uglify" description="compresses/minifies the dynamic load code files">
+	<target name="assemble.dynamic" depends="prepare,gen.manifest.locale" description="compresses/minifies the dynamic load code files">
 		<!-- handle ilib.js as a special case so we can replace the version number in it -->
 		<copy file="${build.lib}/ilib.js" toFile="${build.output.js}/ilib.js" verbose="true"/>
 		<replace token="// !macro ilibVersion" value='"${version}"' preserveLastModified="true">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib",
-    "version": "13.1.0",
+    "version": "13.1.1",
     "main": "js/lib/ilib-node.js",
     "description": "iLib is a cross-engine library of internationalization (i18n) classes written in pure JS",
     "keywords": [


### PR DESCRIPTION
The problem was that the uglify run quietly failed and did not
stop the build. This means that the compressed js files did not
get included into the tar file that was published to npm as 13.1.0.
This fix temporarily fixes that, and we can publish again as 13.1.1
with no code changes. Only build fixes. All the build stuff is
reworked anyways in the build.xml in the webpack branch, so we
will not need this patch in development.