### PR TITLE
Creating a new top-level entry point for ilib

### DIFF
--- a/js/build.xml
+++ b/js/build.xml
@@ -342,8 +342,10 @@ limitations under the License.
             <fileset dir="${build.lib}">
                 <include name="ilib-node*"/>
                 <include name="ilib-qt*"/>
-                <include name="ilib-getdata.js"/>
                 <include name="ilib-unpack.js"/>
+            </fileset>
+            <fileset dir="${build.base}">
+                <include name="index.js"/>
             </fileset>
 			<mapper type="glob" from="*.js" to="*.js"/>
 		</apply>
@@ -467,6 +469,7 @@ limitations under the License.
 		<copy todir="${build.export}/src/js">
 			<fileset dir="${build.base}">
 				<include name="lib/**"/>
+				<include name="index.js"/>
 				<include name="build.xml"/>
 				<include name="build.properties"/>
 				<include name="data/locale/**/*.json"/>
@@ -494,6 +497,7 @@ limitations under the License.
 				<exclude name="ilib-qt.js"/>
 				<exclude name="ilib-rhino.js"/>
 				<exclude name="ilib-enyo.js"/>
+				<exclude name="index.js"/>
             </fileset>
             <fileset dir="${build.export}/js/dyncode">
                 <include name="Loader.js"/>
@@ -505,6 +509,11 @@ limitations under the License.
 				<include name="ilib-full-dyn.js"/>
 				<include name="ilib-full-dyn-compiled.js"/>
 			</fileset>
+		</copy>
+		<copy todir="${build.export}/package">
+            <fileset dir="${build.export}/js/dyncode">
+                <include name="index.js"/>
+            </fileset>
 		</copy>
 		<copy todir="${build.export}/package/locale">
 			<fileset dir="${build.locale}">

--- a/js/index.js
+++ b/js/index.js
@@ -1,0 +1,57 @@
+/*
+ * index.js - top level entry point for ilib
+ *
+ * Copyright © 2018 JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var ilib = require("./lib/ilib.js");
+
+if (!ilib._platform || (typeof(ilib._dyndata) !== 'boolean' && typeof(ilib._dyncode) !== 'boolean')) {
+    if (typeof(__webpack_require__) !== 'undefined') {
+        // The following will either require and then install the
+        // WebpackLoader to dynamically load locale data bundles,
+        // or it will statically require all of the locale data that
+        // this build needs so that it can be included into this
+        // webpack bundle.
+
+        // !defineLocaleData
+    } else {
+        switch (ilib._getPlatform()) {
+            case 'webos':
+            case 'nodejs':
+                require("./lib/ilib-node.js");
+                break;
+
+            case 'qt':
+                require("./lib/ilib-qt.js");
+
+            case 'rhino':
+                require("./lib/ilib-rhino.js");
+                break;
+
+            case 'ringo':
+                require("./lib/ilib-ringo.js");
+                break;
+
+            default:
+                ilib._dyncode = false;
+                ilib._dyndata = false;
+                break;
+        }
+    }
+}
+
+module.exports = ilib;

--- a/js/lib/Address.js
+++ b/js/lib/Address.js
@@ -21,7 +21,7 @@
 
 // !data address countries nativecountries ctrynames
 
-var ilib = require("./ilib.js");
+var ilib = require("../index");
 var Utils = require("./Utils.js");
 var JSUtils = require("./JSUtils.js");
 var Locale = require("./Locale.js");

--- a/js/lib/AddressFmt.js
+++ b/js/lib/AddressFmt.js
@@ -19,7 +19,7 @@
 
 // !data address addressres regionnames
 
-var ilib = require("./ilib.js");
+var ilib = require("../index");
 var Utils = require("./Utils.js");
 var JSUtils = require("./JSUtils.js");
 
@@ -324,17 +324,14 @@ function invertAndFilter(object) {
  * new AddressFmt({
  *   locale: 'nl-NL', // for addresses in the Netherlands
  *   onLoad: ilib.bind(this, function(fmt) {
- *     fmt.getAddressFormatInfo({
- *       // The following is the locale of the UI you would like to see the labels
- *       // like "City" and "Postal Code" translated to. In this example, we
- *       // are showing an input form for Dutch addresses, but the labels are
- *       // written in US English.
- *       locale: "en-US",
- *       onLoad: ilib.bind(this, function(rows) {
- *         // iterate through the rows array and dynamically create the input
- *         // elements with the given labels
- *       })
- *     });
+ *     // The following is the locale of the UI you would like to see the labels
+ *     // like "City" and "Postal Code" translated to. In this example, we
+ *     // are showing an input form for Dutch addresses, but the labels are
+ *     // written in US English.
+ *     fmt.getAddressFormatInfo("en-US", true, ilib.bind(this, function(rows) {
+ *       // iterate through the rows array and dynamically create the input
+ *       // elements with the given labels
+ *     }));
  *   })
  * });
  *

--- a/js/lib/AlphabeticIndex.js
+++ b/js/lib/AlphabeticIndex.js
@@ -19,7 +19,7 @@
 
 // !data nfc nfkd
 
-var ilib = require("./ilib.js");
+var ilib = require("../index");
 var Utils = require("./Utils.js");
 var Locale = require("./Locale.js");
 var CType = require("./CType.js");

--- a/js/lib/Astro.js
+++ b/js/lib/Astro.js
@@ -25,7 +25,7 @@
  * September 1999.
  */
 
