### PR TITLE
Fix warnings from "new Buffer"

### DIFF
--- a/js/lib/UTF16LE.js
+++ b/js/lib/UTF16LE.js
@@ -66,7 +66,7 @@ UTF16LE.prototype._init = function(options) {
 UTF16LE.prototype.mapToUnicode = function (bytes) {
     if (typeof(Buffer) !== "undefined") {
         // nodejs can convert it quickly in native code
-        var b = new Buffer(bytes);
+        var b = Buffer.from(bytes);
         return b.toString("utf16le");
     }
     // otherwise we have to implement it in pure JS
@@ -81,7 +81,7 @@ UTF16LE.prototype.mapToUnicode = function (bytes) {
 UTF16LE.prototype.mapToNative =  function(str) {
     if (typeof(Buffer) !== "undefined") {
         // nodejs can convert it quickly in native code
-        var b = new Buffer(str, "utf16le");
+        var b = Buffer.from(str, "utf16le");
         return new Uint8Array(b);
     }
     // otherwise we have to implement it in pure JS

--- a/js/lib/UTF8.js
+++ b/js/lib/UTF8.js
@@ -100,7 +100,7 @@ UTF8.prototype.validate = function(bytes) {
 UTF8.prototype.mapToUnicode = function (bytes) {
     if (typeof(Buffer) !== "undefined") {
         // nodejs can convert it quickly in native code
-        var b = new Buffer(bytes);
+        var b = Buffer.from(bytes);
         return b.toString("utf8");
     }
     // otherwise we have to implement it in pure JS
@@ -148,7 +148,7 @@ UTF8.prototype.mapToUnicode = function (bytes) {
 UTF8.prototype.mapToNative = function(str) {
     if (typeof(Buffer) !== "undefined") {
         // nodejs can convert it quickly in native code
-        var b = new Buffer(str, "utf8");
+        var b = Buffer.from(str, "utf8");
         return new Uint8Array(b);
     }
     // otherwise we have to implement it in pure JS


### PR DESCRIPTION
Changed from "new Buffer" which is deprecated to "Buffer.from" factory method, which is not.

### Checklist

* [x] At least one test case is included for this feature or bug fix.
* [x] `ReleaseNotes` has added or is not needed.
* [x] This PR has passed all of the test cases on `Nodejs` and `Chrome Browser`.
* [x] This PR has passed all of the test cases on `QT/QML`.
* [ ] This is an API breaking change.
* [ ] Requires a major version change.


### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

### Links
[//]: # (Related issues, references)
