### PR TITLE
Add in the missing methods to IString

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version=14.4.1
+version=14.5.0

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -3,13 +3,21 @@ Release Notes for Version 14
 
 Build 008
 -------
-Published as version 14.4.1
+Published as version 14.5.0
 
 New Features:
+* Added missing methods to the IString classes to echo all the methods on the intrinsic string class
+    * Added methods that have been added in the last few years which some engines define and others do not
+    * Delegates to the string class. Does not offer a polyfill yet.
+    * Methods added are: matchAll, endsWith, startsWith, includes, normalize, padEnd,
+      padStart, repeat, toLocaleLowerCase, toLocaleUpperCase, trim, trimEnd, trimRight,
+      trimStart, trimLeft.
+    * Defined the "length" property so that it returns the string's length like the intrinsic strings do
+    * Added unit tests that only test the new methods if the underlying string class implements each new
+    method.
 
 Bug Fixes:
 * Updated to IANA time zone data 2019c
-
 
 Build 007
 -------

--- a/js/lib/IString.js
+++ b/js/lib/IString.js
@@ -957,6 +957,15 @@ IString.prototype = {
     },
 
     /**
+     * Same as String.matchAll()
+     * @param {string} regexp the regular expression to match
+     * @return {iterator} an iterator of the matches
+     */
+    matchAll: function(regexp) {
+        return this.str.matchAll(regexp);
+    },
+
+    /**
      * Same as String.replace()
      * @param {string} searchValue a regular expression to search for
      * @param {string} newValue the string to replace the matches with
@@ -1051,6 +1060,138 @@ IString.prototype = {
      */
     toUpperCase: function() {
         return this.str.toUpperCase();
+    },
+
+    /**
+     * Same as String.endsWith().
+     * @return {boolean} true if the given characters are found at
+     * the end of the string, and false otherwise
+     */
+    endsWith: function(searchString, length) {
+        return this.str.endsWith(searchString, length);
+    },
+
+    /**
+     * Same as String.startsWith().
+     * @return {boolean} true if the given characters are found at
+     * the beginning of the string, and false otherwise
+     */
+    startsWith: function(searchString, length) {
+        return this.str.startsWith(searchString, length);
+    },
+
+    /**
+     * Same as String.includes().
+     * @return {boolean} true if the search string is found anywhere
+     * with the given string, and false otherwise
+     */
+    includes: function(searchString, position) {
+        return this.str.includes(searchString, position);
+    },
+
+    /**
+     * Same as String.normalize(). If this JS engine does not support
+     * this method, then you can use the NormString class of ilib
+     * to the same thing (albeit a little slower).
+     *
+     * @return {string} the string in normalized form
+     */
+    normalize: function(form) {
+        return this.str.normalize(form);
+    },
+
+    /**
+     * Same as String.padEnd().
+     * @return {string} a string of the specified length with the
+     * pad string applied at the end of the current string
+     */
+    padEnd: function(targetLength, padString) {
+        return this.str.padEnd(targetLength, padString);
+    },
+
+    /**
+     * Same as String.padStart().
+     * @return {string} a string of the specified length with the
+     * pad string applied at the end of the current string
+     */
+    padStart: function(targetLength, padString) {
+        return this.str.padStart(targetLength, padString);
+    },
+
+    /**
+     * Same as String.repeat().
+     * @return {string} a new string containing the specified number
+     * of copies of the given string
+     */
+    repeat: function(count) {
+        return this.str.repeat(count);
+    },
+
+    /**
+     * Same as String.toLocaleLowerCase(). If the JS engine does not support this
+     * method, you can use the ilib CaseMapper class instead.
+     * @return {string} a new string representing the calling string
+     * converted to lower case, according to any locale-sensitive
+     * case mappings
+     */
+    toLocaleLowerCase: function(locale) {
+        return this.str.toLocaleLowerCase(locale);
+    },
+
+    /**
+     * Same as String.toLocaleUpperCase(). If the JS engine does not support this
+     * method, you can use the ilib CaseMapper class instead.
+     * @return {string} a new string representing the calling string
+     * converted to upper case, according to any locale-sensitive
+     * case mappings
+     */
+    toLocaleUpperCase: function(locale) {
+        return this.str.toLocaleUpperCase(locale);
+    },
+
+    /**
+     * Same as String.trim().
+     * @return {string} a new string representing the calling string stripped
+     * of whitespace from both ends.
+     */
+    trim: function() {
+        return this.str.trim();
+    },
+
+    /**
+     * Same as String.trimEnd().
+     * @return {string} a new string representing the calling string stripped
+     * of whitespace from its (right) end.
+     */
+    trimEnd: function() {
+        return this.str.trimEnd();
+    },
+
+    /**
+     * Same as String.trimRight().
+     * @return {string} a new string representing the calling string stripped
+     * of whitespace from its (right) end.
+     */
+    trimRight: function() {
+        return this.str.trimRight();
+    },
+
+    /**
+     * Same as String.trimStart().
+     * @return {string} A new string representing the calling string stripped
+     * of whitespace from its beginning (left end).
+     */
+    trimStart: function() {
+        return this.str.trimStart();
+    },
+
+    /**
+     * Same as String.trimLeft().
+     * @return {string} A new string representing the calling string stripped
+     * of whitespace from its beginning (left end).
+     */
+    trimLeft: function() {
+        return this.str.trimLeft();
     },
 
     /**
@@ -1296,5 +1437,11 @@ IString.prototype = {
         return this.cpLength;
     }
 };
+
+Object.defineProperty(IString, 'length', {
+    get: function() {
+        return this._length();
+    }
+});
 
 module.exports = IString;

--- a/js/lib/IString.js
+++ b/js/lib/IString.js
@@ -49,7 +49,7 @@ var IString = function (string) {
             this.str = string.toString();
         }
     } else if (typeof(string) === 'string') {
-        this.str = new String(string);
+        this.str = String(string); // copy it
     } else {
         this.str = "";
     }

--- a/js/lib/IString.js
+++ b/js/lib/IString.js
@@ -1069,7 +1069,7 @@ IString.prototype = {
      */
     endsWith: function(searchString, length) {
         /* (note)length is optional. If it is omitted the default value is the length of string.
-        *  But If length is omitted, it returns false on QT. (tested on QT 5.12)
+        *  But If length is omitted, it returns false on QT. (tested on QT 5.12.4 and 5.13.0)
         */
         if (typeof length === "undefined") {
             length = this.str.length;

--- a/js/lib/IString.js
+++ b/js/lib/IString.js
@@ -1068,6 +1068,12 @@ IString.prototype = {
      * the end of the string, and false otherwise
      */
     endsWith: function(searchString, length) {
+        /* (note)length is optional. If it is omitted the default value is the length of string.
+        *  But If length is omitted, it returns false on QT. (tested on QT 5.12)
+        */
+        if (typeof length === "undefined") {
+            length = this.str.length;
+        }
         return this.str.endsWith(searchString, length);
     },
 

--- a/js/test/root/testglobal.js
+++ b/js/test/root/testglobal.js
@@ -74,7 +74,7 @@ module.exports.testglobal = {
             return;
         }
         test.expect(1);
-        test.equal(ilib.getVersion().substring(0,4), "14.4");
+        test.equal(ilib.getVersion().substring(0,4), "14.5");
         test.done();
     },
     

--- a/js/test/root/teststrings.js
+++ b/js/test/root/teststrings.js
@@ -1043,6 +1043,52 @@ module.exports.teststrings = {
         test.done();
     },
 
+    testStringDelegateMatchAll: function(test) {
+        if (typeof("".matchAll) === 'function') {
+            test.expect(15);
+            var str = new IString("abc bd bc ab ef bc");
+
+            test.ok(str !== null);
+
+            var it = str.matchAll(/bc/g);
+            
+            test.ok(it);
+            
+            test.ok(it.hasNext());
+
+            var match = it.next();
+            test.ok(match);
+            
+            test.equal(match[1], "bc");
+
+            test.ok(it.hasNext());
+
+            match = it.next();
+            test.ok(match);
+            
+            test.equal(match[1], "bc");
+
+            test.ok(it.hasNext());
+
+            match = it.next();
+            test.ok(match);
+            
+            test.equal(match[1], "bc");
+
+            test.ok(it.hasNext());
+
+            match = it.next();
+            test.ok(match);
+            
+            test.equal(match[1], "bc");
+
+            test.ok(!it.hasNext());
+        } else {
+            console.log("This version of the JS engine does not support String.matchAll()");
+        }
+        test.done();
+    },
+
     testStringDelegateToLocaleLowerCase: function(test) {
         if (typeof("".toLocaleLowerCase) === 'function') {
             test.expect(2);

--- a/js/test/root/teststrings.js
+++ b/js/test/root/teststrings.js
@@ -1,7 +1,7 @@
 /*
  * teststrings.js - test the String object
  *
- * Copyright © 2012-2018, JEDLSoft
+ * Copyright © 2012-2019, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1023,7 +1023,7 @@ module.exports.teststrings = {
         test.done();
     },
     
-    testStringDelegateToLowerCase: function(test) {
+    testStringDelegateToUpperCase: function(test) {
         test.expect(2);
         var str = new IString("abcdef");
     
@@ -1032,7 +1032,271 @@ module.exports.teststrings = {
         test.equal(str.toUpperCase(), "ABCDEF");
         test.done();
     },
+
+    testStringDelegateLength: function(test) {
+        test.expect(2);
+        var str = new IString("abcdef");
     
+        test.ok(str !== null);
+    
+        test.equal(str.length, 6);
+        test.done();
+    },
+
+    testStringDelegateToLocaleLowerCase: function(test) {
+        if (typeof("".toLocaleLowerCase) === 'function') {
+            test.expect(2);
+            var str = new IString("ABCDEF");
+
+            test.ok(str !== null);
+
+            test.equal(str.toLocaleLowerCase(), "abcdef");
+        } else {
+            console.log("This version of the JS engine does not support String.toLocaleLowerCase()");
+        }
+        test.done();
+    },
+    
+    testStringDelegateToLocaleUpperCase: function(test) {
+        if (typeof("".toLocaleUpperCase) === 'function') {
+
+            test.expect(2);
+            var str = new IString("abcdef");
+
+            test.ok(str !== null);
+
+            test.equal(str.toLocaleUpperCase(), "ABCDEF");
+        } else {
+            console.log("This version of the JS engine does not support String.toLocaleUpperCase()");
+        }
+        test.done();
+    },
+
+    testStringDelegateEndsWithTrue: function(test) {
+        if (typeof("".endsWith) === 'function') {
+
+            test.expect(2);
+            var str = new IString("abcdef");
+
+            test.ok(str !== null);
+
+            test.ok(str.endsWith("def"));
+        } else {
+            console.log("This version of the JS engine does not support String.endsWith()");
+        }
+        test.done();
+    },
+
+    testStringDelegateEndsWithFalse: function(test) {
+        if (typeof("".endsWith) === 'function') {
+
+            test.expect(2);
+            var str = new IString("abcdef");
+
+            test.ok(str !== null);
+
+            test.ok(!str.endsWith("de"));
+        } else {
+            console.log("This version of the JS engine does not support String.endsWith()");
+        }
+        test.done();
+    },
+
+    testStringDelegateStartsWithTrue: function(test) {
+        if (typeof("".startsWith) === 'function') {
+
+            test.expect(2);
+            var str = new IString("abcdef");
+
+            test.ok(str !== null);
+
+            test.ok(str.startsWith("abc"));
+        } else {
+            console.log("This version of the JS engine does not support String.startsWith()");
+        }
+        test.done();
+    },
+
+    testStringDelegateStartsWithFalse: function(test) {
+        if (typeof("".startsWith) === 'function') {
+
+            test.expect(2);
+            var str = new IString("abcdef");
+
+            test.ok(str !== null);
+
+            test.ok(!str.startsWith("bc"));
+        } else {
+            console.log("This version of the JS engine does not support String.startsWith()");
+        }
+        test.done();
+    },
+
+    testStringDelegateIncludesTrue: function(test) {
+        if (typeof("".includes) === 'function') {
+
+            test.expect(2);
+            var str = new IString("abcdef");
+
+            test.ok(str !== null);
+
+            test.ok(str.includes("bcd"));
+        } else {
+            console.log("This version of the JS engine does not support String.includes()");
+        }
+        test.done();
+    },
+
+    testStringDelegateIncludesFalse: function(test) {
+        if (typeof("".includes) === 'function') {
+
+            test.expect(2);
+            var str = new IString("abcdef");
+
+            test.ok(str !== null);
+
+            test.ok(!str.includes("bcf"));
+        } else {
+            console.log("This version of the JS engine does not support String.includes()");
+        }
+        test.done();
+    },
+
+    testStringDelegateNormalize: function(test) {
+        if (typeof("".normalize) === 'function') {
+
+            test.expect(2);
+            var str = new IString("abcdef");
+
+            test.ok(str !== null);
+
+            test.equal(str.normalize("NFKC"), "abcdef");
+        } else {
+            console.log("This version of the JS engine does not support String.normalize()");
+        }
+        test.done();
+    },
+
+    testStringDelegatePadEnd: function(test) {
+        if (typeof("".padEnd) === 'function') {
+
+            test.expect(2);
+            var str = new IString("abcdef");
+
+            test.ok(str !== null);
+
+            test.equal(str.padEnd(12, "x"), "abcdefxxxxxx");
+        } else {
+            console.log("This version of the JS engine does not support String.padEnd()");
+        }
+        test.done();
+    },
+
+    testStringDelegatePadStart: function(test) {
+        if (typeof("".padStart) === 'function') {
+
+            test.expect(2);
+            var str = new IString("abcdef");
+
+            test.ok(str !== null);
+
+            test.equal(str.padStart(11, "x"), "xxxxxabcdef");
+        } else {
+            console.log("This version of the JS engine does not support String.padStart()");
+        }
+        test.done();
+    },
+
+    testStringDelegateRepeat: function(test) {
+        if (typeof("".repeat) === 'function') {
+
+            test.expect(2);
+            var str = new IString("abcdef");
+
+            test.ok(str !== null);
+
+            test.equal(str.repeat(3), "abcdefabcdefabcdef");
+        } else {
+            console.log("This version of the JS engine does not support String.repeat()");
+        }
+        test.done();
+    },
+
+    testStringDelegateTrim: function(test) {
+        if (typeof("".trim) === 'function') {
+
+            test.expect(2);
+            var str = new IString("  \r  \n abcdef    \t \t");
+
+            test.ok(str !== null);
+
+            test.equal(str.trim(), "abcdef");
+        } else {
+            console.log("This version of the JS engine does not support String.trim()");
+        }
+        test.done();
+    },
+
+    testStringDelegateTrimEnd: function(test) {
+        if (typeof("".trimEnd) === 'function') {
+
+            test.expect(2);
+            var str = new IString("  \r  \n abcdef    \t \t");
+
+            test.ok(str !== null);
+
+            test.equal(str.trimEnd(), "  \r  \n abcdef");
+        } else {
+            console.log("This version of the JS engine does not support String.trimEnd()");
+        }
+        test.done();
+    },
+
+    testStringDelegateTrimRight: function(test) {
+        if (typeof("".trimRight) === 'function') {
+
+            test.expect(2);
+            var str = new IString("  \r  \n abcdef    \t \t");
+
+            test.ok(str !== null);
+
+            test.equal(str.trimRight(), "  \r  \n abcdef");
+        } else {
+            console.log("This version of the JS engine does not support String.trimRight()");
+        }
+        test.done();
+    },
+
+    testStringDelegateTrimStart: function(test) {
+        if (typeof("".trimStart) === 'function') {
+
+            test.expect(2);
+            var str = new IString("  \r  \n abcdef    \t \t");
+
+            test.ok(str !== null);
+
+            test.equal(str.trimStart(), "abcdef    \t \t");
+        } else {
+            console.log("This version of the JS engine does not support String.trimStart()");
+        }
+        test.done();
+    },
+
+    testStringDelegateTrimLeft: function(test) {
+        if (typeof("".trimLeft) === 'function') {
+
+            test.expect(2);
+            var str = new IString("  \r  \n abcdef    \t \t");
+
+            test.ok(str !== null);
+
+            test.equal(str.trimLeft(), "abcdef    \t \t");
+        } else {
+            console.log("This version of the JS engine does not support String.trimLeft()");
+        }
+        test.done();
+    },
+
     testCodePointToUTF: function(test) {
         test.expect(3);
         var str = IString.fromCodePoint(0x10302);

--- a/js/test/root/teststrings.js
+++ b/js/test/root/teststrings.js
@@ -1115,7 +1115,7 @@ module.exports.teststrings = {
 
             test.ok(str !== null);
 
-            test.ok(str.toString().endsWith("def"));
+            test.ok(str.endsWith("def"));
         } else {
             console.log("This version of the JS engine does not support String.endsWith()");
         }
@@ -1130,7 +1130,7 @@ module.exports.teststrings = {
 
             test.ok(str !== null);
 
-            test.ok(!str.toString().endsWith("de"));
+            test.ok(!str.endsWith("de"));
         } else {
             console.log("This version of the JS engine does not support String.endsWith()");
         }

--- a/js/test/root/teststrings.js
+++ b/js/test/root/teststrings.js
@@ -1115,7 +1115,7 @@ module.exports.teststrings = {
 
             test.ok(str !== null);
 
-            test.ok(str.endsWith("def"));
+            test.ok(str.toString().endsWith("def"));
         } else {
             console.log("This version of the JS engine does not support String.endsWith()");
         }
@@ -1130,7 +1130,7 @@ module.exports.teststrings = {
 
             test.ok(str !== null);
 
-            test.ok(!str.endsWith("de"));
+            test.ok(!str.toString().endsWith("de"));
         } else {
             console.log("This version of the JS engine does not support String.endsWith()");
         }

--- a/js/test/root/teststrings.js
+++ b/js/test/root/teststrings.js
@@ -1122,6 +1122,36 @@ module.exports.teststrings = {
         test.done();
     },
 
+    testStringDelegateEndsWithTrueWithLength1: function(test) {
+        if (typeof("".endsWith) === 'function') {
+
+            test.expect(2);
+            var str = new IString("abcdef");
+
+            test.ok(str !== null);
+
+            test.ok(str.endsWith("def", str.length));
+        } else {
+            console.log("This version of the JS engine does not support String.endsWith()");
+        }
+        test.done();
+    },
+
+    testStringDelegateEndsWithTrueWithLength2: function(test) {
+        if (typeof("".endsWith) === 'function') {
+
+            test.expect(2);
+            var str = new IString("abcdef");
+
+            test.ok(str !== null);
+
+            test.ok(str.endsWith("def", undefined));
+        } else {
+            console.log("This version of the JS engine does not support String.endsWith()");
+        }
+        test.done();
+    },
+
     testStringDelegateEndsWithFalse: function(test) {
         if (typeof("".endsWith) === 'function') {
 
@@ -1131,6 +1161,21 @@ module.exports.teststrings = {
             test.ok(str !== null);
 
             test.ok(!str.endsWith("de"));
+        } else {
+            console.log("This version of the JS engine does not support String.endsWith()");
+        }
+        test.done();
+    },
+
+    testStringDelegateEndsWithFalse2: function(test) {
+        if (typeof("".endsWith) === 'function') {
+
+            test.expect(2);
+            var str = new IString("abcdef");
+
+            test.ok(str !== null);
+
+            test.ok(!str.endsWith("def", 3));
         } else {
             console.log("This version of the JS engine does not support String.endsWith()");
         }
@@ -1152,6 +1197,36 @@ module.exports.teststrings = {
         test.done();
     },
 
+    testStringDelegateStartsWithLength1: function(test) {
+        if (typeof("".startsWith) === 'function') {
+
+            test.expect(2);
+            var str = new IString("abcdef");
+
+            test.ok(str !== null);
+
+            test.ok(str.startsWith("abc", 0));
+        } else {
+            console.log("This version of the JS engine does not support String.startsWith()");
+        }
+        test.done();
+    },
+    testStringDelegateStartsWithLength2: function(test) {
+        if (typeof("".startsWith) === 'function') {
+
+            test.expect(2);
+            var str = new IString("abcdef");
+
+            test.ok(str !== null);
+
+            test.ok(str.startsWith("abc", undefined));
+        } else {
+            console.log("This version of the JS engine does not support String.startsWith()");
+        }
+        test.done();
+    },
+
+
     testStringDelegateStartsWithFalse: function(test) {
         if (typeof("".startsWith) === 'function') {
 
@@ -1161,6 +1236,21 @@ module.exports.teststrings = {
             test.ok(str !== null);
 
             test.ok(!str.startsWith("bc"));
+        } else {
+            console.log("This version of the JS engine does not support String.startsWith()");
+        }
+        test.done();
+    },
+
+    testStringDelegateStartsWithFalse2: function(test) {
+        if (typeof("".startsWith) === 'function') {
+
+            test.expect(2);
+            var str = new IString("abcdef");
+
+            test.ok(str !== null);
+
+            test.ok(!str.startsWith("ab", 4));
         } else {
             console.log("This version of the JS engine does not support String.startsWith()");
         }

--- a/js/test/root/teststrings.js
+++ b/js/test/root/teststrings.js
@@ -1045,7 +1045,7 @@ module.exports.teststrings = {
 
     testStringDelegateMatchAll: function(test) {
         if (typeof("".matchAll) === 'function') {
-            test.expect(15);
+            test.expect(13);
             var str = new IString("abc bd bc ab ef bc");
 
             test.ok(str !== null);
@@ -1054,35 +1054,24 @@ module.exports.teststrings = {
             
             test.ok(it);
             
-            test.ok(it.hasNext());
-
             var match = it.next();
             test.ok(match);
-            
-            test.equal(match[1], "bc");
-
-            test.ok(it.hasNext());
+            test.ok(!match.done);
+            test.equal(match.value[0], "bc");
 
             match = it.next();
             test.ok(match);
-            
-            test.equal(match[1], "bc");
-
-            test.ok(it.hasNext());
+            test.ok(!match.done);
+            test.equal(match.value[0], "bc");
 
             match = it.next();
             test.ok(match);
-            
-            test.equal(match[1], "bc");
-
-            test.ok(it.hasNext());
+            test.ok(!match.done);
+            test.equal(match.value[0], "bc");
 
             match = it.next();
             test.ok(match);
-            
-            test.equal(match[1], "bc");
-
-            test.ok(!it.hasNext());
+            test.ok(match.done);
         } else {
             console.log("This version of the JS engine does not support String.matchAll()");
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib",
-    "version": "14.4.1",
+    "version": "14.5.0",
     "main": "js/index.js",
     "description": "iLib is a cross-engine library of internationalization (i18n) classes written in pure JS",
     "keywords": [


### PR DESCRIPTION
These methods have been added to the String prototype in the years since this class was first coded. Here we put in methods to delegate to the string class. The unit tests only attempt to run if the string class supports these. Older versions of node and browsers of course do not have these new methods.

### Checklist

* [x] At least one test case is included for this feature or bug fix.
* [x] `ReleaseNotes` has added or is not needed.
* [ ] This PR has passed all of the test cases on `Nodejs` and `Chrome Browser`.
* [x] This PR has passed all of the test cases on `QT/QML`.
* [ ] This is an API breaking change.
* [ ] Requires a major version change.


### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

### Links
[//]: # (Related issues, references)