-var ilib = require("./ilib.js");
+var ilib = require("../index");
 var Utils = require("./Utils.js");
 var SearchUtils = require("./SearchUtils.js");
 

--- a/js/lib/AsyncNodeLoader.js
+++ b/js/lib/AsyncNodeLoader.js
@@ -47,7 +47,9 @@ module.exports = function (ilib) {
         //console.log("module.filename is " + module.filename + "\n");
         //console.log("base is defined as " + this.base + "\n");
 
-        this.includePath.push(path.join(this.root, "resources"));     // always check the application's resources dir first
+        // this.includePath.push(path.join(this.root, "resources"));     
+        this._exists(this.root, "resources"); // always check the application's resources dir first
+        this._exists(path.join(this.root, "locale"), "localeinfo.json");
 
         // then a standard locale dir of a built version of ilib from npm
         this._exists(path.join(this.base, "locale"), "localeinfo.json");

--- a/js/lib/AsyncNodeLoader.js
+++ b/js/lib/AsyncNodeLoader.js
@@ -47,7 +47,7 @@ module.exports = function (ilib) {
         //console.log("module.filename is " + module.filename + "\n");
         //console.log("base is defined as " + this.base + "\n");
 
-        // this.includePath.push(path.join(this.root, "resources"));     
+        // this.includePath.push(path.join(this.root, "resources"));
         this._exists(this.root, "resources"); // always check the application's resources dir first
         this._exists(path.join(this.root, "locale"), "localeinfo.json");
 

--- a/js/lib/CType.js
+++ b/js/lib/CType.js
@@ -19,7 +19,7 @@
 
 // !data ctype
 
-var ilib = require("./ilib.js");
+var ilib = require("../index");
 var SearchUtils = require("./SearchUtils.js");
 var Utils = require("./Utils.js");
 var IString = require("./IString.js");

--- a/js/lib/CalendarFactory.js
+++ b/js/lib/CalendarFactory.js
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-var ilib = require("./ilib.js");
+var ilib = require("../index");
 var Locale = require("./Locale.js");
 var LocaleInfo = require("./LocaleInfo.js");
 var Calendar = require("./Calendar.js");

--- a/js/lib/CaseMapper.js
+++ b/js/lib/CaseMapper.js
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-var ilib = require("./ilib.js");
+var ilib = require("../index");
 
 var Locale = require("./Locale.js");
 var IString = require("./IString.js");

--- a/js/lib/Charmap.js
+++ b/js/lib/Charmap.js
@@ -19,7 +19,7 @@
 
 // !data charmaps charset/US-ASCII charset/ISO-10646-UCS-2 charset/ISO-8859-1 charset/ISO-8859-15 charmaps/ISO-8859-15 charmaps/ISO-8859-1 charset/ISO-8859-1
 
-var ilib = require("./ilib.js");
+var ilib = require("../index");
 var JSUtils = require("./JSUtils.js");
 var IString = require("./IString.js");
 

--- a/js/lib/CharmapFactory.js
+++ b/js/lib/CharmapFactory.js
@@ -18,7 +18,7 @@
  * limitations under the License.
  */
 
-var ilib = require("./ilib.js");
+var ilib = require("../index");
 var JSUtils = require("./JSUtils.js");
 
 var Charset = require("./Charset.js");

--- a/js/lib/CharmapTable.js
+++ b/js/lib/CharmapTable.js
@@ -19,7 +19,7 @@
 
 // !data charmaps/ISO-8859-15 charset/ISO-8859-15
 
-var ilib = require("./ilib.js");
+var ilib = require("../index");
 var Utils = require("./Utils.js");
 var Charset = require("./Charset.js");
 var Charmap = require("./Charmap.js");

--- a/js/lib/Charset.js
+++ b/js/lib/Charset.js
@@ -19,7 +19,7 @@
 
 // !data charset charsetaliases charset/ISO-8859-1 charset/ISO-8859-15 charset/UTF-8
 
-var ilib = require("./ilib.js");
+var ilib = require("../index");
 var Utils = require("./Utils.js");
 
 /**

--- a/js/lib/Collator.js
+++ b/js/lib/Collator.js
@@ -19,7 +19,7 @@
 
 // !data collation
 
-var ilib = require("./ilib.js");
+var ilib = require("../index");
 var Utils = require("./Utils.js");
 var JSUtils = require("./JSUtils.js");
 var Locale = require("./Locale.js");

--- a/js/lib/CopticDate.js
+++ b/js/lib/CopticDate.js
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-var ilib = require("./ilib.js");
+var ilib = require("../index");
 var MathUtils = require("./MathUtils.js");
 
 var Locale = require("./Locale.js");

--- a/js/lib/Country.js
+++ b/js/lib/Country.js
@@ -19,7 +19,7 @@
 
 // !data ctryreverse
 
-var ilib = require("./ilib.js");
+var ilib = require("../index");
 var Utils = require("./Utils.js");
 var Locale = require("./Locale.js");
 var LocaleInfo = require("./LocaleInfo.js");

--- a/js/lib/Currency.js
+++ b/js/lib/Currency.js
@@ -19,7 +19,7 @@
 
 // !data currency
 
-var ilib = require("./ilib.js");
+var ilib = require("../index");
 var Utils = require("./Utils.js");
 var Locale = require("./Locale.js");
 var LocaleInfo = require("./LocaleInfo.js");

--- a/js/lib/DateFactory.js
+++ b/js/lib/DateFactory.js
@@ -18,7 +18,7 @@
  * limitations under the License.
  */
 
-var ilib = require("./ilib.js");
+var ilib = require("../index");
 var JSUtils = require("./JSUtils.js");
 
 var Locale = require("./Locale.js");
@@ -195,7 +195,7 @@ DateFactory._init = function(type, options) {
 
     // pass the same options through to the constructor so the subclass
     // has the ability to do something with if it needs to
-    if (!cons && typeof(options.onLoad) === "function") {
+    if (!cons && options && typeof(options.onLoad) === "function") {
         options.onLoad(undefined);
     }
     return cons && new cons(options);

--- a/js/lib/DateFmt.js
+++ b/js/lib/DateFmt.js
@@ -19,7 +19,7 @@
 
 // !data dateformats sysres
 
-var ilib = require("./ilib.js");
+var ilib = require("../index");
 var Utils = require("./Utils.js");
 var JSUtils = require("./JSUtils.js");
 
@@ -432,7 +432,7 @@ var DateFmt = function(options) {
                 // If we are running in the dynamic code loading assembly of ilib, the following
                 // will attempt to dynamically load the calendar date class for this calendar. If
                 // it doesn't work, this just goes on and it will use Gregorian instead.
-                DateFactory._dynLoadDate(this.calName);
+                DateFactory._init(this.calName);
             }
 
             CalendarFactory({

--- a/js/lib/DateRngFmt.js
+++ b/js/lib/DateRngFmt.js
@@ -19,7 +19,7 @@
 
 // !data dateformats sysres
 
-var ilib = require("./ilib.js");
+var ilib = require("../index");
 var JSUtils = require("./JSUtils.js");
 
 var Locale = require("./Locale.js");

--- a/js/lib/DurationFmt.js
+++ b/js/lib/DurationFmt.js
@@ -19,7 +19,7 @@
 
 // !data dateformats sysres
 
-var ilib = require("./ilib.js");
+var ilib = require("../index");
 var JSUtils = require("./JSUtils.js");
 var Locale = require("./Locale.js");
 var LocaleInfo = require("./LocaleInfo.js");

--- a/js/lib/EthiopicDate.js
+++ b/js/lib/EthiopicDate.js
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-var ilib = require("./ilib.js");
+var ilib = require("../index");
 var MathUtils = require("./MathUtils.js");
 
 var EthiopicRataDie = require("./EthiopicRataDie.js");

--- a/js/lib/GlyphString.js
+++ b/js/lib/GlyphString.js
@@ -20,7 +20,7 @@
 
 // !data ccc nfc ctype_m
 
-var ilib = require("./ilib.js");
+var ilib = require("../index");
 var Utils = require("./Utils.js");
 var JSUtils = require("./JSUtils.js");
 

--- a/js/lib/GregorianDate.js
+++ b/js/lib/GregorianDate.js
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-var ilib = require("./ilib.js");
+var ilib = require("../index");
 var SearchUtils = require("./SearchUtils.js");
 var MathUtils = require("./MathUtils.js");
 

--- a/js/lib/HanCal.js
+++ b/js/lib/HanCal.js
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-var ilib = require("./ilib.js");
+var ilib = require("../index");
 var MathUtils = require("./MathUtils.js");
 
 var Calendar = require("./Calendar.js");

--- a/js/lib/HanDate.js
+++ b/js/lib/HanDate.js
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-var ilib = require("./ilib.js");
+var ilib = require("../index");
 var JSUtils = require("./JSUtils.js");
 var MathUtils = require("./MathUtils.js");
 

--- a/js/lib/HanRataDie.js
+++ b/js/lib/HanRataDie.js
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-var ilib = require("./ilib.js");
+var ilib = require("../index");
 var MathUtils = require("./MathUtils.js");
 var HanCal = require("./HanCal.js");
 var RataDie = require("./RataDie.js");

--- a/js/lib/HebrewDate.js
+++ b/js/lib/HebrewDate.js
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-var ilib = require("./ilib.js");
+var ilib = require("../index");
 var MathUtils = require("./MathUtils.js");
 
 var Locale = require("./Locale.js");

--- a/js/lib/INumber.js
+++ b/js/lib/INumber.js
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-var ilib = require("./ilib.js");
+var ilib = require("../index");
 
 var Locale = require("./Locale.js");
 var LocaleInfo = require("./LocaleInfo.js");

--- a/js/lib/IString.js
+++ b/js/lib/IString.js
@@ -19,7 +19,7 @@
 
 // !data plurals
 
-var ilib = require("./ilib.js");
+var ilib = require("../index");
 var Utils = require("./Utils.js");
 var MathUtils = require("./MathUtils.js");
 var Locale = require("./Locale.js");

--- a/js/lib/IslamicDate.js
+++ b/js/lib/IslamicDate.js
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-var ilib = require("./ilib.js");
+var ilib = require("../index");
 var SearchUtils = require("./SearchUtils.js");
 var MathUtils = require("./MathUtils.js");
 

--- a/js/lib/JulianDate.js
+++ b/js/lib/JulianDate.js
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-var ilib = require("./ilib.js");
+var ilib = require("../index");
 var SearchUtils = require("./SearchUtils.js");
 var MathUtils = require("./MathUtils.js");
 

--- a/js/lib/ListFmt.js
+++ b/js/lib/ListFmt.js
@@ -20,7 +20,7 @@
 
 // !data list
 
-var ilib = require("./ilib.js");
+var ilib = require("../index");
 var Utils = require("./Utils.js");
 var Locale = require("./Locale.js");
 

--- a/js/lib/Loader.js
+++ b/js/lib/Loader.js
@@ -44,19 +44,21 @@ Loader.prototype._exists = function(dir, file) {
     var fullpath = Path.normalize(Path.join(dir, file));
     if (this.protocol !== "http://") {
         var text = this._loadFile(fullpath, true);
-        if (text) {
+        if (text && this.includePath.indexOf(text) === -1) {
             this.includePath.push(dir);
         }
     } else {
         // put the dir on the list now assuming it exists, and check for its availability
         // later so we can avoid the 404 errors eventually
-        this.includePath.push(dir);
-        this._loadFile(fullpath, false, ilib.bind(this, function(text) {
-            if (!text) {
-                //console.log("Loader._exists: removing " + dir + " from the include path because it doesn't exist.");
-                this.includePath = this.includePath.slice(-1);
-            }
-        }));
+        if (this.includePath.indexOf(dir) === -1) {
+            this.includePath.push(dir);
+            this._loadFile(fullpath, false, ilib.bind(this, function(text) {
+                if (!text) {
+                    //console.log("Loader._exists: removing " + dir + " from the include path because it doesn't exist.");
+                    this.includePath = this.includePath.slice(-1);
+                }
+            }));
+        }
     }
 };
 

--- a/js/lib/LocaleInfo.js
+++ b/js/lib/LocaleInfo.js
@@ -19,7 +19,7 @@
 
 // !data localeinfo
 
-var ilib = require("./ilib.js");
+var ilib = require("../index");
 var Utils = require("./Utils.js");
 var Locale = require("./Locale.js");
 

--- a/js/lib/LocaleMatcher.js
+++ b/js/lib/LocaleMatcher.js
@@ -19,7 +19,7 @@
 
 // !data localematch
 
-var ilib = require("./ilib.js");
+var ilib = require("../index");
 var Utils = require("./Utils.js");
 var Locale = require("./Locale.js");
 

--- a/js/lib/Name.js
+++ b/js/lib/Name.js
@@ -25,7 +25,7 @@
 // http://www.mentalfloss.com/blogs/archives/59277
 // other countries with first name restrictions: Norway, China, New Zealand, Japan, Sweden, Germany, Hungary
 
-var ilib = require("./ilib.js");
+var ilib = require("../index");
 var Utils = require("./Utils.js");
 var JSUtils = require("./JSUtils.js");
 

--- a/js/lib/NameFmt.js
+++ b/js/lib/NameFmt.js
@@ -19,7 +19,7 @@
 
 // !data name
 
-var ilib = require("./ilib.js");
+var ilib = require("../index");
 var Utils = require("./Utils.js");
 
 var Locale = require("./Locale.js");

--- a/js/lib/NodeLoader.js
+++ b/js/lib/NodeLoader.js
@@ -46,7 +46,9 @@ module.exports = function (ilib) {
         //console.log("module.filename is " + module.filename + "\n");
         //console.log("base is defined as " + this.base + "\n");
 
-        this.includePath.push(path.join(this.root, "resources"));     // always check the application's resources dir first
+        // this.includePath.push(path.join(this.root, "resources"));     // always check the application's resources dir first
+        this._exists(this.root, "resources"); // always check the application's resources dir first
+        this._exists(path.join(this.root, "locale"), "localeinfo.json");
 
         // then a standard locale dir of a built version of ilib from npm
         this._exists(path.join(this.base, "locale"), "localeinfo.json");
@@ -89,7 +91,7 @@ module.exports = function (ilib) {
     NodeLoader.prototype._exists = function(dir, file) {
         var fullpath = path.normalize(path.join(dir, file));
         //console.log("NodeLoader._exists: checking for the existence of " + dir);
-        if (fs.existsSync(fullpath)) {
+        if (this.includePath.indexOf(fullpath) === -1 && fs.existsSync(fullpath)) {
             //console.log("NodeLoader._exists: found");
             this.includePath.push(dir);
         }

--- a/js/lib/NormString.js
+++ b/js/lib/NormString.js
@@ -19,7 +19,7 @@
 
 // !data ccc nfd nfc nfkd nfkc
 
-var ilib = require("./ilib.js");
+var ilib = require("../index");
 var Utils = require("./Utils.js");
 var JSUtils = require("./JSUtils.js");
 

--- a/js/lib/NumFmt.js
+++ b/js/lib/NumFmt.js
@@ -30,7 +30,7 @@ JSUtils.js
 
 // !data localeinfo currency
 
-var ilib = require("./ilib.js");
+var ilib = require("../index");
 var JSUtils = require("./JSUtils.js");
 var MathUtils = require("./MathUtils.js");
 

--- a/js/lib/NumberingPlan.js
+++ b/js/lib/NumberingPlan.js
@@ -19,7 +19,7 @@
 
 // !data numplan
 
-var ilib = require("./ilib.js");
+var ilib = require("../index");
 var Utils = require("./Utils.js");
 var Locale = require("./Locale.js");
 

--- a/js/lib/PersRataDie.js
+++ b/js/lib/PersRataDie.js
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-var ilib = require("./ilib.js");
+var ilib = require("../index");
 var MathUtils = require("./MathUtils.js");
 
 var Astro = require("./Astro.js");

--- a/js/lib/PersianAlgoDate.js
+++ b/js/lib/PersianAlgoDate.js
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-var ilib = require("./ilib.js");
+var ilib = require("../index");
 var SearchUtils = require("./SearchUtils.js");
 var MathUtils = require("./MathUtils.js");
 

--- a/js/lib/PersianDate.js
+++ b/js/lib/PersianDate.js
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-var ilib = require("./ilib.js");
+var ilib = require("../index");
 var SearchUtils = require("./SearchUtils.js");
 var MathUtils = require("./MathUtils.js");
 var JSUtils = require("./JSUtils.js");

--- a/js/lib/PhoneFmt.js
+++ b/js/lib/PhoneFmt.js
@@ -19,7 +19,7 @@
 
 // !data phonefmt
 
-var ilib = require("./ilib.js");
+var ilib = require("../index");
 var Utils = require("./Utils.js");
 var JSUtils = require("./JSUtils.js");
 var Locale = require("./Locale.js");

--- a/js/lib/PhoneGeoLocator.js
+++ b/js/lib/PhoneGeoLocator.js
@@ -19,7 +19,7 @@
 
 // !data iddarea area extarea extstates phoneres
 
-var ilib = require("./ilib.js");
+var ilib = require("../index");
 var Utils = require("./Utils.js");
 var JSUtils = require("./JSUtils.js");
 

--- a/js/lib/PhoneLocale.js
+++ b/js/lib/PhoneLocale.js
@@ -19,7 +19,7 @@
 
 // !data phoneloc
 
-var ilib = require("./ilib.js");
+var ilib = require("../index");
 var Utils = require("./Utils.js");
 var Locale = require("./Locale.js");
 

--- a/js/lib/PhoneNumber.js
+++ b/js/lib/PhoneNumber.js
@@ -19,7 +19,7 @@
 
 // !data states idd mnc
 
-var ilib = require("./ilib.js");
+var ilib = require("../index");
 var Utils = require("./Utils.js");
 var JSUtils = require("./JSUtils.js");
 var NumberingPlan = require("./NumberingPlan.js");

--- a/js/lib/ResBundle.js
+++ b/js/lib/ResBundle.js
@@ -19,7 +19,7 @@
 
 // !data pseudomap
 
-var ilib = require("./ilib.js");
+var ilib = require("../index");
 var Utils = require("./Utils.js");
 var JSUtils = require("./JSUtils.js");
 

--- a/js/lib/ScriptInfo.js
+++ b/js/lib/ScriptInfo.js
@@ -19,7 +19,7 @@
 
 // !data scripts
 
-var ilib = require("./ilib.js");
+var ilib = require("../index");
 var Utils = require("./Utils.js");
 
 /**

--- a/js/lib/StringMapper.js
+++ b/js/lib/StringMapper.js
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-var ilib = require("./ilib.js");
+var ilib = require("../index");
 var Utils = require("./Utils.js");
 
 var Locale = require("./Locale.js");

--- a/js/lib/ThaiSolarDate.js
+++ b/js/lib/ThaiSolarDate.js
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-var ilib = require("./ilib.js");
+var ilib = require("../index");
 var JSUtils = require("./JSUtils.js");
 
 var IDate = require("./IDate.js");

--- a/js/lib/TimeZone.js
+++ b/js/lib/TimeZone.js
@@ -19,7 +19,7 @@
 
 // !data localeinfo zoneinfo
 
-var ilib = require("./ilib.js");
+var ilib = require("../index");
 var Utils = require("./Utils.js");
 var MathUtils = require("./MathUtils.js");
 var JSUtils = require("./JSUtils.js");

--- a/js/lib/UnitFmt.js
+++ b/js/lib/UnitFmt.js
@@ -30,7 +30,7 @@ Measurement.js
 
 // !data unitfmt
 
-var ilib = require("./ilib.js");
+var ilib = require("../index");
 var Utils = require("./Utils.js");
 
 var Locale = require("./Locale.js");

--- a/js/lib/isAlpha.js
+++ b/js/lib/isAlpha.js
@@ -19,7 +19,7 @@
 
 // !data ctype_l
 
-var ilib = require("./ilib.js");
+var ilib = require("../index");
 var CType = require("./CType.js");
 var IString = require("./IString.js");
 

--- a/js/lib/isAscii.js
+++ b/js/lib/isAscii.js
@@ -19,7 +19,7 @@
 
 // !data ctype
 
-var ilib = require("./ilib.js");
+var ilib = require("../index");
 var CType = require("./CType.js");
 var IString = require("./IString.js");
 

--- a/js/lib/isBlank.js
+++ b/js/lib/isBlank.js
@@ -19,7 +19,7 @@
 
 // !data ctype
 
-var ilib = require("./ilib.js");
+var ilib = require("../index");
 var CType = require("./CType.js");
 var IString = require("./IString.js");
 

--- a/js/lib/isCntrl.js
+++ b/js/lib/isCntrl.js
@@ -19,7 +19,7 @@
 
 // !data ctype_c
 
-var ilib = require("./ilib.js");
+var ilib = require("../index");
 var CType = require("./CType.js");
 var IString = require("./IString.js");
 

--- a/js/lib/isDigit.js
+++ b/js/lib/isDigit.js
@@ -19,7 +19,7 @@
 
 // !data ctype ctype_n
 
-var ilib = require("./ilib.js");
+var ilib = require("../index");
 var CType = require("./CType.js");
 var IString = require("./IString.js");
 

--- a/js/lib/isIdeo.js
+++ b/js/lib/isIdeo.js
@@ -19,7 +19,7 @@
 
 // !data ctype
 
-var ilib = require("./ilib.js");
+var ilib = require("../index");
 var CType = require("./CType.js");
 var IString = require("./IString.js");
 

--- a/js/lib/isLower.js
+++ b/js/lib/isLower.js
@@ -19,7 +19,7 @@
 
 // !data ctype_l
 
-var ilib = require("./ilib.js");
+var ilib = require("../index");
 
 var CType = require("./CType.js");
 var IString = require("./IString.js");

--- a/js/lib/isPunct.js
+++ b/js/lib/isPunct.js
@@ -19,7 +19,7 @@
 
 // !data ctype_p
 
-var ilib = require("./ilib.js");
+var ilib = require("../index");
 
 var CType = require("./CType.js");
 var IString = require("./IString.js");

--- a/js/lib/isScript.js
+++ b/js/lib/isScript.js
@@ -19,7 +19,7 @@
 
 // !data scriptToRange
 
-var ilib = require("./ilib.js");
+var ilib = require("../index");
 
 var CType = require("./CType.js");
 var IString = require("./IString.js");

--- a/js/lib/isSpace.js
+++ b/js/lib/isSpace.js
@@ -19,7 +19,7 @@
 
 // !data ctype ctype_z
 
-var ilib = require("./ilib.js");
+var ilib = require("../index");
 
 var CType = require("./CType.js");
 var IString = require("./IString.js");

--- a/js/lib/isUpper.js
+++ b/js/lib/isUpper.js
@@ -19,7 +19,7 @@
 
 // !data ctype_l
 
-var ilib = require("./ilib.js");
+var ilib = require("../index");
 
 var CType = require("./CType.js");
 var IString = require("./IString.js");

--- a/js/lib/isXdigit.js
+++ b/js/lib/isXdigit.js
@@ -19,7 +19,7 @@
 
 // !data ctype
 
-var ilib = require("./ilib.js");
+var ilib = require("../index");
 
 var CType = require("./CType.js");
 var IString = require("./IString.js");

--- a/js/lib/metafiles/ilib-core-webpack.js
+++ b/js/lib/metafiles/ilib-core-webpack.js
@@ -28,7 +28,4 @@ ilib.ScriptInfo = require("../ScriptInfo.js");
 //This unpacks the above classes to the global scope
 require("../ilib-unpack.js");
 
-// Must be at the end of meta file
-require("../ilib-getdata.js");
-
 module.exports = ilib;

--- a/js/lib/metafiles/ilib-demo-webpack.js
+++ b/js/lib/metafiles/ilib-demo-webpack.js
@@ -116,7 +116,4 @@ ilib.DigitalSpeedUnit = require("../DigitalSpeedUnit.js");
 // This unpacks the above classes to the global scope
 require("../ilib-unpack.js");
 
-// Must be at the end of meta file
-require("../ilib-getdata.js");
-
 module.exports = ilib;

--- a/js/lib/metafiles/ilib-full-webpack.js
+++ b/js/lib/metafiles/ilib-full-webpack.js
@@ -116,7 +116,4 @@ ilib.DigitalSpeedUnit = require("../DigitalSpeedUnit.js");
 //This unpacks the above classes to the global scope
 require("../ilib-unpack.js");
 
-// Must be at the end of meta file
-require("../ilib-getdata.js");
-
 module.exports = ilib;

--- a/js/lib/metafiles/ilib-standard-webpack.js
+++ b/js/lib/metafiles/ilib-standard-webpack.js
@@ -46,7 +46,4 @@ ilib.TimeZone = require("../TimeZone.js");
 //This unpacks the above classes to the global scope
 require("../ilib-unpack.js");
 
-// Must be at the end of meta file
-require("../ilib-getdata.js");
-
 module.exports = ilib;

--- a/js/lib/metafiles/ilib-ut-webpack.js
+++ b/js/lib/metafiles/ilib-ut-webpack.js
@@ -150,7 +150,4 @@ ilib.RataDie = require("../RataDie.js");
 // This unpacks the above classes to the global scope
 require("../ilib-unpack.js");
 
-// Must be at the end of meta file
-require("../ilib-getdata.js");
-
 module.exports = ilib;

--- a/js/package.json.template
+++ b/js/package.json.template
@@ -1,7 +1,7 @@
 {
     "name": "ilib",
     "version": "@fullversion@",
-    "main": "lib/ilib-node.js",
+    "main": "index.js",
     "description": "iLib is a cross-engine library of internationalization (i18n) classes written in pure JS",
     "keywords": [
         "internationalization", 
@@ -48,7 +48,8 @@
     "files": [
         "lib",
         "locale",
-        "README.md"
+        "README.md",
+        "index.js"
     ],
     "repository": {
         "type": "git",

--- a/tools/locmaker/locmaker.js
+++ b/tools/locmaker/locmaker.js
@@ -28,7 +28,7 @@ var util = require('util');
 var path = require('path');
 
 // var clargs = require('command-line-args');
-var ilib = require("ilib");
+var ilib = require("../index");
 var Locale = require("ilib/lib/Locale");
 
 var DateFmt = require("ilib/lib/DateFmt");


### PR DESCRIPTION
Before: we had to load in the top-level ilib first to cause it to install the NodeLoader. If you didn't do that first, then the other ilib classes do not know how to load json files.

```
// installs NodeLoader to load json files
var ilib = require("ilib");  

// now that ilib is required above, the code below can now load json data using NodeLoader
var AddressFmt = require("ilib/lib/AddressFmt");
```

There are a number of problems with the above.

1. You have to load ilib first, which may be useless in the rest of the code if it doesn't use the ilib object directly. Plus, eslint complains about the unused variable.
2. It always installs NodeLoader -- what if you were were on Rhino or Qt or more importantly, within Webpack? That's the wrong loader.
3. If you are on one of the other platforms, you have to explicitly use require("ilib/lib/ilib-qt") for Qt for example. What if you didn't know where the code was going to be run before it is run? Or what if the same code was going to be run on multiple platforms?
4. If you forgot to load ilib first, the other classes will silently work but use the US English defaults, so you don't even know it isn't working correctly until later when some sort of class fails or you don't get the results you expect.

After:

```
var AddressFmt = require("ilib/lib/AddressFmt"); // automatically uses the correct loader to load json
```

AddresFmt depends on the new index.js top-level entry point. This new entry point checks the current environment (node, browser, webpack, qt, etc) and loads the appropriate loader for that env.

That way, you can use "npm install ilib" to get ilib onto your local disk and then use it in node with NodeLoader. Then, when you webpack that same code, it will automatically use the
WebpackLoader instead.