### PR TITLE
Add option.sync is true when it is undefined in DateFmt

### DIFF
--- a/js/lib/DateFmt.js
+++ b/js/lib/DateFmt.js
@@ -621,7 +621,7 @@ DateFmt.prototype = {
      * Finish initializing the formatter object
      */
     _init: function(options) {
-        if (!options.sync) {
+        if (typeof (options.sync) === 'undefined') {
             options.sync = true;
         }
         if (!this.template) {

--- a/js/lib/DateFmt.js
+++ b/js/lib/DateFmt.js
@@ -621,6 +621,9 @@ DateFmt.prototype = {
      * Finish initializing the formatter object
      */
     _init: function(options) {
+        if (!options.sync) {
+            options.sync = true;
+        }
         if (!this.template) {
             Utils.loadData({
                 object: "DateFmt", 


### PR DESCRIPTION
Fix legacy platform enyo 2.6+ bug:
Previously, that options were `true` for initial object setting. but it's undefined now.
If it's `undefined`. It set as `false` eventually in https://github.com/iLib-js/iLib/blob/development/js/lib/Utils.js#L341
It occurs error during load `dateformats.json`  in legacy platform enyo 2.6+
