### PR TITLE
Update npm package to include README.md

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version=13.3.0
+version=13.3.1

--- a/build.xml
+++ b/build.xml
@@ -67,6 +67,7 @@ limitations under the License.
 	<target name="dist" depends="all" description="Build the distribution package.">
 		<mkdir dir="${build.dist}" description="Dir to contain all the distribution outputs"/>
 		<iterate target="export"/>
+		<copy file="README.md" todir="${build.export}/package" />
 		<zip destfile="${build.dist}/ilib-${version}.zip"
 			basedir="${build.export}"
 			includes="js/**,java/**,locale/**,qt/**"/>

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -1,6 +1,16 @@
 Release Notes for Version 13
 ============================
 
+Build 005
+-------
+Published as version 13.3.1 on npm only
+
+New Features:
+* No code or documentation changes
+
+Bug Fixes:
+* Forgot to include the README.md in the npm package. Now it is there. This is the only change from 13.3.0.
+
 Build 004
 -------
 Published as version 13.3.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib",
-    "version": "13.3.0",
+    "version": "13.3.1",
     "main": "js/lib/ilib-node.js",
     "description": "iLib is a cross-engine library of internationalization (i18n) classes written in pure JS",
     "keywords": [


### PR DESCRIPTION
Forgot to include the README.md in the npm package. Now it is there. Updated the version to 13.3.1. This is the only change from 13.3.0 -- No code or documentation changes!
