### PR TITLE
Adopt a 'JIT' plugin for grunt

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,5 +1,9 @@
 
 module.exports = function(grunt) {
+    require('jit-grunt')(grunt, {
+        replace: 'grunt-text-replace'
+    });
+
     grunt.initConfig({
         pkg: grunt.file.readJSON('package.json'),
         mkdir: {
@@ -74,14 +78,6 @@ module.exports = function(grunt) {
                 command: 'cd js; ../node_modules/http-server/bin/http-server -p 9090 -o'
             },
             run_webpack: {
-                /*
-                <arg value="--env.assembly=@{assembly}"/>
-                <arg value="--env.size=@{size}"/>
-                <arg value="--env.compilation=@{compilation}"/>
-                <arg value="--env.locales=@{locales}"/>
-                <arg value="--env.target=@{target}"/>
-                <arg value="--env.ilibRoot=${build.base}"/>
-                */
                 command: options => './js/runWebpack.sh ' + options,
             }
         },
@@ -176,18 +172,6 @@ module.exports = function(grunt) {
                 }
             }
         },
-        /*'closure-compiler': {
-            run: {
-                // Target-specific file lists and/or options go here.
-                  closurePath: 'tools/google-closure-compiler.r20150920',
-                  js: 'js/output/js/full-assembled-uncompiled-web/ilib-full.js',
-                  jsOutputFile: 'js/output/js/full-assembled-uncompiled-web/ilib-full-closure.js',
-                  maxBuffer: 1000,
-                  options: {
-                       compilation_level: 'SIMPLE_OPTIMIZATIONS'
-                  }
-            },
-        },*/
         watch: {
             scripts: {
                 files: [],
@@ -195,17 +179,6 @@ module.exports = function(grunt) {
             }
         }
     });
-    grunt.loadNpmTasks('grunt-mkdir');
-    grunt.loadNpmTasks('grunt-move');
-    grunt.loadNpmTasks('grunt-md5sum');
-    grunt.loadNpmTasks('grunt-shell');
-    grunt.loadNpmTasks('grunt-text-replace');
-    grunt.loadNpmTasks('grunt-jsdoc');
-
-    grunt.loadNpmTasks('grunt-contrib-clean');
-    grunt.loadNpmTasks('grunt-contrib-copy');
-    grunt.loadNpmTasks('grunt-contrib-compress');
-    grunt.loadNpmTasks('grunt-contrib-uglify');
 
     grunt.registerTask('build_jsonWork', ['mkdir:prepare', 'replace:pkgVersion','shell:copy_pkgJson','shell:mkli', 'shell:touch_localeinfoStamp', 'shell:compressJson', 'shell:touch_compressJsonStamp', 'shell:gen_manifest_locale']);
     grunt.registerTask('build_copyJson', ['mkdir:export', 'copy:export_locale']);

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -4,6 +4,7 @@ Release Notes for Version 14
 Build 004
 -------
 Published as version 14.1.2
+* Adopt a `JIT` plugin loader for grunt. Load time of Grunt does not slow down even if there are many plugins. instead of `grunt.loadNpmTasks`.
 
 Bug Fixes:
 * Many of the countries of the world were missing data about the correct name of their top-level


### PR DESCRIPTION
### Checklist

* [ ] At least one test case is included for this feature or bug fix.
* [x] `ReleaseNotes` has added or is not needed.
* [x] This PR has passed all of the test cases on `Nodejs` and `Chrome Browser`.
* [x] This PR has passed all of the test cases on `QT/QML`.
* [ ] This is an API breaking change.
* [ ] Requires a major version change.


### Feature Added
Adopt a `JIT` (Just In Time) plugin loader for grunt. Load time of Grunt does not slow down even if there are many plugins. instead of `grunt.loadNpmTasks`. and remove useless comments in `Gruntfile.js`

### Resolution

### Additional Considerations
This change doesn't affect current iLib build and test at all.

### Comments

### Links
https://www.npmjs.com/package/jit-grunt
