### PR TITLE
Implement to include automatically data which doesn't exist in CLDR

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -16,6 +16,7 @@ Bug Fixes:
 * Changed 3 digit iddprefix PhoneNumber format of zh-Hant-TW as corresponding local office feedback.
 * Rollback `js/ilib-web.js` file to support pure Web Application.
 * Added a new platform return type as 'webos-webapp'. If platform type is `webos-webapp`, The iLib won't load any loader as default.
+* Implemented to include automatically Json data which doesn't exist in CLDR in cldrtool script.
 
 
 Build 004

--- a/tools/cldr/datefmts.js
+++ b/tools/cldr/datefmts.js
@@ -936,8 +936,13 @@ module.exports = {
                 var dateOnlyTemplate = "{date} – {date}";
 
                 var dmyiLib = "dmy"
-                    var dmyOrder;
+                var dmyOrder;
                 var dateRangeTemplate = dateRangeTemplateOrder;
+
+                var regExp = /[^s^\s^\-^\.^\/^\u200f]y+/;
+                var regExp2 = /\bd+\b/;
+                var regExp3 = /\by+\b/;
+                var regExp4 = /\bM+\b/;
 
                 dmyOrdercldr = dateOrder(cldrFormats[len]);
 
@@ -953,7 +958,7 @@ module.exports = {
                                 cFmt0 = replaceFormates(cFmt0, "{date}", calendar.date[dmyiLib][lenAbbr]);
 
                                 if (language === 'nnh' && (lenAbbr === 'f' || lenAbbr === 'l' )) { //'lyɛ'̌ʼ d 'na' MMMM, yyyy
-                                    cFmt0 = cFmt0.replace(/\by+\b/, "{ey}").replace(/M+/, "{em}").replace(/\bd+\b/,"{ed}");
+                                    cFmt0 = cFmt0.replace(regExp3, "{ey}").replace(/M+/, "{em}").replace(regExp2,"{ed}");
                                 } else {
                                     cFmt0 = replaceFormates(cFmt0, startTime);
                                 }
@@ -966,7 +971,7 @@ module.exports = {
                                 cFmt1 = dateRangeTemplate;
 
                                 if (language === 'nnh' && (lenAbbr === 'f' || lenAbbr === 'l' )) { //'lyɛ'̌ʼ d 'na' MMMM, yyyy
-                                    cFmt1 = cFmt1.replace(/\by+\b/, "{ey}").replace(/M+/, "{em}").replace(/\bd+\b/,"{ed}");
+                                    cFmt1 = cFmt1.replace(regExp3, "{ey}").replace(/M+/, "{em}").replace(regExp2,"{ed}");
                                 } else {
                                     cFmt1 = replaceFormates(dateRangeTemplate, startTime);
                                 }
@@ -974,7 +979,7 @@ module.exports = {
                                 cFmt1 = replaceFormates(cFmt1,"{time}", "{st}");
                                 cFmt1 = replaceFormates(cFmt1,"{date}", calendar.date[dmyiLib][lenAbbr]);
 
-                                cFmt1 = cFmt1.replace(/\by+\b/,"{ey}").replace(/\bM+\b/, "{em}").replace(/\bd+\b/,"{ed}");
+                                cFmt1 = cFmt1.replace(regExp3,"{ey}").replace(regExp4, "{em}").replace(regExp2,"{ed}");
                                 cFmt1 = replaceFormates(cFmt1, "{time}", "{et}");
                                 cFmt1 = cFmt1.replace(/\'/g,"").replace(/\s\s/g," ");
                                 calendar.range["c01"][lenAbbr] = cFmt1;
@@ -986,15 +991,15 @@ module.exports = {
                                 cFmt10 =  isRtl? "\u200F" + cFmt10 : cFmt10;
 
                                 cFmt10 = cFmt10.replace(/{date}/, calendar.date["d"][lenAbbr]);
-                                cFmt10 = cFmt10.replace(/\bd+\b/,"{sd}");
+                                cFmt10 = cFmt10.replace(regExp2,"{sd}");
 
                                 cFmt10 = replaceFormates(cFmt10,"{date}", calendar.date[dmyiLib][lenAbbr]);
 
                                 if (language === 'nnh' && (lenAbbr === 'f' || lenAbbr === 'l' )) { //'lyɛ'̌ʼ d 'na' MMMM, yyyy
-                                    cFmt10 = cFmt10.replace(/\by+\b/,"{ey}").replace(/M+/, "{em}").replace(/\bd+\b/,"{ed}");
+                                    cFmt10 = cFmt10.replace(regExp3,"{ey}").replace(/M+/, "{em}").replace(regExp2,"{ed}");
 
                                 } else {
-                                    cFmt10 = cFmt10.replace(/[^s^\s^\-^\.^\/^\u200f]y+/,"{ey}").replace(/M+/, "{em}").replace(/\bd+\b/,"{ed}");
+                                    cFmt10 = cFmt10.replace(regExp,"{ey}").replace(/M+/, "{em}").replace(regExp2,"{ed}");
                                 }
 
                                 cFmt10 = cFmt10.replace(/\'/g,"").replace(/\s\s/g," ");
@@ -1004,26 +1009,26 @@ module.exports = {
                                 cFmt11 = replaceFormates(cFmt11, "{date}", calendar.date["dm"][lenAbbr]);
 
                                 if (language === 'nnh' && (lenAbbr === 'f' || lenAbbr === 'l' )) { //'lyɛ'̌ʼ d 'na' MMMM, yyyy
-                                    cFmt11 = cFmt11.replace(/M+/, "{sm}").replace(/\bd+\b/,"{sd}");
+                                    cFmt11 = cFmt11.replace(/M+/, "{sm}").replace(regExp2,"{sd}");
                                 } else {
                                     cFmt11 = replaceFormates(cFmt11, startTime);
                                 }
 
                                 cFmt11 = replaceFormates(cFmt11,"{date}", calendar.date[dmyiLib][lenAbbr]);
-                                cFmt11 = cFmt11.replace(/\by+\b/,"{ey}").replace(/M+/, "{em}").replace(/\bd+\b/,"{ed}");
+                                cFmt11 = cFmt11.replace(regExp3,"{ey}").replace(/M+/, "{em}").replace(regExp2,"{ed}");
                                 cFmt11 = cFmt11.replace(/\'/g,"").replace(/\s\s/g," ");
                                 calendar.range["c11"][lenAbbr] = cFmt11;
 
                                 cFmt12 = dateOnlyTemplate;
 
                                 if (language === 'nnh' && (lenAbbr === 'f' || lenAbbr === 'l' )) { //'lyɛ'̌ʼ d 'na' MMMM, yyyy
-                                    cFmt12 = cFmt12.replace(/\by+\b/, "{sy}").replace(/M+/, "{sm}").replace(/\bd+\b/,"{sd}");
+                                    cFmt12 = cFmt12.replace(regExp3, "{sy}").replace(/M+/, "{sm}").replace(regExp2,"{sd}");
                                 } else {
                                     cFmt12 = replaceFormates(cFmt12, startTime);
                                 }
 
                                 cFmt12 = replaceFormates(cFmt12,"{date}", calendar.date[dmyiLib][lenAbbr]);
-                                cFmt12 = cFmt12.replace(/\by+\b/,"{ey}").replace(/M+/, "{em}").replace(/\bd+\b/,"{ed}");
+                                cFmt12 = cFmt12.replace(regExp3,"{ey}").replace(/M+/, "{em}").replace(regExp2,"{ed}");
                                 cFmt12 = cFmt12.replace(/\'/g,"").replace(/\s\s/g," ");
                                 calendar.range["c12"][lenAbbr] = cFmt12;
 
@@ -1032,13 +1037,13 @@ module.exports = {
                                 cFmt20 = "{date} – {date}";
                                 cFmt20 = replaceFormates(cFmt20, "{date}", calendar.date["my"][lenAbbr]);
 
-                                cFmt20 = cFmt20.replace(/M+/,"{sm}").replace(/L+/, "{sm}").replace(/\by+\b/, "{sy}");
+                                cFmt20 = cFmt20.replace(/M+/,"{sm}").replace(/L+/, "{sm}").replace(regExp3, "{sy}");
                                 cFmt20 = replaceFormates(cFmt20,"{date}", calendar.date["my"][lenAbbr]);
 
                                 if (language === 'nnh' && (lenAbbr === 'f' || lenAbbr === 'l' )) { //'lyɛ'̌ʼ d 'na' MMMM, yyyy
-                                    cFmt20 = cFmt20.replace(/\by+\b/, "{ey}").replace(/M+/, "{em}").replace(/L+/, "{em}");
+                                    cFmt20 = cFmt20.replace(regExp3, "{ey}").replace(/M+/, "{em}").replace(/L+/, "{em}");
                                 } else {
-                                    cFmt20 = cFmt20.replace(/[^s^\s^\-^\.^\/^\u200f]y+/,"{ey}").replace(/M+/, "{em}").replace(/L+/, "{em}");
+                                    cFmt20 = cFmt20.replace(regExp,"{ey}").replace(/M+/, "{em}").replace(/L+/, "{em}");
                                 }
 
                                 cFmt20 = cFmt20.replace(/\'/g,"").replace(/\s\s/g," ");
@@ -1063,7 +1068,7 @@ module.exports = {
                                 cFmt1 = replaceFormates(dateRangeTemplate, startTime);
                                 cFmt1 = replaceFormates(cFmt1,"{time}", "{st}");
                                 cFmt1 = replaceFormates(cFmt1,"{date}", calendar.date[dmyiLib][lenAbbr]);
-                                cFmt1 = cFmt1.replace(/[^s^\s^\-^\.^\/^\u200f]y+/,"{ey}").replace(/M+/, "{em}").replace(/\bd+\b/,"{ed}");
+                                cFmt1 = cFmt1.replace(regExp,"{ey}").replace(/M+/, "{em}").replace(regExp2,"{ed}");
                                 cFmt1 = replaceFormates(cFmt1, "{time}", "{et}");
                                 cFmt1 = cFmt1.replace(/\'/g,"").replace(/\s\s/g," ");
                                 calendar.range["c01"][lenAbbr] = cFmt1;
@@ -1075,14 +1080,15 @@ module.exports = {
                                 if (lenAbbr === 's') {
                                     cFmt10 = replaceFormates(cFmt10,"{date}", calendar.date[dmyiLib][lenAbbr]);
                                     cFmt10 = replaceFormates(cFmt10, startTime);
-                                    cFmt10 = cFmt10.replace(/[^s^\s^\-^\.^\/^\u200f]y+/,"{ey}").replace(/M+/, "{em}").replace(/\bd+\b/,"{ed}");
+                                    cFmt10 = cFmt10.replace(regExp,"{ey}").replace(/M+/, "{em}").replace(regExp2,"{ed}");
                                 } else {
                                     cFmt10 = replaceFormates(cFmt10, startTime);
                                     cFmt10 = cFmt10.replace(/ {sy}/,"");
                                     cFmt10 = replaceFormates(cFmt10,"{date}", calendar.date[dmyiLib][lenAbbr]);
-                                    cFmt10 = cFmt10.replace(/[^s^\s^\-^\.^\/^\u200f]y+/,"{ey}").replace(/M+/, "").replace(/\bd+\b/,"{ed}");
-                                    cFmt10 = cFmt10.replace(/}, –/, "} –");
+                                    cFmt10 = cFmt10.replace(regExp,"{ey}").replace(/M+/, "").replace(regExp2,"{ed}");
+                                    cFmt10 = cFmt10.replace(/}, –/, "} –").replace("– /{",  "– {" );
                                 }
+
                                 cFmt10 = cFmt10.replace(/\'/g,"").replace(/\s\s/g," ");
                                 calendar.range["c10"][lenAbbr] = cFmt10;
 
@@ -1090,14 +1096,14 @@ module.exports = {
                                 cFmt11 = replaceFormates(cFmt11, startTime);
                                 cFmt11 = cFmt11.replace(/[\,][s\s\-\.\/^\u200f]{sy}/,"");
                                 cFmt11 = replaceFormates(cFmt11,"{date}", calendar.date[dmyiLib][lenAbbr]);
-                                cFmt11 = cFmt11.replace(/[^s^\s^\-^\.^\/^\u200f]y+/,"{ey}").replace(/M+/, "{em}").replace(/\bd+\b/,"{ed}");
+                                cFmt11 = cFmt11.replace(regExp,"{ey}").replace(/M+/, "{em}").replace(regExp2,"{ed}");
                                 cFmt11 = cFmt11.replace(/\'/g,"").replace(/\s\s/g," ");
                                 calendar.range["c11"][lenAbbr] = cFmt11;
 
                                 cFmt12 = dateOnlyTemplate;
                                 cFmt12 = replaceFormates(cFmt12, startTime);
                                 cFmt12 = replaceFormates(cFmt12,"{date}", calendar.date[dmyiLib][lenAbbr]);
-                                cFmt12 = cFmt12.replace(/[^s^\s^\-^\.^\/^\u200f]y+/,"{ey}").replace(/M+/, "{em}").replace(/\bd+\b/,"{ed}");
+                                cFmt12 = cFmt12.replace(regExp,"{ey}").replace(/M+/, "{em}").replace(regExp2,"{ed}");
                                 cFmt12 = cFmt12.replace(/\'/g,"").replace(/\s\s/g," ");
                                 calendar.range["c12"][lenAbbr] = cFmt12;
 
@@ -1106,7 +1112,7 @@ module.exports = {
 
                                 cFmt20 = cFmt20.replace(/[\W\s]{sd}/,"");
                                 cFmt20 = replaceFormates(cFmt20,"{date}", calendar.date[dmyiLib][lenAbbr]);
-                                cFmt20 = cFmt20.replace(/[^s^\s^\-^\.^\/^\u200f]y+/,"{ey}").replace(/M+/, "{em}").replace(/[\W]d+/,"");
+                                cFmt20 = cFmt20.replace(regExp,"{ey}").replace(/M+/, "{em}").replace(/[\W]d+/,"");
                                 cFmt20 = cFmt20.replace(/\'/g,"").replace(/\s\s/g," ");
                                 calendar.range["c20"][lenAbbr] = cFmt20;
 
@@ -1131,9 +1137,9 @@ module.exports = {
                                 cFmt1 = replaceFormates(cFmt1,"{date}", calendar.date[dmyiLib][lenAbbr]);
 
                                 if (language === 'lt' && (lenAbbr === 'f' || lenAbbr === 'l')) {
-                                    cFmt1 = cFmt1.replace(/\by+\b/,"{ey}").replace(/M+/, "{em}").replace(/[^\'^s]d+/," {ed}")
+                                    cFmt1 = cFmt1.replace(regExp3,"{ey}").replace(/M+/, "{em}").replace(/[^\'^s]d+/," {ed}")
                                 } else {
-                                    cFmt1 = cFmt1.replace(/\by+\b/,"{ey}").replace(/M+/, "{em}").replace(/\bd+\b/,"{ed}");
+                                    cFmt1 = cFmt1.replace(regExp3,"{ey}").replace(/M+/, "{em}").replace(regExp2,"{ed}");
                                 }
 
                                 cFmt1 = replaceFormates(cFmt1, "{time}", "{et}");
@@ -1147,9 +1153,9 @@ module.exports = {
                                 cFmt2 = replaceFormates(cFmt2,"{date}", calendar.date[dmyiLib][lenAbbr]);
 
                                 if (language === 'lt' && (lenAbbr === 'f' || lenAbbr === 'l')) {
-                                    cFmt2 = cFmt2.replace(/\by+\b/,"{ey}").replace(/M+/, "{em}").replace(/[^\'^s]d+/," {ed}")
+                                    cFmt2 = cFmt2.replace(regExp3,"{ey}").replace(/M+/, "{em}").replace(/[^\'^s]d+/," {ed}")
                                 } else {
-                                    cFmt2 = cFmt2.replace(/\by+\b/,"{ey}").replace(/M+/, "{em}").replace(/\bd+\b/,"{ed}");
+                                    cFmt2 = cFmt2.replace(regExp3,"{ey}").replace(/M+/, "{em}").replace(regExp2,"{ed}");
                                 }
 
                                 cFmt2 = replaceFormates(cFmt2, "{time}", "{et}");
@@ -1163,15 +1169,14 @@ module.exports = {
 
 
                                 if (language === 'lt' && (lenAbbr === 'f' || lenAbbr === 'l')) {
-                                    cFmt3 = cFmt3.replace(/[^s^\s^\-^\.^\/^\u200f]y+/,"{ey}").replace(/M+/, "{em}").replace(/[^\'^s]d+/," {ed}");
+                                    cFmt3 = cFmt3.replace(regExp,"{ey}").replace(/M+/, "{em}").replace(/[^\'^s]d+/," {ed}");
                                 } else {
-                                    cFmt3 = cFmt3.replace(/[^s^\s^\-^\.^\/^\u200f]y+/,"{ey}").replace(/M+/, "{em}").replace(/\bd+\b/,"{ed}");
+                                    cFmt3 = cFmt3.replace(regExp,"{ey}").replace(/M+/, "{em}").replace(regExp2,"{ed}");
                                 }
 
                                 cFmt3 = replaceFormates(cFmt3, "{time}", "{et}");
                                 cFmt3 = cFmt3.replace(/\'/g,"").replace(/\s\s/g," ");
                                 calendar.range["c03"][lenAbbr] = cFmt3;
-
 
                                 cFmt10 = dateOnlyTemplate;
                                 cFmt10 = replaceFormates(cFmt10, startTime);
@@ -1201,18 +1206,18 @@ module.exports = {
                                     cFmt11 = cFmt11.replace(/y+[\s\-\.\/^\u200f]/,"").replace(/M+/, "{em}").replace(/[^'^s^]d+/, " {ed}");
                                     cFmt11 = cFmt11.replace(/'m'. {em}/, " {em}");
                                 } else if (language === 'eu' && (lenAbbr === 'f' || lenAbbr === 'l')) {
-                                    cFmt11 = cFmt11.replace(/y+\(\'e\'\)\'ko\'/,"").replace(/M+/, "{em}").replace(/\bd+\b/,"{ed}");
+                                    cFmt11 = cFmt11.replace(/y+\(\'e\'\)\'ko\'/,"").replace(/M+/, "{em}").replace(regExp2,"{ed}");
                                 } else if (isAsianLang(language)) {
                                     if (lenAbbr === 's' || lenAbbr === 'm') {
-                                        cFmt11 = cFmt11.replace(/[^s^\s]y+/,"{ey}").replace(/M+/, "{em}").replace(/\bd+\b/,"{ed}");
+                                        cFmt11 = cFmt11.replace(/[^s^\s]y+/,"{ey}").replace(/M+/, "{em}").replace(regExp2,"{ed}");
                                     } else {
-                                        cFmt11 = cFmt11.replace(/[^s^\s]y+\W/,"").replace(/M+/, "{em}").replace(/\bd+\b/,"{ed}");
+                                        cFmt11 = cFmt11.replace(/[^s^\s]y+\W/,"").replace(/M+/, "{em}").replace(regExp2,"{ed}");
                                     }
 
                                 } else if (lenAbbr ==='s' || lenAbbr ==='m') {
-                                    cFmt11 = cFmt11.replace(/[^s^\s^\u200f]y+/,"{ey}").replace(/M+/, "{em}").replace(/\bd+\b/,"{ed}");
+                                    cFmt11 = cFmt11.replace(/[^s^\s^\u200f]y+/,"{ey}").replace(/M+/, "{em}").replace(regExp2,"{ed}");
                                 } else {
-                                    cFmt11 = cFmt11.replace(/[^s^\s^\u200f]y+\W+/,"").replace(/M+/, "{em}").replace(/\bd+\b/,"{ed}");
+                                    cFmt11 = cFmt11.replace(/[^s^\s^\u200f]y+\W+/,"").replace(/M+/, "{em}").replace(regExp2,"{ed}");
                                 }
 
                                 cFmt11 = cFmt11.replace(/\'/g,"").replace(/\s\s/g," ");
@@ -1225,9 +1230,9 @@ module.exports = {
                                 cFmt12 = replaceFormates(cFmt12,"{date}", calendar.date[dmyiLib][lenAbbr]);
 
                                 if (language === 'lt' && (lenAbbr === 'f' || lenAbbr === 'l')) {
-                                    cFmt12 = cFmt12.replace(/[^s^\s^\-^\.^\/^\u200f]y+/,"{ey}").replace(/M+/, "{em}").replace(/[^'^s^]d+/, " {ed}");
+                                    cFmt12 = cFmt12.replace(regExp,"{ey}").replace(/M+/, "{em}").replace(/[^'^s^]d+/, " {ed}");
                                 } else {
-                                    cFmt12 = cFmt12.replace(/[^s^\s^\-^\.^\/^\u200f]y+/,"{ey}").replace(/M+/, "{em}").replace(/\bd+\b/,"{ed}");
+                                    cFmt12 = cFmt12.replace(regExp,"{ey}").replace(/M+/, "{em}").replace(regExp2,"{ed}");
                                 }
                                 cFmt12 = cFmt12.replace(/\'/g,"").replace(/\s\s/g," ");
                                 calendar.range["c12"][lenAbbr] = cFmt12;
@@ -1238,7 +1243,7 @@ module.exports = {
 
                                 cFmt20 = cFmt20.replace(/M+/,"{sm}").replace(/L+/,"{sm}").replace(/y+/, "{sy}");
                                 cFmt20 = replaceFormates(cFmt20,"{date}", calendar.date["my"][lenAbbr]);
-                                cFmt20 = cFmt20.replace(/[^s^\s^\-^\.^\/^\u200f]y+/,"{ey}").replace(/M+/, "{em}").replace(/L+/, "{em}");
+                                cFmt20 = cFmt20.replace(regExp,"{ey}").replace(/M+/, "{em}").replace(/L+/, "{em}");
 
                                 cFmt20 = cFmt20.replace(/\'/g,"").replace(/\s\s/g," ").trim();
                                 calendar.range["c20"][lenAbbr] = cFmt20;
@@ -1260,7 +1265,7 @@ module.exports = {
                             case "ydm":
 
                                 cFmt0 = replaceFormates(cFmt0, "{date}", calendar.date[dmyiLib][lenAbbr]);
-                                cFmt0 = cFmt0.replace(/\by+\b/,"{sy}").replace(/M+/, "{sm}").replace(/\bd+\b/,"{sd}");
+                                cFmt0 = cFmt0.replace(regExp3,"{sy}").replace(/M+/, "{sm}").replace(regExp2,"{sd}");
                                 cFmt0 = replaceFormates(cFmt0,"{time}", "{st}");
                                 cFmt0 = replaceFormates(cFmt0,"{time}", "{et}");
                                 cFmt0 = cFmt0.replace(/\'/g,"").replace(/\s\s/g," ");
@@ -1268,10 +1273,10 @@ module.exports = {
 
                                 //{sy} {sd}{sm} {st} - {ey} {ed}{em} {et}
                                 cFmt1 = dateRangeTemplate;
-                                cFmt1 = cFmt1.replace(/\by+\b/,"{sy}").replace(/M+/, "{sm}").replace(/\bd+\b/,"{sd}");
+                                cFmt1 = cFmt1.replace(regExp3,"{sy}").replace(/M+/, "{sm}").replace(regExp2,"{sd}");
                                 cFmt1 = replaceFormates(cFmt1,"{time}", "{st}");
                                 cFmt1 = replaceFormates(cFmt1,"{date}", calendar.date[dmyiLib][lenAbbr]);
-                                cFmt1 = cFmt1.replace(/\by+\b/,"{ey}").replace(/M+/, "{em}").replace(/\bd+\b/,"{ed}");
+                                cFmt1 = cFmt1.replace(regExp3,"{ey}").replace(/M+/, "{em}").replace(regExp2,"{ed}");
                                 cFmt1 = replaceFormates(cFmt1, "{time}", "{et}");
                                 cFmt1 = cFmt1.replace(/\'/g,"").replace(/\s\s/g," ");
                                 calendar.range["c01"][lenAbbr] = cFmt1;
@@ -1280,27 +1285,26 @@ module.exports = {
 
                                 //{sy} {sd}{sm} – {ed}{em}
                                 cFmt10 = dateOnlyTemplate;
-                                cFmt10 = cFmt10.replace(/\by+\b/,"{sy}").replace(/M+/, "{sm}").replace(/\bd+\b/,"{sd}");
+                                cFmt10 = cFmt10.replace(regExp3,"{sy}").replace(/M+/, "{sm}").replace(regExp2,"{sd}");
                                 cFmt10 = replaceFormates(cFmt10,"{date}",calendar.date["dm"][lenAbbr]);
-                                cFmt10 = cFmt10.replace(/M+/, "{em}").replace(/\bd+\b/,"{ed}");
+                                cFmt10 = cFmt10.replace(/M+/, "{em}").replace(regExp2,"{ed}");
                                 cFmt10 = cFmt10.replace(/\'/g,"").replace(/\s\s/g," ");
                                 calendar.range["c10"][lenAbbr] = cFmt10;
 
-
                                 //{sy} {sd}{sm} – {ey} {ed}{em}
                                 cFmt11 = dateOnlyTemplate;
-                                cFmt11 = cFmt11.replace(/\by+\b/,"{sy}").replace(/M+/, "{sm}").replace(/\bd+\b/,"{sd}");
+                                cFmt11 = cFmt11.replace(regExp3,"{sy}").replace(/M+/, "{sm}").replace(regExp2,"{sd}");
                                 cFmt11 = replaceFormates(cFmt11,"{date}", calendar.date[dmyiLib][lenAbbr]);
-                                cFmt11 = cFmt11.replace(/\by+\b/,"{ey}").replace(/M+/, "{em}").replace(/\bd+\b/,"{ed}");
+                                cFmt11 = cFmt11.replace(regExp3,"{ey}").replace(/M+/, "{em}").replace(regExp2,"{ed}");
                                 cFmt11 = cFmt11.replace(/\'/g,"").replace(/\s\s/g," ");
                                 calendar.range["c11"][lenAbbr] = cFmt11;
                                 calendar.range["c12"][lenAbbr] = cFmt11;
 
                                 cFmt20 = dateOnlyTemplate;
-                                cFmt20 = cFmt20.replace(/\by+\b/,"{sy}").replace(/M+/, "{sm}").replace(/\bd+\b/,"{sd}");
+                                cFmt20 = cFmt20.replace(regExp3,"{sy}").replace(/M+/, "{sm}").replace(regExp2,"{sd}");
                                 cFmt20 = cFmt20.replace(/{sd}\W/,"");
                                 cFmt20 = replaceFormates(cFmt20,"{date}", calendar.date[dmyiLib][lenAbbr]);
-                                cFmt20 = cFmt20.replace(/\by+\b/,"{ey}").replace(/M+/, "{em}").replace(/\bd+\W/,"");
+                                cFmt20 = cFmt20.replace(regExp3,"{ey}").replace(/M+/, "{em}").replace(/\bd+\W/,"");
                                 cFmt20 = cFmt20.replace(/\'/g,"").replace(/\s\s/g," ");
                                 calendar.range["c20"][lenAbbr] = cFmt20;
 
@@ -1320,20 +1324,20 @@ module.exports = {
                                 cFmt0 = replaceFormates(cFmt0,"{time}", "{st}");
                                 cFmt0 = replaceFormates(cFmt0,"{time}", "{et}");
                                 cFmt0 = replaceFormates(cFmt0, "{date}", calendar.date[dmyiLib][lenAbbr]);
-                                cFmt0 = cFmt0.replace(/\b\wy+\b/,"{sy}").replace(/\bd+\b/,"{sd}").replace(/\bM+\b/,"{sm}");
+                                cFmt0 = cFmt0.replace(/\b\wy+\b/,"{sy}").replace(regExp2,"{sd}").replace(regExp4,"{sm}");
                                 cFmt0 = cFmt0.replace(/\'/g,"").replace(/\s\s/g," ");
                                 calendar.range["c00"][lenAbbr] = cFmt0;
 
                                 cFmt1 = dateRangeTemplate;
                                 cFmt1 = replaceFormates(cFmt1,"{time}", "{st}");
-                                cFmt1 = cFmt1.replace(/\b\wy+\b/,"{sy}").replace(/\bd+\b/,"{sd}").replace(/\bM+\b/,"{sm}");
+                                cFmt1 = cFmt1.replace(/\b\wy+\b/,"{sy}").replace(regExp2,"{sd}").replace(regExp4,"{sm}");
                                 cFmt1 = replaceFormates(cFmt1,"{date}", calendar.date[dmyiLib][lenAbbr]);
                                 cFmt1 = replaceFormates(cFmt1, "{time}", "{et}");
                                 if (language === 'vi') {
                                     if (lenAbbr === 'l') {
-                                        cFmt1 = cFmt1.replace(/yyyy/,"{ey}").replace(/\bM+\b/, "{em}").replace(/\bd+\b/,"{ed}");
+                                        cFmt1 = cFmt1.replace(/yyyy/,"{ey}").replace(regExp4, "{em}").replace(regExp2,"{ed}");
                                     } else  {
-                                        cFmt1 = cFmt1.replace(/\by+\b/,"{ey}").replace(/\bM+\b/, "{em}").replace(/\bd+\b/,"{ed}");
+                                        cFmt1 = cFmt1.replace(regExp3,"{ey}").replace(regExp4, "{em}").replace(regExp2,"{ed}");
                                     }
                                 }
                                 cFmt1 = cFmt1.replace(/\'/g,"").replace(/\s\s/g," ");
@@ -1349,14 +1353,14 @@ module.exports = {
                                     if (lenAbbr === 'l') {
                                         cFmt10 = replaceFormates(cFmt10,"{date}", calendar.date["dm"][lenAbbr]);
                                         cFmt10 = cFmt10.replace(" 'tháng' MM", "");
-                                        cFmt10 = cFmt10.replace(/\bd+\b/,"{sd}")
+                                        cFmt10 = cFmt10.replace(regExp2,"{sd}")
                                         cFmt10 = replaceFormates(cFmt10,"{date}", calendar.date["dmy"][lenAbbr]);
-                                        cFmt10 = cFmt10.replace(/\bd+\b/, "{ed}").replace(/\bM+\b/, "{em}").replace(/\b\wy+\b/, "{ey}");
+                                        cFmt10 = cFmt10.replace(regExp2, "{ed}").replace(regExp4, "{em}").replace(/\b\wy+\b/, "{ey}");
                                     } else {
                                         cFmt10 = replaceFormates(cFmt10,"{date}", calendar.date["d"][lenAbbr]);
-                                        cFmt10 = cFmt10.replace(/\bd+\b/,"{sd}")
+                                        cFmt10 = cFmt10.replace(regExp2,"{sd}")
                                         cFmt10 = replaceFormates(cFmt10,"{date}", calendar.date["dmy"][lenAbbr]);
-                                        cFmt10 = cFmt10.replace(/\bd+\b/, "{ed}").replace(/\bM+\b/, "{em}").replace(/\by+\b/, "{ey}");
+                                        cFmt10 = cFmt10.replace(regExp2, "{ed}").replace(regExp4, "{em}").replace(regExp3, "{ey}");
 
                                     }
                                 }
@@ -1367,9 +1371,9 @@ module.exports = {
                                 cFmt11 = "{date} – {date}";
                                 if (language === 'vi') {
                                     cFmt11 = replaceFormates(cFmt11,"{date}", calendar.date["dm"][lenAbbr]);
-                                    cFmt11 = cFmt11.replace(/\bd+\b/,"{sd}").replace(/\bM+\b/,"{sm}");
+                                    cFmt11 = cFmt11.replace(regExp2,"{sd}").replace(regExp4,"{sm}");
                                     cFmt11 = replaceFormates(cFmt11,"{date}", calendar.date["dmy"][lenAbbr]);
-                                    cFmt11 = cFmt11.replace(/\bd+\b/, "{ed}").replace(/\bM+\b/, "{em}").replace(/\b\wy+\b/, "{ey}");
+                                    cFmt11 = cFmt11.replace(regExp2, "{ed}").replace(regExp4, "{em}").replace(/\b\wy+\b/, "{ey}");
                                 }
                                 cFmt11 = cFmt11.replace(/\'/g,"").replace(/\s\s/g," ");
                                 calendar.range["c11"][lenAbbr] = cFmt11;
@@ -1378,13 +1382,13 @@ module.exports = {
 
                                 if (language === 'vi') {
                                     if (lenAbbr === 'l') {
-                                        cFmt12 = cFmt12.replace(/\bd+\b/,"{sd}").replace(/\bM+\b/,"{sm}").replace(/\b\wy+\b/, "{sy}");
+                                        cFmt12 = cFmt12.replace(regExp2,"{sd}").replace(regExp4,"{sm}").replace(/\b\wy+\b/, "{sy}");
                                         cFmt12 = replaceFormates(cFmt12,"{date}", calendar.date["dmy"][lenAbbr]);
-                                        cFmt12 = cFmt12.replace(/\bd+\b/, "{ed}").replace(/\bM+\b/, "{em}").replace(/yyyy/, "{ey}");
+                                        cFmt12 = cFmt12.replace(regExp2, "{ed}").replace(regExp4, "{em}").replace(/yyyy/, "{ey}");
                                     } else {
-                                        cFmt12 = cFmt12.replace(/\bd+\b/,"{sd}").replace(/\bM+\b/,"{sm}").replace(/\by+\b/, "{sy}");
+                                        cFmt12 = cFmt12.replace(regExp2,"{sd}").replace(regExp4,"{sm}").replace(regExp3, "{sy}");
                                         cFmt12 = replaceFormates(cFmt12,"{date}", calendar.date["dmy"][lenAbbr]);
-                                        cFmt12 = cFmt12.replace(/\bd+\b/, "{ed}").replace(/\bM+\b/, "{em}").replace(/\b\y+\b/, "{ey}");
+                                        cFmt12 = cFmt12.replace(regExp2, "{ed}").replace(regExp4, "{em}").replace(/\b\y+\b/, "{ey}");
                                     }
                                 }
                                 cFmt12 = cFmt12.replace(/\'/g,"").replace(/\s\s/g," ");
@@ -1402,17 +1406,17 @@ module.exports = {
 
                                     } else if(lenAbbr === 'f') {
                                         cFmt20 = cFmt20.replace(/d+\s/,"");
-                                        cFmt20 = cFmt20.replace(/M+/,"{sm}").replace(/\by+\b/, "{sy}");
+                                        cFmt20 = cFmt20.replace(/M+/,"{sm}").replace(regExp3, "{sy}");
                                         cFmt20 = replaceFormates(cFmt20,"{date}", calendar.date["dmy"][lenAbbr]);
                                         cFmt20 = cFmt20.replace(/[^s]d+/,"");
-                                        cFmt20 = cFmt20.replace(/M+/,"{em}").replace(/\by+\b/, "{ey}");
+                                        cFmt20 = cFmt20.replace(/M+/,"{em}").replace(regExp3, "{ey}");
 
                                     } else {
                                         cFmt20 = cFmt20.replace(/d+\W/,"");
-                                        cFmt20 = cFmt20.replace(/M+/,"{sm}").replace(/\by+\b/, "{sy}");
+                                        cFmt20 = cFmt20.replace(/M+/,"{sm}").replace(regExp3, "{sy}");
                                         cFmt20 = replaceFormates(cFmt20,"{date}", calendar.date["dmy"][lenAbbr]);
                                         cFmt20 = cFmt20.replace(/d+\W/,"");
-                                        cFmt20 = cFmt20.replace(/M+/,"{em}").replace(/\by+\b/, "{ey}");
+                                        cFmt20 = cFmt20.replace(/M+/,"{em}").replace(regExp3, "{ey}");
                                     }
                                 }
                                 cFmt20 = cFmt20.replace(/\'/g,"").replace(/\s\s/g," ");
@@ -1427,7 +1431,7 @@ module.exports = {
                                 cFmt0 = replaceFormates(cFmt0,"{time}", "{st}");
                                 cFmt0 = replaceFormates(cFmt0,"{time}", "{et}");
                                 cFmt0 = replaceFormates(cFmt0, "{date}", calendar.date[dmyiLib][lenAbbr]);
-                                cFmt0 = cFmt0.replace(/\by+\b/,"{sy}").replace(/\bd+\b/,"{sd}").replace(/\bM+\b/,"{sm}");
+                                cFmt0 = cFmt0.replace(regExp3,"{sy}").replace(regExp2,"{sd}").replace(regExp4,"{sm}");
                                 cFmt0 = cFmt0.replace(/\'/g,"").replace(/\s\s/g," ");
                                 calendar.range["c00"][lenAbbr] = cFmt0;
 
@@ -1435,7 +1439,7 @@ module.exports = {
                                 cFmt1 = replaceFormates(dateRangeTemplate, startTime);
                                 cFmt1 = replaceFormates(cFmt1,"{time}", "{st}");
                                 cFmt1 = replaceFormates(cFmt1,"{date}", calendar.date[dmyiLib][lenAbbr]);
-                                cFmt1 = cFmt1.replace(/\by+\b/,"{ey}").replace(/M+/, "{em}").replace(/\bd+\b/,"{ed}");
+                                cFmt1 = cFmt1.replace(regExp3,"{ey}").replace(/M+/, "{em}").replace(regExp2,"{ed}");
                                 cFmt1 = replaceFormates(cFmt1, "{time}", "{et}");
                                 cFmt1 = cFmt1.replace(/\'/g,"").replace(/\s\s/g," ");
                                 calendar.range["c01"][lenAbbr] = cFmt1;
@@ -1447,14 +1451,14 @@ module.exports = {
                                 if (lenAbbr === 's') { //mdy-mdy
                                     cFmt10 = replaceFormates(cFmt10,"{date}", calendar.date[dmyiLib][lenAbbr]);
                                     cFmt10 = replaceFormates(cFmt10, startTime);
-                                    cFmt10 = cFmt10.replace(/\by+\b/,"{sy}").replace(/M+/, "{sm}").replace(/\bd+\b/,"{sd}");
+                                    cFmt10 = cFmt10.replace(regExp3,"{sy}").replace(/M+/, "{sm}").replace(regExp2,"{sd}");
                                     cFmt10 = replaceFormates(cFmt10,"{date}", calendar.date[dmyiLib][lenAbbr]);
-                                    cFmt10 = cFmt10.replace(/\by+\b/,"{ey}").replace(/M+/, "{em}").replace(/\bd+\b/,"{ed}");
+                                    cFmt10 = cFmt10.replace(regExp3,"{ey}").replace(/M+/, "{em}").replace(regExp2,"{ed}");
                                 } else { //m d-d y
                                     cFmt10 = replaceFormates(cFmt10,"{date}", calendar.date["dm"][lenAbbr]);
-                                    cFmt10 = cFmt10.replace(/M+/, "{sm}").replace(/\bd+\b/,"{sd}");
+                                    cFmt10 = cFmt10.replace(/M+/, "{sm}").replace(regExp2,"{sd}");
                                     cFmt10 = replaceFormates(cFmt10,"{date}", calendar.date[dmyiLib][lenAbbr]);
-                                    cFmt10 = cFmt10.replace(/[^s]y+/,"{ey}").replace(/M+/,"").replace(/\bd+\b/,"{ed}");
+                                    cFmt10 = cFmt10.replace(/[^s]y+/,"{ey}").replace(/M+/,"").replace(regExp2,"{ed}");
                                 }
                                 cFmt10 = cFmt10.replace(/\'/g,"").replace(/\s\s/g," ");
                                 calendar.range["c10"][lenAbbr] = cFmt10;
@@ -1462,12 +1466,12 @@ module.exports = {
                                 //md - mdy
                                 cFmt11 = "{date} – {date}";
                                 cFmt11 = replaceFormates(cFmt11,"{date}", calendar.date["dm"][lenAbbr]);
-                                cFmt11 = cFmt11.replace(/M+/, "{sm}").replace(/\bd+\b/,"{sd}");
+                                cFmt11 = cFmt11.replace(/M+/, "{sm}").replace(regExp2,"{sd}");
                                 cFmt11 = replaceFormates(cFmt11,"{date}", calendar.date[dmyiLib][lenAbbr]);
                                 if (lenAbbr === 's') {
-                                    cFmt11 = cFmt11.replace(/\by+\b/,"{ey}").replace(/M+/,"{em}").replace(/\bd+\b/,"{ed}");
+                                    cFmt11 = cFmt11.replace(regExp3,"{ey}").replace(/M+/,"{em}").replace(regExp2,"{ed}");
                                 } else {
-                                    cFmt11 = cFmt11.replace(/[^s]y+/,"{ey}").replace(/M+/,"{em}").replace(/\bd+\b/,"{ed}");
+                                    cFmt11 = cFmt11.replace(/[^s]y+/,"{ey}").replace(/M+/,"{em}").replace(regExp2,"{ed}");
                                 }
 
                                 cFmt11 = cFmt11.replace(/\'/g,"").replace(/\s\s/g," ");
@@ -1476,13 +1480,13 @@ module.exports = {
                                 //mdy - mdy
                                 cFmt12 = "{date} – {date}";
                                 cFmt12 = replaceFormates(cFmt12,"{date}", calendar.date[dmyiLib][lenAbbr]);
-                                cFmt12 = cFmt12.replace(/M+/, "{sm}").replace(/\bd+\b/,"{sd}").replace(/\by+\b/,"{sy}");
+                                cFmt12 = cFmt12.replace(/M+/, "{sm}").replace(regExp2,"{sd}").replace(regExp3,"{sy}");
                                 cFmt12 = replaceFormates(cFmt12,"{date}", calendar.date[dmyiLib][lenAbbr]);
 
                                 if (lenAbbr === 's') {
-                                    cFmt12 = cFmt12.replace(/\by+\b/,"{ey}").replace(/M+/,"{em}").replace(/\bd+\b/,"{ed}");
+                                    cFmt12 = cFmt12.replace(regExp3,"{ey}").replace(/M+/,"{em}").replace(regExp2,"{ed}");
                                 } else {
-                                    cFmt12 = cFmt12.replace(/[^s]y+/,"{ey}").replace(/M+/,"{em}").replace(/\bd+\b/,"{ed}");
+                                    cFmt12 = cFmt12.replace(/[^s]y+/,"{ey}").replace(/M+/,"{em}").replace(regExp2,"{ed}");
                                 }
 
                                 cFmt12 = cFmt1.replace(/\'/g,"").replace(/\s\s/g," ");
@@ -1491,11 +1495,11 @@ module.exports = {
                                 //my - my
                                 cFmt20 = "{date} – {date}";
                                 cFmt20 = replaceFormates(cFmt20,"{date}", calendar.date["my"][lenAbbr]);
-                                cFmt20 = cFmt20.replace(/M+/, "{sm}").replace(/\by+\b/,"{sy}");
+                                cFmt20 = cFmt20.replace(/M+/, "{sm}").replace(regExp3,"{sy}");
                                 cFmt20 = replaceFormates(cFmt20,"{date}", calendar.date["my"][lenAbbr]);
 
                                 if (lenAbbr === 's') {
-                                    cFmt20 = cFmt20.replace(/\by+\b/,"{ey}").replace(/M+/,"{em}");
+                                    cFmt20 = cFmt20.replace(regExp3,"{ey}").replace(/M+/,"{em}");
                                 } else {
                                     cFmt20 = cFmt20.replace(/[^s^\s]y+/,"{ey}").replace(/M+/,"{em}");
                                 }
@@ -1571,6 +1575,12 @@ module.exports = {
                              but I think it's better to reference abbreviated if narrow values are number.
                              and some cases are haveing same alphabets which are not good.
                      */
+                    if (language === "mn") {
+                        formats["NN" + prop + calendarNameSuffix] = part.abbreviated[prop].substring(0,1);
+                    } else if (language === "vi") {
+                        formats["NN" + prop + calendarNameSuffix] = part.abbreviated[prop].substring(0,2) + prop;
+                        formats["N" + prop + calendarNameSuffix] = part.abbreviated[prop].substring(0,1) + prop;
+                    }
                 }
             }
             if (usesStandAlone) {

--- a/tools/cldr/datefmts.js
+++ b/tools/cldr/datefmts.js
@@ -911,10 +911,6 @@ module.exports = {
                 "c30": {}
             };
 
-            /*if (language === 'lt') {
-                console.log("language: " + language + "\n");
-            }*/
-
             for (i = 0; i < lengths.length; i++) {
                 var len = lengths[i];
                 var lenAbbr = len.charAt(0);
@@ -1057,6 +1053,8 @@ module.exports = {
                             case "mdy":
                                 //console.log("{date}{time}, mdy");
 
+
+
                                 cFmt0 = replaceFormates(cFmt0, "{date}", calendar.date[dmyiLib][lenAbbr]);
                                 cFmt0 = replaceFormates(cFmt0, startTime);
                                 cFmt0 = replaceFormates(cFmt0,"{time}", "{st}");
@@ -1083,7 +1081,7 @@ module.exports = {
                                     cFmt10 = cFmt10.replace(regExp,"{ey}").replace(/M+/, "{em}").replace(regExp2,"{ed}");
                                 } else {
                                     cFmt10 = replaceFormates(cFmt10, startTime);
-                                    cFmt10 = cFmt10.replace(/ {sy}/,"");
+                                    cFmt10 = cFmt10.replace(/[\s\/]{sy}/,"");
                                     cFmt10 = replaceFormates(cFmt10,"{date}", calendar.date[dmyiLib][lenAbbr]);
                                     cFmt10 = cFmt10.replace(regExp,"{ey}").replace(/M+/, "").replace(regExp2,"{ed}");
                                     cFmt10 = cFmt10.replace(/}, –/, "} –").replace("– /{",  "– {" );
@@ -1094,7 +1092,7 @@ module.exports = {
 
                                 cFmt11 = dateOnlyTemplate;
                                 cFmt11 = replaceFormates(cFmt11, startTime);
-                                cFmt11 = cFmt11.replace(/[\,][s\s\-\.\/^\u200f]{sy}/,"");
+                                cFmt11 = cFmt11.replace(/[\,][s\s\-\.\/^\u200f]{sy}/,"").replace(/[\/]{sy}/,"");
                                 cFmt11 = replaceFormates(cFmt11,"{date}", calendar.date[dmyiLib][lenAbbr]);
                                 cFmt11 = cFmt11.replace(regExp,"{ey}").replace(/M+/, "{em}").replace(regExp2,"{ed}");
                                 cFmt11 = cFmt11.replace(/\'/g,"").replace(/\s\s/g," ");

--- a/tools/cldr/datefmts.js
+++ b/tools/cldr/datefmts.js
@@ -917,7 +917,6 @@ module.exports = {
                 var dateRangeTemplateOrder;
                 var cFmt0, opcFmt0, cFmt1, cFmt2, cFmt3, cFmt10, cFmt11, cFmt12, cFmt20, cFmt30;
 
-                //console.log("lengths!! " + lengths[i]);
                 if (typeof(calendar.order) === 'object'){
                     dateRangeTemplateOrder = calendar.order[lenAbbr] + " – " + calendar.order[lenAbbr];
                     cFmt0 = calendar.order[lenAbbr] + " – {time}";
@@ -1052,8 +1051,6 @@ module.exports = {
                                 break;
                             case "mdy":
                                 //console.log("{date}{time}, mdy");
-
-
 
                                 cFmt0 = replaceFormates(cFmt0, "{date}", calendar.date[dmyiLib][lenAbbr]);
                                 cFmt0 = replaceFormates(cFmt0, startTime);
@@ -1456,7 +1453,7 @@ module.exports = {
                                     cFmt10 = replaceFormates(cFmt10,"{date}", calendar.date["dm"][lenAbbr]);
                                     cFmt10 = cFmt10.replace(/M+/, "{sm}").replace(regExp2,"{sd}");
                                     cFmt10 = replaceFormates(cFmt10,"{date}", calendar.date[dmyiLib][lenAbbr]);
-                                    cFmt10 = cFmt10.replace(/[^s]y+/,"{ey}").replace(/M+/,"").replace(regExp2,"{ed}");
+                                    cFmt10 = cFmt10.replace(/[^s^\s]y+/,"{ey}").replace(/M+/,"").replace(regExp2,"{ed}");
                                 }
                                 cFmt10 = cFmt10.replace(/\'/g,"").replace(/\s\s/g," ");
                                 calendar.range["c10"][lenAbbr] = cFmt10;
@@ -1469,7 +1466,7 @@ module.exports = {
                                 if (lenAbbr === 's') {
                                     cFmt11 = cFmt11.replace(regExp3,"{ey}").replace(/M+/,"{em}").replace(regExp2,"{ed}");
                                 } else {
-                                    cFmt11 = cFmt11.replace(/[^s]y+/,"{ey}").replace(/M+/,"{em}").replace(regExp2,"{ed}");
+                                    cFmt11 = cFmt11.replace(/[^s^\s]y+/,"{ey}").replace(/M+/,"{em}").replace(regExp2,"{ed}");
                                 }
 
                                 cFmt11 = cFmt11.replace(/\'/g,"").replace(/\s\s/g," ");

--- a/tools/cldr/gendatefmts2.js
+++ b/tools/cldr/gendatefmts2.js
@@ -30,6 +30,29 @@ var Locale = common.Locale;
 var mergeAndPrune = common.mergeAndPrune;
 var makeDirs = common.makeDirs;
 
+var hardCodeData = {
+    "zh": {
+        "azh0": "凌晨",
+        "azh1": "早上",
+        "azh2": "上午",
+        "azh3": "正午",
+        "azh4": "下午",
+        "azh5": "傍晚",
+        "azh6": "晚上",
+        "ordinalChoice": "#{num}天"
+    },
+    "am": {
+      "a0-ethiopic": "ጥዋት",
+      "a1-ethiopic": "ቀትር",
+      "a2-ethiopic": "ከሰዓት",
+      "a3-ethiopic": "ከምሽቱ",
+      "a4-ethiopic": "ከሌሊቱ",
+    },
+    "de": {
+        "ordinalChoice": "#{num}."
+    }
+}
+
 var aux = require("./datefmts.js");
 
 function usage() {
@@ -246,6 +269,11 @@ list.forEach(function (file) {
     //console.log("listPattern data is " + JSON.stringify(newFormats, undefined, 4) + "\n");
     group = aux.getFormatGroup(systemResources, localeComponents);
     group.data = merge(group.data || {}, newFormats);
+
+    if (hardCodeData.hasOwnProperty(language)) {
+        group.data = merge(group.data || {}, hardCodeData[language]);
+    }
+
 });
 
 console.log("\nMerging formats forward ...\n");


### PR DESCRIPTION
### Checklist

* [ ] At least one test case is included for this feature or bug fix.
* [ ] `ReleaseNotes` has added or is not needed.
* [ ] This PR has passed all of the test cases on `Nodejs` and `Chrome Browser`.
* [ ] This PR has passed all of the test cases on `QT/QML`.
* [ ] This is an API breaking change.
* [ ] Requires a major version change.


### Issue Resolved / Feature Added
Implement to include automatically data which doesn't exist in CLDR regarding date/time format features.
and some updates in `tools/cldr/datefmt.js`. Regarding DateFormat range, CLDR doesn't provide data. and iLib has a rule by itself [`DateRangeFormatSpec`](https://github.com/iLib-js/iLib/blob/development/docs/DateRangeFormatSpec.md).There're may regular expressions to automatically generate data and handling exception cases.  It's messy. 

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

### Links
