### PR TITLE
Add ability to get the default timezone from the Intl object

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -6,10 +6,12 @@ Build 004
 Published as version 13.3.0
 
 New Features:
-* LocaleReference Documentation
+* Update of the LocaleReference Test Website Documentation
     * Added is-IS locale to a list.
     * Implemented way of publishing date automatically instead of manual fixing.
     * Updated Name of the Day and Months part. If normal and standAlone are different, It displays both.
+* Modified ilib.getTimeZone() to find the time zone from the Intl object if it is available. If not, it falls back
+to the previous behaviour of checking environment variables.
 
 Bug Fixes:
 * Fixed an ar-IQ currency symbol.

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -10,6 +10,7 @@ New Features:
     * Added is-IS locale to a list.
     * Implemented way of publishing date automatically instead of manual fixing.
     * Updated Name of the Day and Months part. If normal and standAlone are different, It displays both.
+
 Bug Fixes:
 * Fixed an ar-IQ currency symbol.
 * Updated the medium format day of the week translation of the ar-EG locale.
@@ -17,7 +18,9 @@ Bug Fixes:
 * Updated the daterange locale data in fr-CA local office feedback.
 * Updated the week duration locale data in ku-Arab-IQ correspong local office feedback.
 * Updated the meridiems data in or-IN correspond CLDR 33.
-
+* Fixed a bug where dates with the time zone "local" do not switch to DST at the right time because the time was calculated
+in UTC instead of the "local" time zone. This affected TimeZone.inDaylightTime(). If an explicit time zone was given, then
+then the calculation worked fine. It's only the special time zone "local" which had this bug.
 
 Build 003
 -------

