### PR TITLE
Fixed test failures on Qt 5.12

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -9,7 +9,7 @@ New Features:
 * Updated `iddarea.json` file which is used in `PhoneGeoLocator` information and wrote a script file to automatically generate it.
 
 Bug Fixes:
-
+* Fixed unit test failures which occur on QT 5.12
 
 Build 006
 -------

--- a/js/lib/ilib-qt.js
+++ b/js/lib/ilib-qt.js
@@ -62,7 +62,10 @@ requireClass.prototype.normalize = function(pathname) {
 
 requireClass.prototype.require = function(parent, pathname, absolutePath) {
     //console.log("------------------------\nrequire: called with " + pathname);
-    if (pathname === "./TestSuiteModule.js") {
+    if (pathname === "./normdata.js") {
+        return;
+    }
+    else if (pathname === "./TestSuiteModule.js") {
         // special case to redirect to qt instead
         pathname = this.root + "/../../qt/NodeunitTest/TestSuiteModule.js";
     } else if (pathname === "nodeunit") {

--- a/js/test/strings-ext/testnorm.js
+++ b/js/test/strings-ext/testnorm.js
@@ -27,6 +27,10 @@ if (typeof(normtests) === "undefined") {
     var normtests = require("./normdata.js");
 }
 
+if (ilib._getPlatform() === "qt" && typeof normtests === "undefined" ) {
+    Qt.include("./normdata.js");
+}
+
 if (ilib.isDynData()) {
     NormString.init();
 }

--- a/js/test/units/testarea.js
+++ b/js/test/units/testarea.js
@@ -160,14 +160,14 @@ module.exports.testarea = {
         var m = AreaUnit.convert( "hectare", "square meter",2.0);
     
         test.equal(m, 0.0002);
+
+
         test.done();
     },
-    
     testAreaStaticConvert13: function(test) {
         test.expect(1);
-        var m = AreaUnit.convert( "square yard","square inch", 2.0);
-    
-        test.roughlyEqual(m, 0.00154321, 00000001);
+        var m = AreaUnit.convert("square yard","square inch", 2.0);
+        test.roughlyEqual(m, 0.00154321, 0.0000001);
         test.done();
     },
     testAreaStaticConvert14: function(test) {

--- a/js/test/util/testutils.js
+++ b/js/test/util/testutils.js
@@ -1562,15 +1562,8 @@ module.exports.testutils = {
     
     testHashCodeNotEqualFunctionDifferentNames: function(test) {
         test.expect(1);
-        if (ilib._getPlatform() === "qt") {
-            // the qt javascript engine doesn't allow you to see the code of a function, so all 
-            // functions should have the same hash
-            var expected = JSUtils.hashCode(function a() { return "a"; });
-            test.equal(JSUtils.hashCode(function b() { return "a"; }), expected);
-        } else {
-            var expected = JSUtils.hashCode(function a() { return "a"; });
-            test.notEqual(JSUtils.hashCode(function b() { return "a"; }), expected);
-        }
+        var expected = JSUtils.hashCode(function a() { return "a"; });
+        test.notEqual(JSUtils.hashCode(function b() { return "a"; }), expected);
         test.done();
     },
     testHashCodeNotEqualFunctionDifferentContents: function(test) {

--- a/qt/NodeunitTest/TestEnvironment.qml
+++ b/qt/NodeunitTest/TestEnvironment.qml
@@ -7,8 +7,8 @@ QtObject {
 	id: thisObj
 	property string path: ""
     property string moduleName: ""
-    property var ilib: {}
-    property var require: {}
+    property var ilib: ({})
+    property var require: ({})
 	
     Component.onCompleted: {
         //console.log(">>>>>>>>>>>> [TestEnvironment.qml] new context. Loading in a fresh copy of ilib.");
@@ -17,7 +17,7 @@ QtObject {
         ilib = QtIlib.ilib;
         var loader = new QtIlib.QmlLoader(FS.FileReader);
         ilib.setLoaderCallback(loader);
-		require = QtIlib.require;
+        require = QtIlib.require;
 
         var testSuites, runTest, i;
         testSuites = require("qmltest", path);

--- a/qt/NodeunitTest/TestSuiteModule.js
+++ b/qt/NodeunitTest/TestSuiteModule.js
@@ -42,8 +42,8 @@ TestSuite.prototype = {
     runTests: function() {
         //console.log("[TestSuiteModule.js] TestSuite.runTests: for suite (this.moduleName) " + this.moduleName);
         var suiteComponent = Qt.createComponent("./TestEnvironment.qml");
-		if (suiteComponent.status != Component.Ready) {
-		    if (suiteComponent.status == Component.Error)
+        if (suiteComponent.status !== Component.Ready) {
+            if (suiteComponent.status === Component.Error)
                 console.debug("[TestSuiteModules.js] TestSuite.runTests: Error: "+ suiteComponent.errorString());
 		    return; // or maybe throw
 		}
@@ -51,7 +51,7 @@ TestSuite.prototype = {
         	path: this.path,
             moduleName: this.moduleName
         });
-        if (suiteRunner == null) {
+        if (suiteRunner === null) {
         	console.log("TestSuite.runTests: failed to run test suite " + this.path);
         }
 	}

--- a/qt/build.xml
+++ b/qt/build.xml
@@ -92,6 +92,17 @@ limitations under the License.
 		</sequential>
 	</target>
 
+     <target name="qt.version" description="Check the currently running on qt version">
+        <sequential>
+            <exec osfamily="unix" executable="qmake" failifexecutionfails="true" failonerror="true">
+                <arg line="--version"/>
+            </exec>
+            <exec osfamily="windows" executable="qmake.exe" failifexecutionfails="true"  failonerror="true">
+                <arg line="--version"/>
+        </exec>
+        </sequential>
+    </target>
+
 	<!-- =================================================================== -->
 	<!-- Create the core jar file                                            -->
 	<!-- =================================================================== -->
@@ -123,7 +134,7 @@ limitations under the License.
 		</copy>
 	</target>
 	
-	<target name="test.all" depends="filereader" description="Run the unit tests in the qt test framework. Make sure you have Qt 5.4 or later, and it is the first Qt in your path.">
+	<target name="test.all" depends="qt.version, filereader" description="Run the unit tests in the qt test framework. Make sure you have Qt 5.4 or later, and it is the first Qt in your path.">
 		<sequential>
 			<exec osfamily="unix" executable="qmlscene" dir="${build.unittest}" failifexecutionfails="true" failonerror="true">
 				<env key="QML2_IMPORT_PATH" value="../FileReader/imports"/>
@@ -136,7 +147,7 @@ limitations under the License.
 		</sequential>
 	</target>
 
-    <target name="test.address" depends="filereader" description="Run the address unit tests in the qt test framework.">
+    <target name="test.address" depends="qt.version, filereader" description="Run the address unit tests in the qt test framework.">
         <sequential>
             <exec osfamily="unix" executable="qmlscene" dir="${build.unittest}" failifexecutionfails="true" failonerror="true">
                 <env key="QML2_IMPORT_PATH" value="../FileReader/imports"/>
@@ -149,7 +160,7 @@ limitations under the License.
         </sequential>
     </target>
 
-    <target name="test.calendar" depends="export" description="Run the calendar unit tests in the qt test framework.">
+    <target name="test.calendar" depends="qt.version, export" description="Run the calendar unit tests in the qt test framework.">
         <sequential>
             <exec osfamily="unix" executable="qmlscene" dir="${build.base}/NodeunitTest" failifexecutionfails="true" failonerror="true">
                 <env key="QML2_IMPORT_PATH" value="../FileReader/imports"/>
@@ -162,7 +173,7 @@ limitations under the License.
         </sequential>
     </target>
 
-    <target name="test.collate" depends="export" description="Run the collate unit tests in the qt test framework.">
+    <target name="test.collate" depends="qt.version, export" description="Run the collate unit tests in the qt test framework.">
         <sequential>
             <exec osfamily="unix" executable="qmlscene" dir="${build.base}/NodeunitTest" failifexecutionfails="true" failonerror="true">
                 <env key="QML2_IMPORT_PATH" value="../FileReader/imports"/>
@@ -175,7 +186,7 @@ limitations under the License.
         </sequential>
     </target>
 
-    <target name="test.ctype" depends="export" description="Run the ctype unit tests in the qt test framework.">
+    <target name="test.ctype" depends="qt.version, export" description="Run the ctype unit tests in the qt test framework.">
         <sequential>
             <exec osfamily="unix" executable="qmlscene" dir="${build.base}/NodeunitTest" failifexecutionfails="true" failonerror="true">
                 <env key="QML2_IMPORT_PATH" value="../FileReader/imports"/>
@@ -188,7 +199,7 @@ limitations under the License.
         </sequential>
     </target>
 
-    <target name="test.date" depends="export" description="Run the date unit tests in the qt test framework.">
+    <target name="test.date" depends="qt.version, export" description="Run the date unit tests in the qt test framework.">
         <sequential>
             <exec osfamily="unix" executable="qmlscene" dir="${build.base}/NodeunitTest" failifexecutionfails="true" failonerror="true">
                 <env key="QML2_IMPORT_PATH" value="../FileReader/imports"/>
@@ -201,7 +212,7 @@ limitations under the License.
         </sequential>
     </target>
 
-    <target name="test.daterange" depends="export" description="Run the daterange unit tests in the qt test framework.">
+    <target name="test.daterange" depends="qt.version, export" description="Run the daterange unit tests in the qt test framework.">
         <sequential>
             <exec osfamily="unix" executable="qmlscene" dir="${build.base}/NodeunitTest" failifexecutionfails="true" failonerror="true">
                 <env key="QML2_IMPORT_PATH" value="../FileReader/imports"/>
@@ -214,7 +225,7 @@ limitations under the License.
         </sequential>
     </target>
 
-    <target name="test.durfmt" depends="export" description="Run the durfmt unit tests in the qt test framework.">
+    <target name="test.durfmt" depends="qt.version, export" description="Run the durfmt unit tests in the qt test framework.">
         <sequential>
             <exec osfamily="unix" executable="qmlscene" dir="${build.base}/NodeunitTest" failifexecutionfails="true" failonerror="true">
                 <env key="QML2_IMPORT_PATH" value="../FileReader/imports"/>
@@ -227,7 +238,7 @@ limitations under the License.
         </sequential>
     </target>
 
-    <target name="test.maps" depends="export" description="Run the maps unit tests in the qt test framework.">
+    <target name="test.maps" depends="qt.version, export" description="Run the maps unit tests in the qt test framework.">
         <sequential>
             <exec osfamily="unix" executable="qmlscene" dir="${build.base}/NodeunitTest" failifexecutionfails="true" failonerror="true">
                 <env key="QML2_IMPORT_PATH" value="../FileReader/imports"/>
@@ -240,7 +251,7 @@ limitations under the License.
         </sequential>
     </target>
 
-    <target name="test.name" depends="export" description="Run the name unit tests in the qt test framework.">
+    <target name="test.name" depends="qt.version, export" description="Run the name unit tests in the qt test framework.">
         <sequential>
             <exec osfamily="unix" executable="qmlscene" dir="${build.base}/NodeunitTest" failifexecutionfails="true" failonerror="true">
                 <env key="QML2_IMPORT_PATH" value="../FileReader/imports"/>
@@ -253,7 +264,7 @@ limitations under the License.
         </sequential>
     </target>
 
-    <target name="test.number" depends="export" description="Run the number unit tests in the qt test framework.">
+    <target name="test.number" depends="qt.version, export" description="Run the number unit tests in the qt test framework.">
         <sequential>
             <exec osfamily="unix" executable="qmlscene" dir="${build.base}/NodeunitTest" failifexecutionfails="true" failonerror="true">
                 <env key="QML2_IMPORT_PATH" value="../FileReader/imports"/>
@@ -266,7 +277,7 @@ limitations under the License.
         </sequential>
     </target>
 
-    <target name="test.phone" depends="export" description="Run the phone unit tests in the qt test framework.">
+    <target name="test.phone" depends="qt.version, export" description="Run the phone unit tests in the qt test framework.">
         <sequential>
             <exec osfamily="unix" executable="qmlscene" dir="${build.base}/NodeunitTest" failifexecutionfails="true" failonerror="true">
                 <env key="QML2_IMPORT_PATH" value="../FileReader/imports"/>
@@ -279,7 +290,7 @@ limitations under the License.
         </sequential>
     </target>
 
-    <target name="test.root" depends="export" description="Run the root unit tests in the qt test framework.">
+    <target name="test.root" depends="qt.version, export" description="Run the root unit tests in the qt test framework.">
         <sequential>
             <exec osfamily="unix" executable="qmlscene" dir="${build.base}/NodeunitTest" failifexecutionfails="true" failonerror="true">
                 <env key="QML2_IMPORT_PATH" value="../FileReader/imports"/>
@@ -292,7 +303,7 @@ limitations under the License.
         </sequential>
     </target>
 
-    <target name="test.strings_ext" depends="export" description="Run the strings_ext unit tests in the qt test framework.">
+    <target name="test.strings_ext" depends="qt.version, export" description="Run the strings_ext unit tests in the qt test framework.">
         <sequential>
             <exec osfamily="unix" executable="qmlscene" dir="${build.base}/NodeunitTest" failifexecutionfails="true" failonerror="true">
                 <env key="QML2_IMPORT_PATH" value="../FileReader/imports"/>
@@ -305,7 +316,7 @@ limitations under the License.
         </sequential>
     </target>
 
-    <target name="test.units" depends="export" description="Run the units unit tests in the qt test framework.">
+    <target name="test.units" depends="qt.version, export" description="Run the units unit tests in the qt test framework.">
         <sequential>
             <exec osfamily="unix" executable="qmlscene" dir="${build.base}/NodeunitTest" failifexecutionfails="true" failonerror="true">
                 <env key="QML2_IMPORT_PATH" value="../FileReader/imports"/>
@@ -318,7 +329,7 @@ limitations under the License.
         </sequential>
     </target>
 
-    <target name="test.util" depends="export" description="Run the util unit tests in the qt test framework.">
+    <target name="test.util" depends="qt.version, export" description="Run the util unit tests in the qt test framework.">
         <sequential>
             <exec osfamily="unix" executable="qmlscene" dir="${build.base}/NodeunitTest" failifexecutionfails="true" failonerror="true">
                 <env key="QML2_IMPORT_PATH" value="../FileReader/imports"/>

--- a/qt/build.xml
+++ b/qt/build.xml
@@ -2,7 +2,7 @@
 <!--
 build.xml - build the Qt/QML parts
 
-Copyright © 2015, JEDLSoft
+Copyright © 2015, 2019 JEDLSoft
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -92,7 +92,7 @@ limitations under the License.
 		</sequential>
 	</target>
 
-     <target name="qt.version" description="Check the currently running on qt version">
+     <target name="qt.version" description="Check the currently running on Qt version">
         <sequential>
             <exec osfamily="unix" executable="qmake" failifexecutionfails="true" failonerror="true">
                 <arg line="--version"/>


### PR DESCRIPTION
### Checklist

* [ ] At least one test case is included for this feature or bug fix.
* [x] `ReleaseNotes` has added or is not needed.
* [x] This PR has passed all of the test cases on `Nodejs` and `Chrome Browser`.
* [x] This PR has passed all of the test cases on `QT/QML`.
* [ ] This is an API breaking change.
* [ ] Requires a major version change.


### Issue Resolved / Feature Added
I've confirmed if iLib works ok on Qt 5.12. There were some test failures in units, strings-ext and util. I've fixed them to be passed. Added `qt.version` target in qt/build.xml to check which version of QT is running on. I've run a test on QT JS minified version too. 

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

### Links
* https://wiki.qt.io/New_Features_in_Qt_5.12.
  * Updated to Chromnium 69
