### PR TITLE
Fix build

### DIFF
--- a/js/webpack.config.js
+++ b/js/webpack.config.js
@@ -68,6 +68,16 @@ module.exports = function(env, args) {
         path.resolve(__dirname, urlPath) :
         path.resolve(__dirname, urlPath);
 
+    var options = {
+        locales: locales,
+        assembly: assembly,
+        compilation: compilationType,
+        size: size,
+        ilibRoot: ilibRoot,
+        target: target,
+        tempDir: path.join("ilib/js", urlPath) 
+    };
+
     var ret = {
         entry: './lib/metafiles/ilib-' + size + '-webpack.js',
         output: {
@@ -84,14 +94,7 @@ module.exports = function(env, args) {
                 exclude: /node_modules/, // ignore all files in the node_modules folder
                 use: {
                     loader: 'ilib-webpack-loader',
-                    options: {
-                        locales: locales,
-                        assembly: assembly,
-                        compilation: compilationType,
-                        size: size,
-                        ilibRoot: ilibRoot,
-                        target: target
-                    }
+                    options: options
                 }
             }]
         },
@@ -99,13 +102,7 @@ module.exports = function(env, args) {
             new webpack.DefinePlugin({
                 __VERSION__: JSON.stringify(require("./package.json").version)
             }),
-            new IlibWebpackPlugin({
-                locales: locales,
-                assembly: assembly,
-                compilation: compilationType,
-                size: size,
-                ilibRoot: ilibRoot
-            })
+            new IlibWebpackPlugin(options)
         ]
     };
 

--- a/js/webpack.config.js
+++ b/js/webpack.config.js
@@ -75,7 +75,7 @@ module.exports = function(env, args) {
         size: size,
         ilibRoot: ilibRoot,
         target: target,
-        tempDir: path.join("ilib/js", urlPath) 
+        tempDir: path.join("ilib/js", urlPath)
     };
 
     var ret = {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
         "grunt-contrib-nodeunit": "~0.4.1",
         "grunt-shell": "^2.1.0",
         "grunt-text-replace": "^0.4.0",
-        "grunt-contrib-uglify": "~0.5.0",
         "http-server": "^0.11.1",
         "ilib-webpack-loader": "^1.0.2",
         "ilib-webpack-plugin": "^1.0.2",


### PR DESCRIPTION
### Checklist

* [ ] At least one test case is included for this feature or bug fix.
* [x] `ReleaseNotes` has added or is not needed.
* [x] This PR has passed all of the test cases on `Nodejs` and `Chrome Browser`.
* [ ] This PR has passed all of the test cases on `QT/QML`.
* [ ] This is an API breaking change.
* [ ] Requires a major version change.


### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

Using the old ilib webpack loader and plugin, the temporary directory used to be inside of the output directory. This caused dependency problems with webpack, so the loader and plugin moved it outside of the output dir. However, now ilib builds need to specify the location of the temporary directory so that the locale files in the different types of webpacked builds do not conflict with each other. With the latest plugin and loader but without this change, ilib would not build on travis because the unit tests would not have their own locale data. This fixes that problem and also makes sure that the options passed to the loader and the plugin are the same as each other.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Comments

### Links
[//]: # (Related issues, references)