### PR TITLE
Make sure address formatter works with missing data.

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -16,6 +16,9 @@ Bug Fixes:
   of `index.js`. If file name extension is missing, QT cannot load that
   file properly.
 * Added missing `index.js` require statement in MeasurementFactory
+* AddressFmt.getFormatInfo would throw an exception for locales where the locale data was not available. Now,
+  it does not, and instead, it returns some hard-coded info by default that is roughly similar to the en-US
+  settings.
 
 Build 002
 -------

--- a/js/lib/AddressFmt.js
+++ b/js/lib/AddressFmt.js
@@ -28,6 +28,42 @@ var Address = require("./Address.js");
 var IString = require("./IString.js");
 var ResBundle = require("./ResBundle.js");
 
+// default generic data
+var defaultData = {
+    formats: {
+        "default": "{streetAddress}\n{locality} {region} {postalCode}\n{country}",
+        "nocountry": "{streetAddress}\n{locality} {region} {postalCode}"
+    },
+    startAt: "end",
+    fields: [
+        {
+            "name": "postalCode",
+            "line": "startAtLast",
+            "pattern": "[0-9]+",
+            "matchGroup": 0
+        },
+        {
+            "name": "region",
+            "line": "last",
+            "pattern": "([A-zÀÁÈÉÌÍÑÒÓÙÚÜàáèéìíñòóùúü\\.\\-\\']+\\s*){1,2}$",
+            "matchGroup": 0
+        },
+        {
+            "name": "locality",
+            "line": "last",
+            "pattern": "([A-zÀÁÈÉÌÍÑÒÓÙÚÜàáèéìíñòóùúü\\.\\-\\']+\\s*){1,2}$",
+            "matchGroup": 0
+        }
+    ],
+    fieldNames: {
+        "streetAddress": "Street Address",
+        "locality": "City",
+        "postalCode": "Zip Code",
+        "region": "State",
+        "country": "Country"
+    }
+};
+
 /**
  * @class
  * Create a new formatter object to format physical addresses in a particular way.
@@ -128,10 +164,16 @@ var AddressFmt = function(options) {
  * @private
  */
 AddressFmt.prototype._init = function () {
-    this.style = this.info && this.info.formats && this.info.formats[this.styleName];
+    if (!this.info) this.info = defaultData;
+
+    this.style = this.info.formats && this.info.formats[this.styleName];
 
     // use generic default -- should not happen, but just in case...
-    this.style = this.style || (this.info && this.info.formats && this.info.formats["default"]) || "{streetAddress}\n{locality} {region} {postalCode}\n{country}";
+    this.style = this.style || (this.info.formats && this.info.formats["default"]) || defaultData.formats["default"];
+
+    if (!this.info.fieldNames) {
+        this.info.fieldNames = defaultData.fieldNames;
+    }
 };
 
 /**
@@ -369,7 +411,7 @@ AddressFmt.prototype.getFormatInfo = function(locale, sync, callback) {
                 sync: this.sync,
                 loadParams: this.loadParams,
                 onLoad: ilib.bind(this, function (rb) {
-                    var type, format, fields = this.info.fields;
+                    var type, format, fields = this.info.fields || defaultData.fields;
                     if (this.info.multiformat) {
                         type = isAsianLocale(this.locale) ? "asian" : "latin";
                         fields = this.info.fields[type];

--- a/js/test/address/testaddress.js
+++ b/js/test/address/testaddress.js
@@ -345,7 +345,24 @@ module.exports.testaddress = {
         test.equal(formatter.format(parsedAddress), expected);
         test.done();
     },
-    
+
+    testFormatAddressUnknownCountry: function(test) {
+        test.expect(1);
+        var parsedAddress = new Address({
+            streetAddress: "1234 Any Street",
+            locality: "Anytown",
+            region: "CA",
+            postalCode: "94085",
+            country: "Unknown",
+            countryCode: "XY"
+        }, {locale: 'en-XY'});
+
+        var expected = "1234 Any Street\nAnytown CA 94085\nUnknown";
+        var formatter = new AddressFmt({locale: 'en-XY', style: 'nocountry'});
+        test.equal(formatter.format(parsedAddress), expected);
+        test.done();
+    },
+
     // for DFISH-9927
     testParseAddressUnknownLocale: function(test) {
         test.expect(7);
@@ -1514,6 +1531,26 @@ module.exports.testaddress = {
         test.equal(info[3][0].component, "country");
         test.equal(info[3][0].label, "국가");
         test.done();
-    }
+    },
 
+    testAddressFmtGetFormatInfoUnknownCountry: function(test) {
+        test.expect(7);
+        var formatter = new AddressFmt({locale: 'en-XY'});
+
+        var info = formatter.getFormatInfo();
+
+        test.ok(info);
+
+        // test for generic data
+        test.equal(info[1][0].component, "locality");
+        test.equal(info[1][0].constraint, "([A-zÀÁÈÉÌÍÑÒÓÙÚÜàáèéìíñòóùúü\\.\\-\\']+\\s*){1,2}$");
+
+        test.equal(info[1][1].component, "region");
+        test.equal(info[1][1].constraint, "([A-zÀÁÈÉÌÍÑÒÓÙÚÜàáèéìíñòóùúü\\.\\-\\']+\\s*){1,2}$");
+
+        test.equal(info[1][2].component, "postalCode");
+        test.equal(info[1][2].constraint, "[0-9]+");
+
+        test.done();
+    }
 };

--- a/js/test/address/testaddress.js
+++ b/js/test/address/testaddress.js
@@ -1534,21 +1534,24 @@ module.exports.testaddress = {
     },
 
     testAddressFmtGetFormatInfoUnknownCountry: function(test) {
-        test.expect(7);
+        test.expect(10);
         var formatter = new AddressFmt({locale: 'en-XY'});
 
         var info = formatter.getFormatInfo();
 
         test.ok(info);
 
-        // test for generic data
+        // test for generic root data
         test.equal(info[1][0].component, "locality");
+        test.equal(info[1][0].label, "City");
         test.equal(info[1][0].constraint, "([A-zÀÁÈÉÌÍÑÒÓÙÚÜàáèéìíñòóùúü\\.\\-\\']+\\s*){1,2}$");
 
         test.equal(info[1][1].component, "region");
+        test.equal(info[1][1].label, "Province");
         test.equal(info[1][1].constraint, "([A-zÀÁÈÉÌÍÑÒÓÙÚÜàáèéìíñòóùúü\\.\\-\\']+\\s*){1,2}$");
 
         test.equal(info[1][2].component, "postalCode");
+        test.equal(info[1][2].label, "Postal Code");
         test.equal(info[1][2].constraint, "[0-9]+");
 
         test.done();

--- a/js/test/address/testaddressasync.js
+++ b/js/test/address/testaddressasync.js
@@ -399,7 +399,30 @@ module.exports.testaddressasync = {
             }
         });
     },
-    
+
+    testFormatAddressUnknownCountry: function(test) {
+        test.expect(1);
+        var parsedAddress = new Address({
+            streetAddress: "1234 Any Street",
+            locality: "Anytown",
+            region: "CA",
+            postalCode: "94085",
+            country: "Unknown",
+            countryCode: "XY"
+        }, {locale: 'en-XY'});
+
+        var expected = "1234 Any Street\nAnytown CA 94085\nUnknown";
+        new AddressFmt({
+            locale: 'en-XY',
+            sync: false,
+            style: 'nocountry',
+            onLoad: function(formatter) {
+                test.equal(formatter.format(parsedAddress), expected);
+                test.done();
+            }
+        });
+    },
+
     testAddressFmtGetFormatInfoUSRightConstraints: function(test) {
         test.expect(19);
         new AddressFmt({
@@ -435,6 +458,31 @@ module.exports.testaddressasync = {
                     r = searchRegions(info[2][0].constraint, "ZA");
                     test.equal(r.code, "ZA");
                     test.equal(r.name, "South Africa");
+
+                    test.done();
+                });
+            }
+        });
+    },
+
+    testAddressFmtGetFormatInfoUnknownCountry: function(test) {
+        test.expect(7);
+        new AddressFmt({
+            locale: 'en-XY',
+            sync: false,
+            onLoad: function(formatter) {
+                formatter.getFormatInfo(undefined, false, function(info) {
+                    test.ok(info);
+
+                    // test for generic data
+                    test.equal(info[1][0].component, "locality");
+                    test.equal(info[1][0].constraint, "([A-zÀÁÈÉÌÍÑÒÓÙÚÜàáèéìíñòóùúü\\.\\-\\']+\\s*){1,2}$");
+
+                    test.equal(info[1][1].component, "region");
+                    test.equal(info[1][1].constraint, "([A-zÀÁÈÉÌÍÑÒÓÙÚÜàáèéìíñòóùúü\\.\\-\\']+\\s*){1,2}$");
+
+                    test.equal(info[1][2].component, "postalCode");
+                    test.equal(info[1][2].constraint, "[0-9]+");
 
                     test.done();
                 });


### PR DESCRIPTION
Previously, the call AddressFmt.getFormatInfo() would throw an exception if the locale of the formatter was not known or if the data for the locale was not available. This change puts in generic default data so that even when data is not available, at least something is returned that is somewhat like the en-US data. 