### PR TITLE
Fix dates with local time zone

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -10,6 +10,7 @@ New Features:
     * Added is-IS locale to a list.
     * Implemented way of publishing date automatically instead of manual fixing.
     * Updated Name of the Day and Months part. If normal and standAlone are different, It displays both.
+
 Bug Fixes:
 * Fixed an ar-IQ currency symbol.
 * Updated the medium format day of the week translation of the ar-EG locale.
@@ -17,7 +18,9 @@ Bug Fixes:
 * Updated the daterange locale data in fr-CA local office feedback.
 * Updated the week duration locale data in ku-Arab-IQ correspong local office feedback.
 * Updated the meridiems data in or-IN correspond CLDR 33.
-
+* Fixed a bug where dates with the time zone "local" do not switch to DST at the right time because the time was calculated
+in UTC instead of the "local" time zone. This affected TimeZone.inDaylightTime(). If an explicit time zone was given, then
+then the calculation worked fine. It's only the special time zone "local" which had this bug.
 
 Build 003
 -------

--- a/js/lib/TimeZone.js
+++ b/js/lib/TimeZone.js
@@ -803,7 +803,7 @@ TimeZone.prototype.inDaylightTime = function (date, wallTime) {
 		// check if the dst property is defined -- the intrinsic JS Date object doesn't work so
 		// well if we are in the overlap time at the end of DST, so we have to work around that
 		// problem by adding in the savings ourselves
-		var offset = this.offset * 60000;
+		var offset = -(this.offset * 60000);
 		if (typeof(date.dst) !== 'undefined' && !date.dst) {
 			offset += this.dstSavings * 60000;
 		}

--- a/js/lib/TimeZone.js
+++ b/js/lib/TimeZone.js
@@ -803,12 +803,12 @@ TimeZone.prototype.inDaylightTime = function (date, wallTime) {
 		// check if the dst property is defined -- the intrinsic JS Date object doesn't work so
 		// well if we are in the overlap time at the end of DST, so we have to work around that
 		// problem by adding in the savings ourselves
-		var offset = 0;
+		var offset = this.offset * 60000;
 		if (typeof(date.dst) !== 'undefined' && !date.dst) {
-			offset = this.dstSavings * 60000;
+			offset += this.dstSavings * 60000;
 		}
-		
-		var d = new Date(date ? date.getTimeExtended() + offset: undefined);
+
+		var d = new Date(date ? date.getTimeExtended() - offset: undefined);
 		// the DST offset is always the one that is closest to positive infinity, no matter 
 		// if you are in the northern or southern hemisphere, east or west
 		var dst = Math.max(this.offsetJan1, this.offsetJun1);

--- a/js/lib/TimeZone.js
+++ b/js/lib/TimeZone.js
@@ -803,7 +803,7 @@ TimeZone.prototype.inDaylightTime = function (date, wallTime) {
 		// check if the dst property is defined -- the intrinsic JS Date object doesn't work so
 		// well if we are in the overlap time at the end of DST, so we have to work around that
 		// problem by adding in the savings ourselves
-		var offset = -(this.offset * 60000);
+		var offset = this.offset * 60000;
 		if (typeof(date.dst) !== 'undefined' && !date.dst) {
 			offset += this.dstSavings * 60000;
 		}

--- a/js/test/calendar/nodeunit/testpersiandateastro.js
+++ b/js/test/calendar/nodeunit/testpersiandateastro.js
@@ -621,6 +621,62 @@ module.exports.testpersiandateastro = {
         test.done();
     },
     
+    testPersDateAstroConstructorNearDSTWithExplicitTimeZone: function(test) {
+        test.expect(2);
+        var pd = new PersianDate({
+            year: 1397,
+            month: 1,
+            day: 1,
+            hour: 21,
+            minute: 13,
+            locale: "fa-IR",
+            timezone: "Asia/Tehran"
+        });
+
+        test.ok(pd !== null);
+
+        test.equal(pd.getJulianDay(), 2458199.238194444);
+        test.done();
+    },
+
+    /*
+    Doesn't work on node because you cannot change the time zone after the first
+    call to a Date method is called. After that, the time zone is fixed. So, we
+    cannot set up this test correctly in order to test it unless you set the 
+    system time zone to Asia/Tehran before running the entire suite.
+    testPersDateAstroConstructorNearDSTWithImplicitTimeZone: function(test) {
+        if (ilib._getPlatform() === "nodejs") {
+            test.expect(3);
+
+            ilib.tz = undefined;
+            var oldTZ = process.env.TZ;
+            process.env.TZ = "Asia/Tehran";
+
+            test.equal(ilib.getTimeZone(), "Asia/Tehran");
+
+            var pd = new PersianDate({
+                year: 1397,
+                month: 1,
+                day: 1,
+                hour: 21,
+                minute: 13,
+                timezone: "local",
+                locale: "fa-IR"
+            });
+
+            // var pd2 = DateFactory({year: 1397, month: 1, day: 1, hour: 21, minute: 13, timezone: "local", locale: "fa-IR"});
+            test.ok(pd !== null);
+
+            test.equal(pd.getJulianDay(), 2458199.238194444);
+
+            process.env.TZ = oldTZ;
+            ilib.tz = undefined;
+        }
+
+        test.done();
+    },
+    */
+
     testPersDateAstroSetYears: function(test) {
         test.expect(2);
         var pd = new PersianDate();

--- a/js/test/calendar/nodeunit/testpersiandateastro.js
+++ b/js/test/calendar/nodeunit/testpersiandateastro.js
@@ -644,7 +644,9 @@ module.exports.testpersiandateastro = {
     call to a Date method is called. After that, the time zone is fixed. So, we
     cannot set up this test correctly in order to test it unless you set the 
     system time zone to Asia/Tehran before running the entire suite.
-    testPersDateAstroConstructorNearDSTWithImplicitTimeZone: function(test) {
+    To run these, temporarily set your TZ environment variable to "Asia/Tehran"
+    first, uncomment these, and run as normal.
+    testPersDateAstroConstructorBeforeDSTWithImplicitTimeZone: function(test) {
         if (ilib._getPlatform() === "nodejs") {
             test.expect(3);
 
@@ -664,10 +666,40 @@ module.exports.testpersiandateastro = {
                 locale: "fa-IR"
             });
 
-            // var pd2 = DateFactory({year: 1397, month: 1, day: 1, hour: 21, minute: 13, timezone: "local", locale: "fa-IR"});
             test.ok(pd !== null);
 
             test.equal(pd.getJulianDay(), 2458199.238194444);
+
+            process.env.TZ = oldTZ;
+            ilib.tz = undefined;
+        }
+
+        test.done();
+    },
+
+    testPersDateAstroConstructorAfterDSTWithImplicitTimeZone: function(test) {
+        if (ilib._getPlatform() === "nodejs") {
+            test.expect(3);
+
+            ilib.tz = undefined;
+            var oldTZ = process.env.TZ;
+            process.env.TZ = "Asia/Tehran";
+
+            test.equal(ilib.getTimeZone(), "Asia/Tehran");
+
+            var pd = new PersianDate({
+                year: 1397,
+                month: 1,
+                day: 2,
+                hour: 1,
+                minute: 13,
+                timezone: "local",
+                locale: "fa-IR"
+            });
+
+            test.ok(pd !== null);
+
+            test.equal(pd.getJulianDay(), 2458199.363194444);
 
             process.env.TZ = oldTZ;
             ilib.tz = undefined;


### PR DESCRIPTION
Subtract the time zone offset from the current extended unix time so that we can correctly tell if the given date is in dst time or not. Otherwise, it will check if UTC time is in DST or not, which is wrong.