### PR TITLE
Fix the output dir for the locale temp files

### DIFF
--- a/js/build.xml
+++ b/js/build.xml
@@ -136,7 +136,7 @@ limitations under the License.
 				<arg value="--env.locales=@{locales}"/>
 				<arg value="--env.target=@{target}"/>
 				<arg value="--env.ilibRoot=${build.base}"/>
-				<arg value="--env.tempDir=${build.output.js}"/>
+				<arg value="--env.tempDir=${build.output}"/>
 			</exec>
 			<exec osfamily="windows" executable="webpack.bat" dir="${build.base}" failifexecutionfails="@{failquit}"  failonerror="@{failquit}">
 				<env key="NODE_OPTIONS" value="--max-old-space-size=3072"/>
@@ -146,7 +146,7 @@ limitations under the License.
 				<arg value="--env.locales=@{locales}"/>
                 <arg value="--env.target=@{target}"/>
                 <arg value="--env.ilibRoot=${build.base}"/>
-                <arg value="--env.tempDir=${build.output.js}"/>
+                <arg value="--env.tempDir=${build.output}"/>
 			</exec>
 		</sequential>
 	</macrodef>

--- a/js/build.xml
+++ b/js/build.xml
@@ -136,6 +136,7 @@ limitations under the License.
 				<arg value="--env.locales=@{locales}"/>
 				<arg value="--env.target=@{target}"/>
 				<arg value="--env.ilibRoot=${build.base}"/>
+				<arg value="--env.tempDir=${build.output.js}"/>
 			</exec>
 			<exec osfamily="windows" executable="webpack.bat" dir="${build.base}" failifexecutionfails="@{failquit}"  failonerror="@{failquit}">
 				<env key="NODE_OPTIONS" value="--max-old-space-size=3072"/>
@@ -145,6 +146,7 @@ limitations under the License.
 				<arg value="--env.locales=@{locales}"/>
                 <arg value="--env.target=@{target}"/>
                 <arg value="--env.ilibRoot=${build.base}"/>
+                <arg value="--env.tempDir=${build.output.js}"/>
 			</exec>
 		</sequential>
 	</macrodef>

--- a/js/webpack.config.js
+++ b/js/webpack.config.js
@@ -29,6 +29,7 @@ module.exports = function(env, args) {
         target = env.target || "web",
         locales = env.locales,
         ilibRoot = path.resolve(env.ilibRoot || "."),
+        tempDirRoot = path.resolve(env.tempDir || "temp"),
         outputPath;
 
     // "ut" is unit tests
@@ -63,6 +64,7 @@ module.exports = function(env, args) {
     }
 
     var dirName = [size, assembly, compilationType, target].join("-");
+    var tempDir = path.join(tempDirRoot, 'locales', dirName);
     var urlPath = path.join('output/js', dirName);
     outputPath = (assembly === "assembled") ?
         path.resolve(__dirname, urlPath) :
@@ -75,7 +77,7 @@ module.exports = function(env, args) {
         size: size,
         ilibRoot: ilibRoot,
         target: target,
-        tempDir: path.join("ilib/js", urlPath)
+        tempDir: tempDir
     };
 
     var ret = {


### PR DESCRIPTION
This used to go in js/ilib, but now it goes into js/output/locales so that it gets cleaned up with ant clean.

### Checklist

* [ ] At least one test case is included for this feature or bug fix.
* [ ] `ReleaseNotes` has added or is not needed.
* [ ] This PR has passed all of the test cases on `Nodejs` and `Chrome Browser`.
* [ ] This PR has passed all of the test cases on `QT/QML`.
* [ ] This is an API breaking change.
* [ ] Requires a major version change.


### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Comments

### Links
[//]: # (Related issues, references)