### PR TITLE
Handle the case where statements end in comma instead of semi-colon

### DIFF
--- a/tools/qmlizer/qmlizer.js
+++ b/tools/qmlizer/qmlizer.js
@@ -1,10 +1,29 @@
+/*
+ * qmlizer.js - fix the output of uglify so that it works properly in
+ * Qt/qml.
+ *
+ * Copyright © 2018, LGE, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 var fs = require('fs');
 
 function qmlize(text) {
 	// replace reserved keyword as with "as"
 	text = text.replace(/([\,\{]\s*)(as)(\s*:)/gm, '$1"$2"$3')
-	text = text.replace(/(new\s+[^\(\)\{\}\s;]+)(\s*;)/gm, '$1()$2')
-	text = text.replace(/(new\s+[^\(\)\{\}\s;]+)(\s*\})/gm, '$1();$2')
+	text = text.replace(/(new\s+[^\(\)\{\}\s;,]+)(\s*[;,])/gm, '$1()$2')
+	text = text.replace(/(new\s+[^\(\)\{\}\s;,]+)(\s*\})/gm, '$1();$2')
 	text = text.replace(/(\{\s*break)(\s*\})/gm, '$1;$2')
 	return text;
 }


### PR DESCRIPTION
The following code causes a problem after uglify + qmlizer is run:

```
var locale = new Locale(),
    foundData = false;
```

This gets translated to:

```
var u=new Locale,v=!1();
```

because the regular expression didn't stop at the comma. It continued to the next semicolon instead. When you run it, you get the error "'1' is not a function."

The solution was simple: make it stop at the comma or the semicolon. Resulting code is:

```
var u=new Locale(),v=!1;
```

which is correct now.