### PR TITLE
Restore missing mapping for Japan in the native country name to iso code mapping

### DIFF
--- a/js/data/locale/nativecountries.json
+++ b/js/data/locale/nativecountries.json
@@ -52,6 +52,7 @@
     "中国": "CN",
     "union des comores": "KM",
     "udzima wa komori": "KM",
+    "日本":"JP",
     "الاتحاد القمري": "KM",
     "al-ittiḥād al-qumurī/qamarī": "KM",
     "république du congo": "CG",


### PR DESCRIPTION
Not sure how that got deleted!