### PR TITLE
Fix a bug which a default script for pa(Punjabi) should be Guru instead of Arabic

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -14,6 +14,7 @@ Bug Fixes:
 * Updated to IANA time zone data version 2019a
 * Fixed a bug where the DateRngFmt was not heeding the specified
   time zone when formatting the start and end dates
+* Fixed a bug which a default script for pa-IN should be Guru instead of Arabic
 
 
 Build 005

--- a/js/data/locale/pa/scripts.jf
+++ b/js/data/locale/pa/scripts.jf
@@ -1,7 +1,7 @@
 {
     "scripts": [
-        "Arab",
-        "Guru"
+        "Guru",
+        "Arab"
     ],
     "generated": true
 }

--- a/js/test/date/testMeridiems.js
+++ b/js/test/date/testMeridiems.js
@@ -1894,7 +1894,7 @@ module.exports.testmeridiems = {
         
         test.done();
     },
-    testMeridiem_pa_PK: function(test) {
+    testMeridiem_pa_Arab_PK: function(test) {
         test.expect(3);
         var fmt = DateFmt.getMeridiemsRange({locale:"pa-Arab-PK"});
         test.ok(fmt !== null);

--- a/js/test/date/testMeridiems.js
+++ b/js/test/date/testMeridiems.js
@@ -1896,11 +1896,11 @@ module.exports.testmeridiems = {
     },
     testMeridiem_pa_PK: function(test) {
         test.expect(3);
-        var fmt = DateFmt.getMeridiemsRange({locale:"pa-PK"});
+        var fmt = DateFmt.getMeridiemsRange({locale:"pa-Arab-PK"});
         test.ok(fmt !== null);
         
-        test.equal(fmt[0].name,  "ਪੂ.ਦੁ.");
-        test.equal(fmt[1].name,  "ਬਾ.ਦੁ.");
+        test.equal(fmt[0].name, 'AM');
+        test.equal(fmt[1].name, 'PM');
         
         test.done();
     },

--- a/js/test/durfmt/testdurfmt2.js
+++ b/js/test/durfmt/testdurfmt2.js
@@ -4219,23 +4219,26 @@ module.exports.testdurfmt2 = {
         test.done();
     },
     testDurFmt_pa_Guru_IN: function(test) {
-        test.expect(16);
-        // 1 2
+        test.expect(24);
+        // 1 2 18
         var textfmt;
         var data = setVariable();
         var length = data["fullLength"];
 
-        var textformatted_1 = [],textformatted_2 = [];
-        var clockformatted_1 = [],clockformatted_2 = [];
+        var textformatted_1 = [],textformatted_2 = [],textformatted_18 = [];
+        var clockformatted_1 = [],clockformatted_2 = [],clockformatted_18 = [];;
+
 
         for (var i=0; i<4; i++) {
             textfmt = new DurationFmt({locale: "pa-Guru-IN", style:"text", length:length[i]});
 
             textformatted_1.push(textfmt.format({year: 1,month: 1,week: 1,day: 1}).toString());
             textformatted_2.push(textfmt.format({year: 2,month: 2,week: 2,day: 2}).toString());
+            textformatted_18.push(textfmt.format({year: 18,month: 18,week: 18,day: 18}).toString());
 
             clockformatted_1.push(textfmt.format({hour: 1,minute: 1,second: 1}).toString());
             clockformatted_2.push(textfmt.format({hour: 2,minute: 2,second: 2}).toString());
+            clockformatted_18.push(textfmt.format({hour: 18,minute: 18,second: 18}).toString());
         }
 
         test.equal(textformatted_1[0], '1 ਸਾਲ, 1 ਮਹੀਨਾ, 1 ਹਫ਼ਤਾ, 1 ਦਿਨ');
@@ -4248,6 +4251,11 @@ module.exports.testdurfmt2 = {
         test.equal(textformatted_2[2], '2 ਸਾਲ, 2 ਮਹੀਨੇ, 2 ਹਫ਼ਤੇ, 2 ਦਿਨ');
         test.equal(textformatted_2[3], '2 ਸਾਲ, 2 ਮਹੀਨੇ, 2 ਹਫ਼ਤੇ, 2 ਦਿਨ');
 
+        test.equal(textformatted_18[0], '18 ਸਾਲ, 18 ਮਹੀਨੇ, 18 ਹਫ਼ਤੇ, 18 ਦਿਨ');
+        test.equal(textformatted_18[1], '18 ਸਾਲ, 18 ਮਹੀਨੇ, 18 ਹਫ਼ਤੇ, 18 ਦਿਨ');
+        test.equal(textformatted_18[2], '18 ਸਾਲ, 18 ਮਹੀਨੇ, 18 ਹਫ਼ਤੇ, 18 ਦਿਨ');
+        test.equal(textformatted_18[3], '18 ਸਾਲ, 18 ਮਹੀਨੇ, 18 ਹਫ਼ਤੇ, 18 ਦਿਨ');
+
         test.equal(clockformatted_1[0], '1 ਘੰਟਾ, 1 ਮਿੰਟ, 1 ਸਕਿੰਟ');
         test.equal(clockformatted_1[1], '1 ਘੰਟਾ, 1 ਮਿੰਟ, 1 ਸਕਿੰਟ');
         test.equal(clockformatted_1[2], '1 ਘੰਟਾ, 1 ਮਿੰਟ, 1 ਸਕਿੰਟ');
@@ -4257,6 +4265,11 @@ module.exports.testdurfmt2 = {
         test.equal(clockformatted_2[1], '2 ਘੰਟੇ, 2 ਮਿੰਟ, 2 ਸਕਿੰਟ');
         test.equal(clockformatted_2[2], '2 ਘੰਟੇ, 2 ਮਿੰਟ, 2 ਸਕਿੰਟ');
         test.equal(clockformatted_2[3], '2 ਘੰਟੇ, 2 ਮਿੰਟ, 2 ਸਕਿੰਟ');
+
+        test.equal(clockformatted_18[0], '18 ਘੰਟੇ, 18 ਮਿੰਟ, 18 ਸਕਿੰਟ');
+        test.equal(clockformatted_18[1], '18 ਘੰਟੇ, 18 ਮਿੰਟ, 18 ਸਕਿੰਟ');
+        test.equal(clockformatted_18[2], '18 ਘੰਟੇ, 18 ਮਿੰਟ, 18 ਸਕਿੰਟ');
+        test.equal(clockformatted_18[3], '18 ਘੰਟੇ, 18 ਮਿੰਟ, 18 ਸਕਿੰਟ');
 
         test.done();
     },

--- a/js/test/durfmt/testdurfmt2.js
+++ b/js/test/durfmt/testdurfmt2.js
@@ -8720,7 +8720,7 @@ module.exports.testdurfmt2 = {
 
         test.done();
     },
-    testDurFmt_pa_PK: function(test) {
+    testDurFmt_pa_Arab_PK: function(test) {
         test.expect(16);
         // 1 18
         var textfmt;
@@ -8731,7 +8731,7 @@ module.exports.testdurfmt2 = {
         var clockformatted_1 = [],clockformatted_18 = [];
 
         for (var i=0; i<4; i++) {
-            textfmt = new DurationFmt({locale: "pa-PK", style:"text", length:length[i]});
+            textfmt = new DurationFmt({locale: "pa-Arab-PK", style:"text", length:length[i], useNative:false});
 
             textformatted_1.push(textfmt.format({year: 1,month: 1,week: 1,day: 1}).toString());
             textformatted_18.push(textfmt.format({year: 18,month: 18,week: 18,day: 18}).toString());
@@ -8740,25 +8740,25 @@ module.exports.testdurfmt2 = {
             clockformatted_18.push(textfmt.format({hour: 18,minute: 18,second: 18}).toString());
         }
 
-        test.equal(textformatted_1[0], '‏1 ਸਾਲ, 1 ਮਹੀਨਾ, 1 ਹਫ਼ਤਾ, 1 ਦਿਨ');
-        test.equal(textformatted_1[1], '‏1 ਸਾਲ, 1 ਮਹੀਨਾ, 1 ਹਫ਼ਤਾ, 1 ਦਿਨ');
-        test.equal(textformatted_1[2], '‏1 ਸਾਲ, 1 ਮਹੀਨਾ, 1 ਹਫ਼ਤਾ, 1 ਦਿਨ');
-        test.equal(textformatted_1[3], '‏1 ਸਾਲ, 1 ਮਹੀਨਾ, 1 ਹਫ਼ਤਾ, 1 ਦਿਨ');
+        test.equal(textformatted_1[0], '‏1 y, 1 m, 1 w, 1 d');
+        test.equal(textformatted_1[1], '‏1 y, 1 m, 1 w, 1 d');
+        test.equal(textformatted_1[2], '‏1 y, 1 m, 1 w, 1 d');
+        test.equal(textformatted_1[3], '‏1 y, 1 m, 1 w, 1 d');
 
-        test.equal(textformatted_18[0], '‏18 ਸਾਲ, 18 ਮਹੀਨੇ, 18 ਹਫ਼ਤੇ, 18 ਦਿਨ');
-        test.equal(textformatted_18[1], '‏18 ਸਾਲ, 18 ਮਹੀਨੇ, 18 ਹਫ਼ਤੇ, 18 ਦਿਨ');
-        test.equal(textformatted_18[2], '‏18 ਸਾਲ, 18 ਮਹੀਨੇ, 18 ਹਫ਼ਤੇ, 18 ਦਿਨ');
-        test.equal(textformatted_18[3], '‏18 ਸਾਲ, 18 ਮਹੀਨੇ, 18 ਹਫ਼ਤੇ, 18 ਦਿਨ');
+        test.equal(textformatted_18[0], '‏18 y, 18 m, 18 w, 18 d');
+        test.equal(textformatted_18[1], '‏18 y, 18 m, 18 w, 18 d');
+        test.equal(textformatted_18[2], '‏18 y, 18 m, 18 w, 18 d');
+        test.equal(textformatted_18[3], '‏18 y, 18 m, 18 w, 18 d');
 
-        test.equal(clockformatted_1[0], '‏1 ਘੰਟਾ, 1 ਮਿੰਟ, 1 ਸਕਿੰਟ');
-        test.equal(clockformatted_1[1], '‏1 ਘੰਟਾ, 1 ਮਿੰਟ, 1 ਸਕਿੰਟ');
-        test.equal(clockformatted_1[2], '‏1 ਘੰਟਾ, 1 ਮਿੰਟ, 1 ਸਕਿੰਟ');
-        test.equal(clockformatted_1[3], '‏1 ਘੰਟਾ, 1 ਮਿੰਟ, 1 ਸਕਿੰਟ');
+        test.equal(clockformatted_1[0], '‏1 h, 1 min, 1 s');
+        test.equal(clockformatted_1[1], '‏1 h, 1 min, 1 s');
+        test.equal(clockformatted_1[2], '‏1 h, 1 min, 1 s');
+        test.equal(clockformatted_1[3], '‏1 h, 1 min, 1 s');
     
-        test.equal(clockformatted_18[0], '‏18 ਘੰਟੇ, 18 ਮਿੰਟ, 18 ਸਕਿੰਟ');
-        test.equal(clockformatted_18[1], '‏18 ਘੰਟੇ, 18 ਮਿੰਟ, 18 ਸਕਿੰਟ');
-        test.equal(clockformatted_18[2], '‏18 ਘੰਟੇ, 18 ਮਿੰਟ, 18 ਸਕਿੰਟ');
-        test.equal(clockformatted_18[3], '‏18 ਘੰਟੇ, 18 ਮਿੰਟ, 18 ਸਕਿੰਟ');
+        test.equal(clockformatted_18[0], '‏18 h, 18 min, 18 s');
+        test.equal(clockformatted_18[1], '‏18 h, 18 min, 18 s');
+        test.equal(clockformatted_18[2], '‏18 h, 18 min, 18 s');
+        test.equal(clockformatted_18[3], '‏18 h, 18 min, 18 s');
                                          
         test.done();
     },

--- a/js/test/root/testscriptinfo.js
+++ b/js/test/root/testscriptinfo.js
@@ -1186,6 +1186,16 @@ module.exports.testscriptinfo = {
         test.equal(scinfo.getScriptDirection(), "ltr");
         test.done();
     },
+    testScriptInfo_pa_IN: function(test) {
+        test.expect(4);
+        var li = new LocaleInfo("pa-IN");
+        var scinfo = new ScriptInfo(li.getScript());
+        test.ok(li !== null);
+        test.ok(scinfo !== null);
+        test.equal(li.getScript(), "Guru");
+        test.equal(scinfo.getScriptDirection(), "ltr");
+        test.done();
+    },
     testScriptInfo_pa_Guru_IN: function(test) {
         test.expect(4);
         var li = new LocaleInfo("pa-Guru-IN");
@@ -2096,9 +2106,9 @@ module.exports.testscriptinfo = {
         test.equal(scinfo.getScriptDirection(), "ltr");
         test.done();
     },
-    testScriptInfo_pa_PK: function(test) {
+    testScriptInfo_pa_Arab_PK: function(test) {
         test.expect(4);
-        var li = new LocaleInfo("pa-PK");
+        var li = new LocaleInfo("pa-Arab-PK");
         var scinfo = new ScriptInfo(li.getScript());
         test.ok(li !== null);
         test.ok(scinfo !== null);

--- a/tools/cldr/genlangscripts.js
+++ b/tools/cldr/genlangscripts.js
@@ -111,7 +111,7 @@ for (var language in scripts) {
         if (!fs.existsSync(filename)) {
             fs.mkdirSync(filename);
         }
-        if (language === 'ms' || language === 'kk') {
+        if (language === 'ms' || language === 'kk' || language === 'pa') {
             scripts[language] = scripts[language].reverse();
         }
         console.log(language + ':\t"scripts": ' + JSON.stringify(scripts[language]) + ',');


### PR DESCRIPTION
### Checklist

* [x] At least one test case is included for this feature or bug fix.
* [x] `ReleaseNotes` has added or is not needed.
* [x] This PR has passed all of the test cases on `Nodejs` and `Chrome Browser`.
* [x] This PR has passed all of the test cases on `QT/QML`.
* [ ] This is an API breaking change.
* [ ] Requires a major version change.


### Issue Resolved / Feature Added
Currently, If a locale is set `pa-IN` it is displayed  `RTL` layout. but it's should be `LTR` layout.
Fix a bug which a default script for `pa` should be `Guru` instead of Arabic. and Fix related test cases and tool code too. 

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

### Links
[//]: # (Related issues, references)
