### PR TITLE
Updated the Korean name formatting component per style as a more natural way

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -18,6 +18,7 @@ New Features:
 
 Bug Fixes:
 * Updated to IANA time zone data 2019c
+* Updated the Korean Name Formatting component per style. Including 'suffix' is more natural than having a 'prefix' or 'honorific'.
 
 Build 007
 -------

--- a/js/data/locale/ko/name.json
+++ b/js/data/locale/ko/name.json
@@ -1,7 +1,7 @@
 {
 	"components": {
-		"formal_short": "pgf",
-		"formal_long": "pgf"
+		"formal_short": "gfs",
+		"formal_long": "pgfs"
 	},
 	"useSpaces": false,
 	"format": "{prefix} {familyName}{middleName}{givenName} {suffix}",

--- a/js/data/locale/ko/name.json
+++ b/js/data/locale/ko/name.json
@@ -1,6 +1,9 @@
 {
 	"components": {
-		"formal_short": "gfs",
+		"medium": "gmf",
+        "long": "gmfs",
+        "full": "pgmfs",
+        "formal_short": "gfs",
 		"formal_long": "pgfs"
 	},
 	"useSpaces": false,

--- a/js/test/name/testname_ko.js
+++ b/js/test/name/testname_ko.js
@@ -426,7 +426,7 @@ module.exports.testname_ko = {
         var formatted = fmt.format(name);
         test.ok(typeof(formatted) !== "undefined");
         
-        var expected = "미스터 김동경";
+        var expected = "김동경 , 박사";
         
         test.equal(formatted, expected);
         test.done();
@@ -501,7 +501,7 @@ module.exports.testname_ko = {
         var formatted = fmt.format(name);
         test.ok(typeof(formatted) !== "undefined");
         
-        var expected = "미스터 남궁동경";
+        var expected = "남궁동경 씨";
         
         test.equal(formatted, expected);
         test.done();

--- a/js/test/name/testnamefmt.js
+++ b/js/test/name/testnamefmt.js
@@ -672,7 +672,27 @@ module.exports.testnamefmt = {
         
         // use the full name, even in formal_short
         // honorifics are prefixes in Korean
-        test.equal(fmt.format(name), "닥터 박은성");
+        test.equal(fmt.format(name), "박은성");
+        test.done();
+    },
+    testNameFmtKOFormalShort2: function(test) {
+        test.expect(1);
+        var name = new Name({
+            honorific: "닥터",
+            givenName: "은성",
+            familyName: "박",
+            suffix: "님"
+        }, {
+            locale: "ko-KR"
+        });
+        var fmt = new NameFmt({
+            style: "formal_short",
+            locale: "ko-KR"
+        });
+
+        // use the full name, even in formal_short
+        // honorifics are prefixes in Korean
+        test.equal(fmt.format(name), "박은성 님");
         test.done();
     },
 
@@ -691,6 +711,25 @@ module.exports.testnamefmt = {
         });
         
         test.equal(fmt.format(name), "닥터 박은성");
+        test.done();
+    },
+
+    testNameFmtZHFormalLong2: function(test) {
+        test.expect(1);
+        var name = new Name({
+            honorific: "닥터",
+            givenName: "은성",
+            familyName: "박",
+            suffix: "님"
+        }, {
+            locale: "ko-KR"
+        });
+        var fmt = new NameFmt({
+            style: "formal_long",
+            locale: "ko-KR"
+        });
+
+        test.equal(fmt.format(name), "닥터 박은성 님");
         test.done();
     },
     

--- a/js/test/name/testnamefmt.js
+++ b/js/test/name/testnamefmt.js
@@ -696,6 +696,81 @@ module.exports.testnamefmt = {
         test.done();
     },
 
+    testNameFmtKOShort: function(test) {
+        test.expect(1);
+        var name = new Name({
+            honorific: "닥터",
+            givenName: "은성",
+            familyName: "박",
+            suffix: "님"
+        }, {
+            locale: "ko-KR"
+        });
+        var fmt = new NameFmt({
+            locale: "ko-KR",
+            style: "short"
+        });
+        test.equal(fmt.format(name), "박은성");
+        test.done();
+    },
+
+    testNameFmtKOMedium: function(test) {
+        test.expect(1);
+        var name = new Name({
+            honorific: "닥터",
+            givenName: "은성",
+            familyName: "박",
+            suffix: "님"
+        }, {
+            locale: "ko-KR"
+        });
+        var fmt = new NameFmt({
+            locale: "ko-KR",
+            style: "medium"
+        });
+
+        test.equal(fmt.format(name), "박은성");
+        test.done();
+    },
+
+    testNameFmtKOLong: function(test) {
+        test.expect(1);
+        var name = new Name({
+            honorific: "닥터",
+            givenName: "은성",
+            familyName: "박",
+            suffix: "님"
+        }, {
+            locale: "ko-KR"
+        });
+        var fmt = new NameFmt({
+            locale: "ko-KR",
+            style: "long"
+        });
+
+        test.equal(fmt.format(name), "박은성 님");
+        test.done();
+    },
+
+    testNameFmtKOFull: function(test) {
+        test.expect(1);
+        var name = new Name({
+            honorific: "닥터",
+            givenName: "은성",
+            familyName: "박",
+            suffix: "님"
+        }, {
+            locale: "ko-KR"
+        });
+        var fmt = new NameFmt({
+            locale: "ko-KR",
+            style: "full"
+        });
+
+        test.equal(fmt.format(name), "닥터 박은성 님");
+        test.done();
+    },
+
     testNameFmtZHFormalLong: function(test) {
         test.expect(1);
         var name = new Name({


### PR DESCRIPTION
### Checklist

* [x] At least one test case is included for this feature or bug fix.
* [x] `ReleaseNotes` has added or is not needed.
* [x] This PR has passed all of the test cases on `Nodejs` and `Chrome Browser`.
* [x] This PR has passed all of the test cases on `QT/QML`.
* [ ] This is an API breaking change.
* [ ] Requires a major version change.


### Issue Resolved / Feature Added
Updated the Korean Name Formatting component per style. Including `suffix` is more natural than `prefix` or `honorific` and Fixed and added regarding test cases.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

### Links
[//]: # (Related issues, references)
