### PR TITLE
Fix async html tests.

### DIFF
--- a/js/test/address/nodeunit/testSuiteAsync.html
+++ b/js/test/address/nodeunit/testSuiteAsync.html
@@ -24,7 +24,7 @@ limitations under the License.
         var module = {};
     </script>
     <script src="/test/nodeunit/nodeunit.js"></script>
-    <script src="/output/js/ut/dynamic/uncompiled/ilib-ut-dyn.js"></script>
+    <script src="/output/js/ilib-ut.js"></script>
     <script>
         module = {
             exports: {}

--- a/js/test/calendar/nodeunit/testSuiteAsync.html
+++ b/js/test/calendar/nodeunit/testSuiteAsync.html
@@ -24,7 +24,7 @@ limitations under the License.
         var module = {};
     </script>
     <script src="/test/nodeunit/nodeunit.js"></script>
-    <script src="/output/js/ut/dynamic/uncompiled/ilib-ut-dyn.js"></script>
+    <script src="/output/js/ilib-ut.js"></script>
     <script>
         module = {
             exports: {}

--- a/js/test/collate/nodeunit/testSuiteAsync.html
+++ b/js/test/collate/nodeunit/testSuiteAsync.html
@@ -24,7 +24,7 @@ limitations under the License.
         var module = {};
     </script>
     <script src="/test/nodeunit/nodeunit.js"></script>
-    <script src="/output/js/ut/dynamic/uncompiled/ilib-ut-dyn.js"></script>
+    <script src="/output/js/ilib-ut.js"></script>
     <script>
         module = {
             exports: {}

--- a/js/test/ctype/nodeunit/testSuiteAsync.html
+++ b/js/test/ctype/nodeunit/testSuiteAsync.html
@@ -24,7 +24,7 @@ limitations under the License.
         var module = {};
     </script>
     <script src="/test/nodeunit/nodeunit.js"></script>
-    <script src="/output/js/ut/dynamic/uncompiled/ilib-ut-dyn.js"></script>
+    <script src="/output/js/ilib-ut.js"></script>
     <script>
         module = {
             exports: {}

--- a/js/test/date/nodeunit/testSuiteAsync.html
+++ b/js/test/date/nodeunit/testSuiteAsync.html
@@ -24,7 +24,7 @@ limitations under the License.
         var module = {};
     </script>
     <script src="/test/nodeunit/nodeunit.js"></script>
-    <script src="/output/js/ut/dynamic/uncompiled/ilib-ut-dyn.js"></script>
+    <script src="/output/js/ilib-ut.js"></script>
     <script>
         module = {
             exports: {}

--- a/js/test/daterange/nodeunit/testSuiteAsync.html
+++ b/js/test/daterange/nodeunit/testSuiteAsync.html
@@ -24,7 +24,7 @@ limitations under the License.
         var module = {};
     </script>
     <script src="/test/nodeunit/nodeunit.js"></script>
-    <script src="/output/js/ut/dynamic/uncompiled/ilib-ut-dyn.js"></script>
+    <script src="/output/js/ilib-ut.js"></script>
     <script>
         module = {
             exports: {}

--- a/js/test/durfmt/nodeunit/testSuiteAsync.html
+++ b/js/test/durfmt/nodeunit/testSuiteAsync.html
@@ -24,7 +24,7 @@ limitations under the License.
         var module = {};
     </script>
     <script src="/test/nodeunit/nodeunit.js"></script>
-    <script src="/output/js/ut/assembled/ilib-ut-dyn.js"></script>
+    <script src="/output/js/ilib-ut.js"></script>
     <script>
         module = {
             exports: {}

--- a/js/test/maps/nodeunit/testSuiteAsync.html
+++ b/js/test/maps/nodeunit/testSuiteAsync.html
@@ -24,7 +24,7 @@ limitations under the License.
         var module = {};
     </script>
     <script src="/test/nodeunit/nodeunit.js"></script>
-    <script src="/output/js/ut/assembled/ilib-ut-dyn.js"></script>
+    <script src="/output/js/ilib-ut.js"></script>
     <script>
         module = {
             exports: {}

--- a/js/test/name/nodeunit/testSuiteAsync.html
+++ b/js/test/name/nodeunit/testSuiteAsync.html
@@ -24,7 +24,7 @@ limitations under the License.
         var module = {};
     </script>
     <script src="/test/nodeunit/nodeunit.js"></script>
-    <script src="/output/js/ut/assembled/ilib-ut-dyn.js"></script>
+    <script src="/output/js/ilib-ut.js"></script>
     <script>
         module = {
             exports: {}

--- a/js/test/number/nodeunit/testSuiteAsync.html
+++ b/js/test/number/nodeunit/testSuiteAsync.html
@@ -24,7 +24,7 @@ limitations under the License.
         var module = {};
     </script>
     <script src="/test/nodeunit/nodeunit.js"></script>
-    <script src="/output/js/ut/assembled/ilib-ut-dyn.js"></script>
+    <script src="/output/js/ilib-ut.js"></script>
     <script>
         module = {
             exports: {}

--- a/js/test/strings-ext/nodeunit/testSuiteAsync.html
+++ b/js/test/strings-ext/nodeunit/testSuiteAsync.html
@@ -24,7 +24,7 @@ limitations under the License.
         var module = {};
     </script>
     <script src="/test/nodeunit/nodeunit.js"></script>
-    <script src="/output/js/ut/assembled/ilib-ut-dyn.js"></script>
+    <script src="/output/js/ilib-ut.js"></script>
     <script src="/test/strings-ext/test/normdata.js"></script>
     <script>
         module = {

--- a/js/test/testSuiteAsync.html
+++ b/js/test/testSuiteAsync.html
@@ -25,7 +25,7 @@ limitations under the License.
         var module = {};
     </script>
     <script src="/test/nodeunit/nodeunit.js"></script>
-    <script src="/output/js/ut/dynamic/ilib-ut-dyn.js"></script>
+    <script src="/output/js/ilib-ut.js"></script>
     <script src="strings-ext/test/normdata.js"></script>
     <script>
         var suites = {};

--- a/js/test/units/nodeunit/testSuiteAsync.html
+++ b/js/test/units/nodeunit/testSuiteAsync.html
@@ -24,7 +24,7 @@ limitations under the License.
         var module = {};
     </script>
     <script src="/test/nodeunit/nodeunit.js"></script>
-    <script src="/output/js/ut/assembled/ilib-ut-dyn.js"></script>
+    <script src="/output/js/ilib-ut.js"></script>
     <script>
         module = {
             exports: {}


### PR DESCRIPTION
We can't do real async tests with the asembled ilib yet because the dynamic loading of data depends on webpack. Instead, here we use an assembled version of ilib and ensure that the calls with async callbacks work correctly. These tests will become more useful when the webpack support is added.