### PR TITLE
Make iLib test to work properly on QT/QML

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -17,6 +17,8 @@ New Features:
 Bug Fixes
 * Restored a missing mapping from the the native name for "Japan" to the ISO code "JP" in the nativecountries.json
     * Fixes address parsing for Japan
+* Added full file name includeing file extention when `index.js` on require statement. if file extention is missed, QT could not load file properly
+* Added missing `index.js` require statement in MeasurementFatory
 
 Build 001
 -------

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -17,8 +17,8 @@ New Features:
 Bug Fixes
 * Restored a missing mapping from the the native name for "Japan" to the ISO code "JP" in the nativecountries.json
     * Fixes address parsing for Japan
-* Added full file name includeing file extention when `index.js` on require statement. if file extention is missed, QT could not load file properly
-* Added missing `index.js` require statement in MeasurementFatory
+* Added the full file name including the file extension for requires of `index.js`. If file extention is missing, QT cannot load the file properly.
+* Added missing `index.js` require statement in MeasurementFactory
 
 Build 001
 -------

--- a/js/index.js
+++ b/js/index.js
@@ -37,7 +37,7 @@ if (!ilib._platform || (typeof(ilib._dyndata) !== 'boolean' && typeof(ilib._dync
 
             case 'qt':
                 require("./lib/ilib-qt.js");
-
+                break;
             case 'rhino':
                 require("./lib/ilib-rhino.js");
                 break;

--- a/js/lib/Address.js
+++ b/js/lib/Address.js
@@ -21,7 +21,7 @@
 
 // !data address countries nativecountries ctrynames
 
-var ilib = require("../index");
+var ilib = require("../index.js");
 var Utils = require("./Utils.js");
 var JSUtils = require("./JSUtils.js");
 var Locale = require("./Locale.js");

--- a/js/lib/AddressFmt.js
+++ b/js/lib/AddressFmt.js
@@ -19,7 +19,7 @@
 
 // !data address addressres regionnames
 
-var ilib = require("../index");
+var ilib = require("../index.js");
 var Utils = require("./Utils.js");
 var JSUtils = require("./JSUtils.js");
 

--- a/js/lib/AlphabeticIndex.js
+++ b/js/lib/AlphabeticIndex.js
@@ -19,7 +19,7 @@
 
 // !data nfc nfkd
 
-var ilib = require("../index");
+var ilib = require("../index.js");
 var Utils = require("./Utils.js");
 var Locale = require("./Locale.js");
 var CType = require("./CType.js");

--- a/js/lib/Astro.js
+++ b/js/lib/Astro.js
@@ -25,7 +25,7 @@
  * September 1999.
  */
 
-var ilib = require("../index");
+var ilib = require("../index.js");
 var Utils = require("./Utils.js");
 var SearchUtils = require("./SearchUtils.js");
 

--- a/js/lib/CType.js
+++ b/js/lib/CType.js
@@ -19,7 +19,7 @@
 
 // !data ctype
 
-var ilib = require("../index");
+var ilib = require("../index.js");
 var SearchUtils = require("./SearchUtils.js");
 var Utils = require("./Utils.js");
 var IString = require("./IString.js");

--- a/js/lib/CalendarFactory.js
+++ b/js/lib/CalendarFactory.js
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-var ilib = require("../index");
+var ilib = require("../index.js");
 var Locale = require("./Locale.js");
 var LocaleInfo = require("./LocaleInfo.js");
 var Calendar = require("./Calendar.js");

--- a/js/lib/CaseMapper.js
+++ b/js/lib/CaseMapper.js
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-var ilib = require("../index");
+var ilib = require("../index.js");
 
 var Locale = require("./Locale.js");
 var IString = require("./IString.js");

--- a/js/lib/Charmap.js
+++ b/js/lib/Charmap.js
@@ -19,7 +19,7 @@
 
 // !data charmaps charset/US-ASCII charset/ISO-10646-UCS-2 charset/ISO-8859-1 charset/ISO-8859-15 charmaps/ISO-8859-15 charmaps/ISO-8859-1 charset/ISO-8859-1
 
-var ilib = require("../index");
+var ilib = require("../index.js");
 var JSUtils = require("./JSUtils.js");
 var IString = require("./IString.js");
 

--- a/js/lib/CharmapFactory.js
+++ b/js/lib/CharmapFactory.js
@@ -18,7 +18,7 @@
  * limitations under the License.
  */
 
-var ilib = require("../index");
+var ilib = require("../index.js");
 var JSUtils = require("./JSUtils.js");
 
 var Charset = require("./Charset.js");

--- a/js/lib/CharmapTable.js
+++ b/js/lib/CharmapTable.js
@@ -19,7 +19,7 @@
 
 // !data charmaps/ISO-8859-15 charset/ISO-8859-15
 
-var ilib = require("../index");
+var ilib = require("../index.js");
 var Utils = require("./Utils.js");
 var Charset = require("./Charset.js");
 var Charmap = require("./Charmap.js");

--- a/js/lib/Charset.js
+++ b/js/lib/Charset.js
@@ -19,7 +19,7 @@
 
 // !data charset charsetaliases charset/ISO-8859-1 charset/ISO-8859-15 charset/UTF-8
 
-var ilib = require("../index");
+var ilib = require("../index.js");
 var Utils = require("./Utils.js");
 
 /**

--- a/js/lib/Collator.js
+++ b/js/lib/Collator.js
@@ -19,7 +19,7 @@
 
 // !data collation
 
-var ilib = require("../index");
+var ilib = require("../index.js");
 var Utils = require("./Utils.js");
 var JSUtils = require("./JSUtils.js");
 var Locale = require("./Locale.js");

--- a/js/lib/CopticDate.js
+++ b/js/lib/CopticDate.js
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-var ilib = require("../index");
+var ilib = require("../index.js");
 var MathUtils = require("./MathUtils.js");
 
 var Locale = require("./Locale.js");

--- a/js/lib/Country.js
+++ b/js/lib/Country.js
@@ -19,7 +19,7 @@
 
 // !data ctryreverse
 
-var ilib = require("../index");
+var ilib = require("../index.js");
 var Utils = require("./Utils.js");
 var Locale = require("./Locale.js");
 var LocaleInfo = require("./LocaleInfo.js");

--- a/js/lib/Currency.js
+++ b/js/lib/Currency.js
@@ -19,7 +19,7 @@
 
 // !data currency
 
-var ilib = require("../index");
+var ilib = require("../index.js");
 var Utils = require("./Utils.js");
 var Locale = require("./Locale.js");
 var LocaleInfo = require("./LocaleInfo.js");

--- a/js/lib/DateFactory.js
+++ b/js/lib/DateFactory.js
@@ -18,7 +18,7 @@
  * limitations under the License.
  */
 
-var ilib = require("../index");
+var ilib = require("../index.js");
 var JSUtils = require("./JSUtils.js");
 
 var Locale = require("./Locale.js");

--- a/js/lib/DateFmt.js
+++ b/js/lib/DateFmt.js
@@ -19,7 +19,7 @@
 
 // !data dateformats sysres
 
-var ilib = require("../index");
+var ilib = require("../index.js");
 var Utils = require("./Utils.js");
 var JSUtils = require("./JSUtils.js");
 

--- a/js/lib/DateRngFmt.js
+++ b/js/lib/DateRngFmt.js
@@ -19,7 +19,7 @@
 
 // !data dateformats sysres
 
-var ilib = require("../index");
+var ilib = require("../index.js");
 var JSUtils = require("./JSUtils.js");
 
 var Locale = require("./Locale.js");

--- a/js/lib/DurationFmt.js
+++ b/js/lib/DurationFmt.js
@@ -19,7 +19,7 @@
 
 // !data dateformats sysres
 
-var ilib = require("../index");
+var ilib = require("../index.js");
 var JSUtils = require("./JSUtils.js");
 var Locale = require("./Locale.js");
 var LocaleInfo = require("./LocaleInfo.js");

--- a/js/lib/EthiopicDate.js
+++ b/js/lib/EthiopicDate.js
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-var ilib = require("../index");
+var ilib = require("../index.js");
 var MathUtils = require("./MathUtils.js");
 
 var EthiopicRataDie = require("./EthiopicRataDie.js");

--- a/js/lib/GlyphString.js
+++ b/js/lib/GlyphString.js
@@ -20,7 +20,7 @@
 
 // !data ccc nfc ctype_m
 
-var ilib = require("../index");
+var ilib = require("../index.js");
 var Utils = require("./Utils.js");
 var JSUtils = require("./JSUtils.js");
 

--- a/js/lib/GregorianDate.js
+++ b/js/lib/GregorianDate.js
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-var ilib = require("../index");
+var ilib = require("../index.js");
 var SearchUtils = require("./SearchUtils.js");
 var MathUtils = require("./MathUtils.js");
 

--- a/js/lib/HanCal.js
+++ b/js/lib/HanCal.js
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-var ilib = require("../index");
+var ilib = require("../index.js");
 var MathUtils = require("./MathUtils.js");
 
 var Calendar = require("./Calendar.js");

--- a/js/lib/HanDate.js
+++ b/js/lib/HanDate.js
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-var ilib = require("../index");
+var ilib = require("../index.js");
 var JSUtils = require("./JSUtils.js");
 var MathUtils = require("./MathUtils.js");
 

--- a/js/lib/HanRataDie.js
+++ b/js/lib/HanRataDie.js
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-var ilib = require("../index");
+var ilib = require("../index.js");
 var MathUtils = require("./MathUtils.js");
 var HanCal = require("./HanCal.js");
 var RataDie = require("./RataDie.js");

--- a/js/lib/HebrewDate.js
+++ b/js/lib/HebrewDate.js
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-var ilib = require("../index");
+var ilib = require("../index.js");
 var MathUtils = require("./MathUtils.js");
 
 var Locale = require("./Locale.js");

--- a/js/lib/INumber.js
+++ b/js/lib/INumber.js
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-var ilib = require("../index");
+var ilib = require("../index.js");
 
 var Locale = require("./Locale.js");
 var LocaleInfo = require("./LocaleInfo.js");

--- a/js/lib/IString.js
+++ b/js/lib/IString.js
@@ -19,7 +19,7 @@
 
 // !data plurals
 
-var ilib = require("../index");
+var ilib = require("../index.js");
 var Utils = require("./Utils.js");
 var MathUtils = require("./MathUtils.js");
 var Locale = require("./Locale.js");

--- a/js/lib/IslamicDate.js
+++ b/js/lib/IslamicDate.js
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-var ilib = require("../index");
+var ilib = require("../index.js");
 var SearchUtils = require("./SearchUtils.js");
 var MathUtils = require("./MathUtils.js");
 

--- a/js/lib/JulianDate.js
+++ b/js/lib/JulianDate.js
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-var ilib = require("../index");
+var ilib = require("../index.js");
 var SearchUtils = require("./SearchUtils.js");
 var MathUtils = require("./MathUtils.js");
 

--- a/js/lib/ListFmt.js
+++ b/js/lib/ListFmt.js
@@ -20,7 +20,7 @@
 
 // !data list
 
-var ilib = require("../index");
+var ilib = require("../index.js");
 var Utils = require("./Utils.js");
 var Locale = require("./Locale.js");
 

--- a/js/lib/LocaleInfo.js
+++ b/js/lib/LocaleInfo.js
@@ -19,7 +19,7 @@
 
 // !data localeinfo
 
-var ilib = require("../index");
+var ilib = require("../index.js");
 var Utils = require("./Utils.js");
 var Locale = require("./Locale.js");
 

--- a/js/lib/LocaleMatcher.js
+++ b/js/lib/LocaleMatcher.js
@@ -19,7 +19,7 @@
 
 // !data localematch
 
-var ilib = require("../index");
+var ilib = require("../index.js");
 var Utils = require("./Utils.js");
 var Locale = require("./Locale.js");
 

--- a/js/lib/MeasurementFactory.js
+++ b/js/lib/MeasurementFactory.js
@@ -37,6 +37,7 @@ Measurement.js
 
 // TODO: make these dependencies dynamic or at least generate them in the build
 // These will each add themselves to Measurement._constructors[]
+var ilib = require("../index.js");
 var UnknownUnit = require("./UnknownUnit.js");
 var AreaUnit = require("./AreaUnit.js");
 var DigitalStorageUnit = require("./DigitalStorageUnit.js");

--- a/js/lib/Name.js
+++ b/js/lib/Name.js
@@ -25,7 +25,7 @@
 // http://www.mentalfloss.com/blogs/archives/59277
 // other countries with first name restrictions: Norway, China, New Zealand, Japan, Sweden, Germany, Hungary
 
-var ilib = require("../index");
+var ilib = require("../index.js");
 var Utils = require("./Utils.js");
 var JSUtils = require("./JSUtils.js");
 

--- a/js/lib/NameFmt.js
+++ b/js/lib/NameFmt.js
@@ -19,7 +19,7 @@
 
 // !data name
 
-var ilib = require("../index");
+var ilib = require("../index.js");
 var Utils = require("./Utils.js");
 
 var Locale = require("./Locale.js");

--- a/js/lib/NormString.js
+++ b/js/lib/NormString.js
@@ -19,7 +19,7 @@
 
 // !data ccc nfd nfc nfkd nfkc
 
-var ilib = require("../index");
+var ilib = require("../index.js");
 var Utils = require("./Utils.js");
 var JSUtils = require("./JSUtils.js");
 

--- a/js/lib/NumFmt.js
+++ b/js/lib/NumFmt.js
@@ -30,7 +30,7 @@ JSUtils.js
 
 // !data localeinfo currency
 
-var ilib = require("../index");
+var ilib = require("../index.js");
 var JSUtils = require("./JSUtils.js");
 var MathUtils = require("./MathUtils.js");
 

--- a/js/lib/NumberingPlan.js
+++ b/js/lib/NumberingPlan.js
@@ -19,7 +19,7 @@
 
 // !data numplan
 
-var ilib = require("../index");
+var ilib = require("../index.js");
 var Utils = require("./Utils.js");
 var Locale = require("./Locale.js");
 

--- a/js/lib/PersRataDie.js
+++ b/js/lib/PersRataDie.js
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-var ilib = require("../index");
+var ilib = require("../index.js");
 var MathUtils = require("./MathUtils.js");
 
 var Astro = require("./Astro.js");

--- a/js/lib/PersianAlgoDate.js
+++ b/js/lib/PersianAlgoDate.js
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-var ilib = require("../index");
+var ilib = require("../index.js");
 var SearchUtils = require("./SearchUtils.js");
 var MathUtils = require("./MathUtils.js");
 

--- a/js/lib/PersianDate.js
+++ b/js/lib/PersianDate.js
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-var ilib = require("../index");
+var ilib = require("../index.js");
 var SearchUtils = require("./SearchUtils.js");
 var MathUtils = require("./MathUtils.js");
 var JSUtils = require("./JSUtils.js");

--- a/js/lib/PhoneFmt.js
+++ b/js/lib/PhoneFmt.js
@@ -19,7 +19,7 @@
 
 // !data phonefmt
 
-var ilib = require("../index");
+var ilib = require("../index.js");
 var Utils = require("./Utils.js");
 var JSUtils = require("./JSUtils.js");
 var Locale = require("./Locale.js");

--- a/js/lib/PhoneGeoLocator.js
+++ b/js/lib/PhoneGeoLocator.js
@@ -19,7 +19,7 @@
 
 // !data iddarea area extarea extstates phoneres
 
-var ilib = require("../index");
+var ilib = require("../index.js");
 var Utils = require("./Utils.js");
 var JSUtils = require("./JSUtils.js");
 

--- a/js/lib/PhoneLocale.js
+++ b/js/lib/PhoneLocale.js
@@ -19,7 +19,7 @@
 
 // !data phoneloc
 
-var ilib = require("../index");
+var ilib = require("../index.js");
 var Utils = require("./Utils.js");
 var Locale = require("./Locale.js");
 

--- a/js/lib/PhoneNumber.js
+++ b/js/lib/PhoneNumber.js
@@ -19,7 +19,7 @@
 
 // !data states idd mnc
 
-var ilib = require("../index");
+var ilib = require("../index.js");
 var Utils = require("./Utils.js");
 var JSUtils = require("./JSUtils.js");
 var NumberingPlan = require("./NumberingPlan.js");

--- a/js/lib/ResBundle.js
+++ b/js/lib/ResBundle.js
@@ -19,7 +19,7 @@
 
 // !data pseudomap
 
-var ilib = require("../index");
+var ilib = require("../index.js");
 var Utils = require("./Utils.js");
 var JSUtils = require("./JSUtils.js");
 

--- a/js/lib/ScriptInfo.js
+++ b/js/lib/ScriptInfo.js
@@ -19,7 +19,7 @@
 
 // !data scripts
 
-var ilib = require("../index");
+var ilib = require("../index.js");
 var Utils = require("./Utils.js");
 
 /**

--- a/js/lib/StringMapper.js
+++ b/js/lib/StringMapper.js
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-var ilib = require("../index");
+var ilib = require("../index.js");
 var Utils = require("./Utils.js");
 
 var Locale = require("./Locale.js");

--- a/js/lib/ThaiSolarDate.js
+++ b/js/lib/ThaiSolarDate.js
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-var ilib = require("../index");
+var ilib = require("../index.js");
 var JSUtils = require("./JSUtils.js");
 
 var IDate = require("./IDate.js");

--- a/js/lib/TimeZone.js
+++ b/js/lib/TimeZone.js
@@ -19,7 +19,7 @@
 
 // !data localeinfo zoneinfo
 
-var ilib = require("../index");
+var ilib = require("../index.js");
 var Utils = require("./Utils.js");
 var MathUtils = require("./MathUtils.js");
 var JSUtils = require("./JSUtils.js");

--- a/js/lib/UnitFmt.js
+++ b/js/lib/UnitFmt.js
@@ -30,7 +30,7 @@ Measurement.js
 
 // !data unitfmt
 
-var ilib = require("../index");
+var ilib = require("../index.js");
 var Utils = require("./Utils.js");
 
 var Locale = require("./Locale.js");

--- a/js/lib/ilib-qt.js
+++ b/js/lib/ilib-qt.js
@@ -72,7 +72,6 @@ requireClass.prototype.require = function(parent, pathname, absolutePath) {
         pathname = this.root + "/../test" + absolutePath;
         //console.log("[ilib-qt.js] Loading Test file...  "+ pathname);
     } else {
-
         if (parent && parent.charAt(0) !== '/') {
             // take care of relative parents (aren't all parents relatives? haha)
             parent = this.root + '/' + parent;
@@ -84,7 +83,7 @@ requireClass.prototype.require = function(parent, pathname, absolutePath) {
 
         var base = parent || (module.filename && this.dirname(module.filename)) || this.root;
 
-        //console.log("require: base is " + base);
+        //console.log("******** require: base is " + base);
 
         if (pathname.charAt(0) !== '/') {
             pathname = base + "/" + pathname;

--- a/js/lib/isAlpha.js
+++ b/js/lib/isAlpha.js
@@ -19,7 +19,7 @@
 
 // !data ctype_l
 
-var ilib = require("../index");
+var ilib = require("../index.js");
 var CType = require("./CType.js");
 var IString = require("./IString.js");
 

--- a/js/lib/isAscii.js
+++ b/js/lib/isAscii.js
@@ -19,7 +19,7 @@
 
 // !data ctype
 
-var ilib = require("../index");
+var ilib = require("../index.js");
 var CType = require("./CType.js");
 var IString = require("./IString.js");
 

--- a/js/lib/isBlank.js
+++ b/js/lib/isBlank.js
@@ -19,7 +19,7 @@
 
 // !data ctype
 
-var ilib = require("../index");
+var ilib = require("../index.js");
 var CType = require("./CType.js");
 var IString = require("./IString.js");
 

--- a/js/lib/isCntrl.js
+++ b/js/lib/isCntrl.js
@@ -19,7 +19,7 @@
 
 // !data ctype_c
 
-var ilib = require("../index");
+var ilib = require("../index.js");
 var CType = require("./CType.js");
 var IString = require("./IString.js");
 

--- a/js/lib/isDigit.js
+++ b/js/lib/isDigit.js
@@ -19,7 +19,7 @@
 
 // !data ctype ctype_n
 
-var ilib = require("../index");
+var ilib = require("../index.js");
 var CType = require("./CType.js");
 var IString = require("./IString.js");
 

--- a/js/lib/isIdeo.js
+++ b/js/lib/isIdeo.js
@@ -19,7 +19,7 @@
 
 // !data ctype
 
-var ilib = require("../index");
+var ilib = require("../index.js");
 var CType = require("./CType.js");
 var IString = require("./IString.js");
 

--- a/js/lib/isLower.js
+++ b/js/lib/isLower.js
@@ -19,7 +19,7 @@
 
 // !data ctype_l
 
-var ilib = require("../index");
+var ilib = require("../index.js");
 
 var CType = require("./CType.js");
 var IString = require("./IString.js");

--- a/js/lib/isPunct.js
+++ b/js/lib/isPunct.js
@@ -19,7 +19,7 @@
 
 // !data ctype_p
 
-var ilib = require("../index");
+var ilib = require("../index.js");
 
 var CType = require("./CType.js");
 var IString = require("./IString.js");

--- a/js/lib/isScript.js
+++ b/js/lib/isScript.js
@@ -19,7 +19,7 @@
 
 // !data scriptToRange
 
-var ilib = require("../index");
+var ilib = require("../index.js");
 
 var CType = require("./CType.js");
 var IString = require("./IString.js");

--- a/js/lib/isSpace.js
+++ b/js/lib/isSpace.js
@@ -19,7 +19,7 @@
 
 // !data ctype ctype_z
 
-var ilib = require("../index");
+var ilib = require("../index.js");
 
 var CType = require("./CType.js");
 var IString = require("./IString.js");

--- a/js/lib/isUpper.js
+++ b/js/lib/isUpper.js
@@ -19,7 +19,7 @@
 
 // !data ctype_l
 
-var ilib = require("../index");
+var ilib = require("../index.js");
 
 var CType = require("./CType.js");
 var IString = require("./IString.js");

--- a/js/lib/isXdigit.js
+++ b/js/lib/isXdigit.js
@@ -19,7 +19,7 @@
 
 // !data ctype
 
-var ilib = require("../index");
+var ilib = require("../index.js");
 
 var CType = require("./CType.js");
 var IString = require("./IString.js");

--- a/js/test/nodeunit/nodeunit-qml.js
+++ b/js/test/nodeunit/nodeunit-qml.js
@@ -363,7 +363,7 @@ var nodeunit = (function(){
 
         function getFailureDetails(assertion) {
             if (assertion.error && assertion.error.name === "AssertionError") {
-                return "Expected that actual " + assertion.error.operator + " " + assertion.error.expected + ", but got " + assertion.error.actual + " instead.";
+                return "Expected that actual " + assertion.error.operator + " [[" + assertion.error.expected + "]] , but got [[" + assertion.error.actual + "]] instead.";
             } else if (assertion.message) {
                 return assertion.message;
             }

--- a/qt/NodeunitTest/NodeunitRunAll.qml
+++ b/qt/NodeunitTest/NodeunitRunAll.qml
@@ -11,6 +11,7 @@ QtObject {
             var TestSuite = TestSuiteModule.TestSuite;
             var TestRunner = TestRunnerModule.TestRunner;
             var runner = new TestRunner();
+            var date = new Date();
 
             var suiteDefinitions = {
                 "address": "/address/testSuiteFiles.js",
@@ -29,7 +30,7 @@ QtObject {
                 "units": "/units/testSuiteFiles.js",
                 "util": "/util/testSuiteFiles.js"
             };
-
+            console.log("<<<<< Start time of full test: " +  date.getHours() +":"+ date.getMinutes() +":"+ date.getSeconds()+ " >>>>>");
             var s, ts;
             for (s in suiteDefinitions) {
                 ts = new TestSuite(suiteDefinitions[s], s);
@@ -37,6 +38,7 @@ QtObject {
                 runner.addSuite(ts);
             }
             runner.runTests();
+             console.log("<<<<< End time of full test: " +  date.getHours() +":"+ date.getMinutes() +":"+ date.getSeconds()+ " >>>>>");
             console.log("\n *************************** All iLib tests on QML are done. ***********************************");
             Qt.quit();
         }

--- a/qt/NodeunitTest/NodeunitRunAll.qml
+++ b/qt/NodeunitTest/NodeunitRunAll.qml
@@ -38,7 +38,7 @@ QtObject {
                 runner.addSuite(ts);
             }
             runner.runTests();
-             console.log("<<<<< End time of full test: " +  date.getHours() +":"+ date.getMinutes() +":"+ date.getSeconds()+ " >>>>>");
+            console.log("<<<<< End time of full test: " +  date.getHours() +":"+ date.getMinutes() +":"+ date.getSeconds()+ " >>>>>");
             console.log("\n *************************** All iLib tests on QML are done. ***********************************");
             Qt.quit();
         }


### PR DESCRIPTION
##### Major fix:
* Add missing `break'` in switch statement in `index.js` 
* Previously, require statement was as below. but QT couldn't load `index.js` file. so I added full file name includeing file extension.
```
var ilib = require("../index");
```

##### Minor fix:
* Add timestamp when running a full ilib test on QT/QML. because it takes so long.
* Add parentheses to compare value exactly between `actual value` and `expected value`
* Add `index.js` requirement in MeasurementFactory in order to fix lots of test case failures.
