### PR TITLE
Fix a wrong documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ iLib is an internationalization library written in pure ES5 Javascript. It does 
 and can run equally well in various older and newer browsers, on various OS's (including mobile), nodejs, webOS, Qt/QML, 
 RingoJS, React/Enact, or rhino.
 
-More elaborate documentation can be found [here](doc/index.md)
+More elaborate documentation can be found [here](docs/index.md)
 
 What Can iLib Do?
 ------
@@ -151,14 +151,14 @@ limitations under the License.
 More Documentation
 ------
 
-More elaborate documentation can be found [here](doc/index.md).
+More elaborate documentation can be found [here](docs/index.md).
 
 Other Information
 ------
 
 Please point your browser to the following places to get more documentation:
 
-- JSDocs: http://www.translationcircle.com/ilib/jsdoc/
+- JSDocs: http://www.translationcircle.com/ilib/doc/jsdoc/
 - Github: git clone git@github.com:iLib-js/iLib.git
 - Builds: https://github.com/iLib-js/iLib/releases
 - Wiki: https://github.com/iLib-js/iLib/wiki

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -81,7 +81,7 @@ console.log("The date is " + formatter.format(date));
 // output is "The date is Fri 5/18/2012"
 ~~~~~
 
-Et voila, you have a formatted date. The strength of iLib is that the formatter classes are very flexible. The format is controlled via options to the _DateFmt()_ constructor. In the example above, only one argument was passed to the _DateFmt_ constructor to tell it to format dates only. Other arguments are assumed. It will use the current ilib locale, which it attempts to glean from the environment, and default format and length of format for that locale. See [the API reference documentation](http://www.translationcircle.com/ilib/jsdoc/) for more details on the parameters to the constructor of the _DateFmt_ class.
+Et voila, you have a formatted date. The strength of iLib is that the formatter classes are very flexible. The format is controlled via options to the _DateFmt()_ constructor. In the example above, only one argument was passed to the _DateFmt_ constructor to tell it to format dates only. Other arguments are assumed. It will use the current ilib locale, which it attempts to glean from the environment, and default format and length of format for that locale. See [the API reference documentation](http://www.translationcircle.com/ilib/doc/jsdoc/) for more details on the parameters to the constructor of the _DateFmt_ class.
 
 ## An Info Object ##
 
@@ -118,4 +118,4 @@ As a side note, all time zone information is compiled from the IANA tzdata datab
 
 ## More Reading ##
 
-The above is just a flavour of what you can get from iLib. There is also a more complete [tutorial](iLib1.0JSTutorial.pdf) for iLib 1.0 (a little out of date) that goes into detail about all the things iLib can do and a number of tutorial pages listed on the home page of this wiki. You can also browse [the latest API reference documentation](http://www.translationcircle.com/ilib/jsdoc/) when you are ready to start coding.
+The above is just a flavour of what you can get from iLib. There is also a more complete [tutorial](iLib1.0JSTutorial.pdf) for iLib 1.0 (a little out of date) that goes into detail about all the things iLib can do and a number of tutorial pages listed on the home page of this wiki. You can also browse [the latest API reference documentation](http://www.translationcircle.com/ilib/doc/jsdoc/) when you are ready to start coding.

--- a/docs/Welcome.md
+++ b/docs/Welcome.md
@@ -24,4 +24,4 @@ Using it is easy. Just include iliball-compiled.js in your HTML, et voila, the i
 
 If you don't need everything in iLib for your web site, iLib comes with a tool that allows you to reassemble a new, smaller file that only contains the classes you need, and all the classes they depend on. 
 
-For more detailed instructions, see the [Getting Started Guide](Getting Started) or the full [iLib Tutorial](iLib1.0JSTutorial.pdf). If you are an old pro at APIs or Javascript, you can skip directly to the [API Reference Documentation](http://www.translationcircle.com/ilib/jsdoc/).
+For more detailed instructions, see the [Getting Started Guide](Getting Started) or the full [iLib Tutorial](iLib1.0JSTutorial.pdf). If you are an old pro at APIs or Javascript, you can skip directly to the [API Reference Documentation](http://www.translationcircle.com/ilib/doc/jsdoc/).


### PR DESCRIPTION
Fix wrong documentation link:
* doc/index.md --> docs/index.md
* http://www.translationcircle.com/ilib/jsdoc/ --> http://www.translationcircle.com/ilib/doc/jsdoc