### PR TITLE
Added missing likely locale for hr-ME

### DIFF
--- a/js/data/locale/localematch.json
+++ b/js/data/locale/localematch.json
@@ -2374,6 +2374,7 @@
         "hr": "hr-Latn-HR",
         "hr-HR": "hr-Latn-HR",
         "hr-Latn": "hr-Latn-HR",
+        "hr-ME": "hr-Latn-ME",
         "hsb": "hsb-Latn-DE",
         "hsb-DE": "hsb-Latn-DE",
         "hsb-Latn": "hsb-Latn-DE",

--- a/js/test/root/testlocalematch.js
+++ b/js/test/root/testlocalematch.js
@@ -1015,6 +1015,19 @@ module.exports.testlocalematch = {
         test.equal(locale.getSpec(), "ur-Arab-PK");
         test.done();
     },
+
+    testLocaleMatcherGetLikelyLocaleByLocaleCode58: function(test) {
+        test.expect(3);
+        var lm = new LocaleMatcher({
+            locale: "hr-ME"
+        });
+        test.ok(typeof(lm) !== "undefined");
+        var locale = lm.getLikelyLocale();
+        test.ok(typeof(locale) !== "undefined");
+        test.equal(locale.getSpec(), "hr-Latn-ME");
+        test.done();
+    },
+
     testLocaleMatcherMatchExactFullLocale: function(test) {
         test.expect(2);
         var lm = new LocaleMatcher({


### PR DESCRIPTION
### Checklist

* [ ] At least one test case is included for this feature or bug fix.
* [ ] `ReleaseNotes` has added or is not needed.
* [ ] This PR has passed all of the test cases on `Nodejs` and `Chrome Browser`.
* [ ] This PR has passed all of the test cases on `QT/QML`.
* [ ] This is an API breaking change.
* [ ] Requires a major version change.


### Issue Resolved / Feature Added
Added missing likely locale for ht-ME. it should return `hr-Latn-ME`
but it's `hr-Latn-HR` now.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

### Links
[//]: # (Related issues, references)