--- a/js/lib/TimeZone.js
+++ b/js/lib/TimeZone.js
@@ -803,12 +803,12 @@ TimeZone.prototype.inDaylightTime = function (date, wallTime) {
 		// check if the dst property is defined -- the intrinsic JS Date object doesn't work so
 		// well if we are in the overlap time at the end of DST, so we have to work around that
 		// problem by adding in the savings ourselves
-		var offset = 0;
+		var offset = this.offset * 60000;
 		if (typeof(date.dst) !== 'undefined' && !date.dst) {
-			offset = this.dstSavings * 60000;
+			offset += this.dstSavings * 60000;
 		}
-		
-		var d = new Date(date ? date.getTimeExtended() + offset: undefined);
+
+		var d = new Date(date ? date.getTimeExtended() - offset: undefined);
 		// the DST offset is always the one that is closest to positive infinity, no matter 
 		// if you are in the northern or southern hemisphere, east or west
 		var dst = Math.max(this.offsetJan1, this.offsetJun1);

--- a/js/lib/ilib.js
+++ b/js/lib/ilib.js
@@ -384,29 +384,36 @@ ilib.setTimeZone = function (tz) {
  */
 ilib.getTimeZone = function() {
     if (typeof(ilib.tz) === 'undefined') {
-        if (typeof(navigator) !== 'undefined' && typeof(navigator.timezone) !== 'undefined') {
-            // running in a browser
-            if (navigator.timezone.length > 0) {
-                ilib.tz = navigator.timezone;
-            }
-        } else if (typeof(PalmSystem) !== 'undefined' && typeof(PalmSystem.timezone) !== 'undefined') {
-            // running in webkit on webOS
-            if (PalmSystem.timezone.length > 0) {
-                ilib.tz = PalmSystem.timezone;
-            }
-        } else if (typeof(environment) !== 'undefined' && typeof(environment.user) !== 'undefined') {
-            // running under rhino
-            if (typeof(environment.user.timezone) !== 'undefined' && environment.user.timezone.length > 0) {
-                ilib.tz = environment.user.timezone;
-            }
-        } else if (typeof(process) !== 'undefined' && typeof(process.env) !== 'undefined') {
-            // running in nodejs
-            if (process.env.TZ && typeof(process.env.TZ) !== "undefined") {
-                ilib.tz = process.env.TZ;
-            }
+        if (typeof(Intl) !== 'undefined' && typeof(Intl.DateTimeFormat) !== 'undefined') {
+            var ro = new Intl.DateTimeFormat().resolvedOptions();
+            ilib.tz = ro && ro.timeZone;
         }
         
-        ilib.tz = ilib.tz || "local"; 
+        if (!ilib.tz) {
+            if (typeof(navigator) !== 'undefined' && typeof(navigator.timezone) !== 'undefined') {
+                // running in a browser
+                if (navigator.timezone.length > 0) {
+                    ilib.tz = navigator.timezone;
+                }
+            } else if (typeof(PalmSystem) !== 'undefined' && typeof(PalmSystem.timezone) !== 'undefined') {
+                // running in webkit on webOS
+                if (PalmSystem.timezone.length > 0) {
+                    ilib.tz = PalmSystem.timezone;
+                }
+            } else if (typeof(environment) !== 'undefined' && typeof(environment.user) !== 'undefined') {
+                // running under rhino
+                if (typeof(environment.user.timezone) !== 'undefined' && environment.user.timezone.length > 0) {
+                    ilib.tz = environment.user.timezone;
+                }
+            } else if (typeof(process) !== 'undefined' && typeof(process.env) !== 'undefined') {
+                // running in nodejs
+                if (process.env.TZ && typeof(process.env.TZ) !== "undefined") {
+                    ilib.tz = process.env.TZ;
+                }
+            }
+            
+            ilib.tz = ilib.tz || "local";
+        }
     }
 
     return ilib.tz;

--- a/js/test/calendar/nodeunit/testpersiandateastro.js
+++ b/js/test/calendar/nodeunit/testpersiandateastro.js
@@ -621,6 +621,62 @@ module.exports.testpersiandateastro = {
         test.done();
     },
     
+    testPersDateAstroConstructorNearDSTWithExplicitTimeZone: function(test) {
+        test.expect(2);
+        var pd = new PersianDate({
+            year: 1397,
+            month: 1,
+            day: 1,
+            hour: 21,
+            minute: 13,
+            locale: "fa-IR",
+            timezone: "Asia/Tehran"
+        });
+
+        test.ok(pd !== null);
+
+        test.equal(pd.getJulianDay(), 2458199.238194444);
+        test.done();
+    },
+
+    /*
+    Doesn't work on node because you cannot change the time zone after the first
+    call to a Date method is called. After that, the time zone is fixed. So, we
+    cannot set up this test correctly in order to test it unless you set the 
+    system time zone to Asia/Tehran before running the entire suite.
+    testPersDateAstroConstructorNearDSTWithImplicitTimeZone: function(test) {
+        if (ilib._getPlatform() === "nodejs") {
+            test.expect(3);
+
+            ilib.tz = undefined;
+            var oldTZ = process.env.TZ;
+            process.env.TZ = "Asia/Tehran";
+
+            test.equal(ilib.getTimeZone(), "Asia/Tehran");
+
+            var pd = new PersianDate({
+                year: 1397,
+                month: 1,
+                day: 1,
+                hour: 21,
+                minute: 13,
+                timezone: "local",
+                locale: "fa-IR"
+            });
+
+            // var pd2 = DateFactory({year: 1397, month: 1, day: 1, hour: 21, minute: 13, timezone: "local", locale: "fa-IR"});
+            test.ok(pd !== null);
+
+            test.equal(pd.getJulianDay(), 2458199.238194444);
+
+            process.env.TZ = oldTZ;
+            ilib.tz = undefined;
+        }
+
+        test.done();
+    },
+    */
+
     testPersDateAstroSetYears: function(test) {
         test.expect(2);
         var pd = new PersianDate();


### PR DESCRIPTION
If the Intl object is available on this platform, ilib.getTimeZone() will attempt to get it from there. If it can't, then it will fall back to its previous behaviour of checking environment variables, and if there are none, then fall back to the hard coded defaults.