### PR TITLE
Update weekdate localedata to CLDR 36

### DIFF
--- a/js/data/locale/und/UG/weekendstart.jf
+++ b/js/data/locale/und/UG/weekendstart.jf
@@ -1,4 +1,4 @@
 {
-    "firstDayOfWeek": 1,
+    "weekendStart": 0,
     "generated": true
 }

--- a/js/test/date/testDayOfWeek.js
+++ b/js/test/date/testDayOfWeek.js
@@ -425,7 +425,7 @@ module.exports.testweekdata = {
         test.ok(info !== null);
 
         test.equal(info.getFirstDayOfWeek(), 1);
-        test.equal(info.getWeekEndStart(), 6);
+        test.equal(info.getWeekEndStart(), 0);
         test.equal(info.getWeekEndEnd(), 0);
         test.done();
     },
@@ -454,7 +454,7 @@ module.exports.testweekdata = {
         var info = new LocaleInfo("es-AR");
         test.ok(info !== null);
 
-        test.equal(info.getFirstDayOfWeek(), 0);
+        test.equal(info.getFirstDayOfWeek(), 1);
         test.equal(info.getWeekEndStart(), 6);
         test.equal(info.getWeekEndEnd(), 0);
         test.done();

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "cldr-data-coverage": "full",
     "devDependencies": {
         "babel-loader": "^7.1.5",
-        "cldr-data": "^34.0.0",
+        "cldr-data": "^36.0.0",
         "ejs": "^2.6.1",
         "grunt": "^1.0.3",
         "grunt-cli": "^1.2.0",


### PR DESCRIPTION
### Checklist

* [ ] At least one test case is included for this feature or bug fix.
* [ ] `ReleaseNotes` has added or is not needed.
* [x] This PR has passed all of the test cases on `Nodejs` and `Chrome Browser`.
* [ ] This PR has passed all of the test cases on `QT/QML`.
* [ ] This is an API breaking change.
* [ ] Requires a major version change.


### Issue Resolved / Feature Added
Update firstDayOfWeek, weekendStart, and weekendEnd information to CLDR 36.
AR (Argentina), UG(Uganda) has been changed.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

### Links
https://unicode-org.atlassian.net/browse/CLDR-11893
https://unicode-org.atlassian.net/browse/CLDR-13050
