### PR TITLE
Update number and currency locale data to CLDR 36

### DIFF
--- a/js/data/locale/ceb/numfmt.jf
+++ b/js/data/locale/ceb/numfmt.jf
@@ -2,7 +2,8 @@
     "generated": true,
     "numfmt": {
         "currencyFormats": {
-            "commonNegative": "-{s} {n}"
+            "common": "{s}{n}",
+            "commonNegative": "-{s}{n}"
         }
     }
 }

--- a/js/data/locale/currency.jf
+++ b/js/data/locale/currency.jf
@@ -1,1 +1,3 @@
-{"currency": "USD"}
+{
+    "currency": "USD"
+}

--- a/js/data/locale/currency.json
+++ b/js/data/locale/currency.json
@@ -184,11 +184,6 @@
         "decimals": 0,
         "sign": "$"
     },
-    "CNH": {
-        "name": "Chinese Yuan (offshore)",
-        "decimals": 2,
-        "sign": "CNH"
-    },
     "CNY": {
         "name": "Chinese Yuan",
         "decimals": 2,

--- a/js/data/locale/en/150/numfmt.jf
+++ b/js/data/locale/en/150/numfmt.jf
@@ -1,8 +1,6 @@
 {
     "generated": true,
     "numfmt": {
-        "decimalChar": ",",
-        "groupChar": ".",
         "currencyFormats": {
             "common": "{n} {s}",
             "commonNegative": "-{n} {s}"

--- a/js/data/locale/en/CH/numfmt.jf
+++ b/js/data/locale/en/CH/numfmt.jf
@@ -1,8 +1,7 @@
 {
     "generated": true,
     "numfmt": {
-        "decimalChar": ",",
-        "groupChar": ".",
+        "groupChar": "’",
         "currencyFormats": {
             "common": "{s} {n}",
             "commonNegative": "{s}-{n}"

--- a/js/data/locale/en/IN/numfmt.jf
+++ b/js/data/locale/en/IN/numfmt.jf
@@ -1,10 +1,6 @@
 {
     "generated": true,
     "numfmt": {
-        "secgroupSize": 2,
-        "currencyFormats": {
-            "common": "{s} {n}",
-            "commonNegative": "-{s} {n}"
-        }
+        "secgroupSize": 2
     }
 }

--- a/js/data/locale/es/PE/numfmt.jf
+++ b/js/data/locale/es/PE/numfmt.jf
@@ -4,8 +4,8 @@
         "decimalChar": ".",
         "groupChar": ",",
         "currencyFormats": {
-            "common": "{s}{n}",
-            "commonNegative": "-{s}{n}"
+            "common": "{s} {n}",
+            "commonNegative": "-{s} {n}"
         }
     }
 }

--- a/js/data/locale/jv/numfmt.jf
+++ b/js/data/locale/jv/numfmt.jf
@@ -1,5 +1,23 @@
 {
     "generated": true,
+    "native_numfmt": {
+        "script": "Java",
+        "decimalChar": ",",
+        "groupChar": ".",
+        "pctChar": "%",
+        "exponential": "E",
+        "prigroupSize": 3,
+        "currencyFormats": {
+            "common": "{s} {n}",
+            "commonNegative": "-{s} {n}"
+        },
+        "negativenumFmt": "-{n}",
+        "pctFmt": "{n}%",
+        "negativepctFmt": "-{n}%",
+        "roundingMode": "halfdown",
+        "digits": "꧐꧑꧒꧓꧔꧕꧖꧗꧘꧙",
+        "useNative": true
+    },
     "numfmt": {
         "decimalChar": ",",
         "groupChar": "."

--- a/js/data/locale/kok/numfmt.jf
+++ b/js/data/locale/kok/numfmt.jf
@@ -7,10 +7,9 @@
         "pctChar": "%",
         "exponential": "E",
         "prigroupSize": 3,
-        "secgroupSize": 2,
         "currencyFormats": {
-            "common": "{s} {n}",
-            "commonNegative": "-{s} {n}"
+            "common": "{s}{n}",
+            "commonNegative": "-{s}{n}"
         },
         "negativenumFmt": "-{n}",
         "pctFmt": "{n}%",
@@ -18,8 +17,5 @@
         "roundingMode": "halfdown",
         "digits": "०१२३४५६७८९",
         "useNative": true
-    },
-    "numfmt": {
-        "secgroupSize": 2
     }
 }

--- a/js/data/locale/mk/numfmt.jf
+++ b/js/data/locale/mk/numfmt.jf
@@ -6,6 +6,8 @@
         "currencyFormats": {
             "common": "{n} {s}",
             "commonNegative": "-{n} {s}"
-        }
+        },
+        "pctFmt": "{n} %",
+        "negativepctFmt": "-{n} %"
     }
 }

--- a/js/data/locale/zxx/currency.jf
+++ b/js/data/locale/zxx/currency.jf
@@ -1,1 +1,3 @@
-{"currency": "USD"}
+{
+    "currency": "USD"
+}

--- a/js/test/number/testnumfmt.js
+++ b/js/test/number/testnumfmt.js
@@ -4243,7 +4243,7 @@ module.exports.testnumfmt = {
     
         test.ok(fmt);
     
-        test.equal(fmt.format(100110.57), "₹ 1,00,110.57");
+        test.equal(fmt.format(100110.57), "₹1,00,110.57");
         test.done();
     },
     
@@ -4934,7 +4934,7 @@ module.exports.testnumfmt = {
     
         test.ok(fmt);
     
-        test.equal(fmt.format(57.8), "57,8%");
+        test.equal(fmt.format(57.8), "57,8 %");
         test.done();
     },
     //test cases for ms-MY

--- a/js/test/number/testnumfmt2.js
+++ b/js/test/number/testnumfmt2.js
@@ -505,9 +505,9 @@ module.exports.testnumfmt2 = {
         test.equal(pctfmt.format(34), "34%");
 
         var curfmt = new NumFmt({locale: "en-IN", type: "currency", useNative:false, currency:li.getCurrency()});
-        test.equal(li.getCurrencyFormats().common, "{s} {n}");
-        test.equal(li.getCurrencyFormats().commonNegative, "-{s} {n}");
-        test.equal(curfmt.format(57.05), "₹ 57.05"); //INR
+        test.equal(li.getCurrencyFormats().common, "{s}{n}");
+        test.equal(li.getCurrencyFormats().commonNegative, "-{s}{n}");
+        test.equal(curfmt.format(57.05), "₹57.05"); //INR
         test.done();
     },
     testNumFmt_en_IS: function(test) {
@@ -1098,9 +1098,9 @@ module.exports.testnumfmt2 = {
         test.equal(pctfmt.format(34), "34 %");
 
         var curfmt = new NumFmt({locale: "es-PE", type: "currency", useNative:false, currency:li.getCurrency()});
-        test.equal(li.getCurrencyFormats().common, "{s}{n}");
-        test.equal(li.getCurrencyFormats().commonNegative, "-{s}{n}");
-        test.equal(curfmt.format(57.05), "S/.57.05"); //PEN
+        test.equal(li.getCurrencyFormats().common, "{s} {n}");
+        test.equal(li.getCurrencyFormats().commonNegative, "-{s} {n}");
+        test.equal(curfmt.format(57.05), "S/. 57.05"); //PEN
         
         test.done();
     },
@@ -1769,9 +1769,9 @@ module.exports.testnumfmt2 = {
         test.equal(fmt.format(123456789.45), "123.456.789,45");
 
         var pctfmt = new NumFmt({locale:"mk-MK", type:"percentage", useNative:false});
-        test.equal(li.getPercentageFormat(), "{n}%");
-        test.equal(li.getNegativePercentageFormat(), "-{n}%");
-        test.equal(pctfmt.format(34), "34%");
+        test.equal(li.getPercentageFormat(), "{n} %");
+        test.equal(li.getNegativePercentageFormat(), "-{n} %");
+        test.equal(pctfmt.format(34), "34 %");
 
         var curfmt = new NumFmt({locale: "mk-MK", type: "currency", useNative:false, currency:li.getCurrency()});
         test.equal(li.getCurrencyFormats().common, "{n} {s}");

--- a/js/test/number/testnumfmt2.js
+++ b/js/test/number/testnumfmt2.js
@@ -1869,8 +1869,8 @@ module.exports.testnumfmt2 = {
         test.equal(pctfmt.format(34), "34%");
 
         var curfmt = new NumFmt({locale: "nl-BE", type: "currency", useNative:false, currency:li.getCurrency()});
-        test.equal(li.getCurrencyFormats().common, "{s} {n}"); // CLDR 34 change
-        test.equal(li.getCurrencyFormats().commonNegative, "-{s} {n}"); // CLDR 34 change
+        test.equal(li.getCurrencyFormats().common, "{s} {n}");
+        test.equal(li.getCurrencyFormats().commonNegative, "{s} -{n}");
         test.equal(curfmt.format(57.05), "€ 57,05"); //EUR
         test.done();
     },

--- a/js/test/root/testlocaleinfo.js
+++ b/js/test/root/testlocaleinfo.js
@@ -6789,7 +6789,7 @@ module.exports.testlocaleinfo = {
         var info = new LocaleInfo("mk-MK");
         test.ok(info !== null);
     
-        test.equal(info.getPercentageFormat(), "{n}%");
+        test.equal(info.getPercentageFormat(), "{n} %");
         test.done();
     },
     
@@ -6816,7 +6816,7 @@ module.exports.testlocaleinfo = {
         var info = new LocaleInfo("mk-MK");
         test.ok(info !== null);
     
-        test.equal(info.getNegativePercentageFormat(), "-{n}%");
+        test.equal(info.getNegativePercentageFormat(), "-{n} %");
         test.done();
     },
     

--- a/js/test/root/testlocaleinfo.js
+++ b/js/test/root/testlocaleinfo.js
@@ -7281,7 +7281,7 @@ module.exports.testlocaleinfo = {
         var info = new LocaleInfo("nl-BE");
         test.ok(info !== null);
     
-        test.equal(info.getCurrencyFormats().commonNegative, "-{s} {n}");
+        test.equal(info.getCurrencyFormats().commonNegative, "{s} -{n}");
         test.done();
     },
     

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "cldr-data-coverage": "full",
     "devDependencies": {
         "babel-loader": "^7.1.5",
-        "cldr-data": "^34.0.0",
+        "cldr-data": "^36.0.0",
         "ejs": "^2.6.1",
         "grunt": "^1.0.3",
         "grunt-cli": "^1.2.0",

--- a/tools/cldr/gencurrencies.js
+++ b/tools/cldr/gencurrencies.js
@@ -2,7 +2,7 @@
  * gencurrencies.js - ilib tool to generate the json data about currency
  * the CLDR data files
  *
- * Copyright © 2016, 2018-2019, JEDLSoft
+ * Copyright © 2016, 2018-2020, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,10 +31,12 @@ var mkdirs = common.makeDirs;
 var path = require("path");
 
 function usage() {
-    console.log("Usage: gencurrency [-h] [toDir]\n" +
+    console.log("Usage: gencurrency [-h] [iLib locale Dir] [toDir]\n" +
         "Generate the currency.jf files for each country.\n\n" +
         "-h or --help\n" +
         "  this help\n" +
+        "iLibDataDir\n" +
+    "  Current ilib locale directory in order to refer the current currency info.\n" +
         "toDir\n" +
     "  directory to output the currency.jf json files. Default: current dir.\n");
     process.exit(1);
@@ -96,7 +98,7 @@ function getNameAndSign(currency, cldrData, ilibData) {
 }
 
 var currencyDataFileName;
-var toDir = "tmp";
+var toDir = "./tmp";
 
 process.argv.forEach(function (val, index, array) {
     if (val === "-h" || val === "--help") {
@@ -110,13 +112,17 @@ if (process.argv.length < 2) {
 }
 
 if (process.argv.length > 2) {
-    toDir = process.argv[2];
+    ilibDir = process.argv[2];
 }
 
-console.log("gencurrency - generate currency information files.\n" + "Copyright (c) 2016 LGE\n");
+if (process.argv.length > 3) {
+    toDir = process.argv[3];
+}
+
+console.log("gencurrency - generate currency information files.\n" + "Copyright © 2016, 2018-2020, JEDLSoft\n");
 console.log("output dir: " + toDir + "\n");
 
-var ilibDataFileName = path.join(toDir, "currency.json");
+var ilibDataFileName = path.join(ilibDir, "currency.json");
 
 if (!fs.existsSync(toDir)) {
     common.makeDirs(toDir);
@@ -135,13 +141,19 @@ var currencyObj = {}; // for saving currency.jf in each directory
 var currencyInfoObj = {}; // currency information object for currency.json
 var filename, nameAndSign = [], cur = [];
 
+var rootCurrency = {"currency": "USD"}
+fs.writeFileSync(path.join(toDir, "currency.jf"), JSON.stringify(rootCurrency, true, 4), "utf-8");
+
+var zxxPath = path.join(toDir, "zxx");
+if (!fs.existsSync(zxxPath)) {
+    mkdirs(zxxPath);
+}
+fs.writeFileSync(path.join(zxxPath, "currency.jf"), JSON.stringify(rootCurrency, true, 4), "utf-8");
+
 for (var region in currencyData.region) {
     if (region && currencyData.region[region]) {
-        if (region == "150") { // 150 code: europe
-            continue;
-        } else {
-            filename = path.join(toDir, 'und', region);
-        }
+        filename = path.join(toDir, 'und', region);
+
         if (!fs.existsSync(filename)) {
             mkdirs(filename);
         }

--- a/tools/cldr/gennumfmt.js
+++ b/tools/cldr/gennumfmt.js
@@ -2,7 +2,7 @@
  * gennumfmt.js - ilib tool to generate the  number json fragments from
  * the CLDR data files
  *
- * Copyright © 2013-2018, LGE
+ * Copyright © 2013-2018, 2020 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,16 +34,16 @@ var makeDirs = common.makeDirs;
 var isEmpty = common.isEmpty;
 
 function usage() {
-    console.log("Usage: gennumfmts [-h] [locale_data_dir]\n" +
+    console.log("Usage: gennumfmts [-h] [toDir]\n" +
         "Generate number formats information files.\n\n" +
         "-h or --help\n" +
         "  this help\n" +
-        "locale_data_dir\n" +
-        "  the top level of the ilib locale data directory\n");
+        "toDir\n" +
+        "  directory to output the currency.jf json files. Default: current dir.\n");
     process.exit(1);
 }
 
-var localeDirName;
+var toDir;
 
 process.argv.forEach(function (val, index, array) {
     if (val === "-h" || val === "--help") {
@@ -51,22 +51,27 @@ process.argv.forEach(function (val, index, array) {
     }
 });
 
-localeDirName = process.argv[2] || ".";
+if (process.argv.length <= 2) {
+    console.error('Error: not enough arguments.\n');
+    usage();
+} else {
+    toDir = process.argv[2];
+}
 
 console.log("gennumfmts - generate number formats information files.\n" +
-    "Copyright (c) 2013-2018 LGE\n");
+    "Copyright (c) 2013-2018, 2020 JEDLSoft\n");
 
-console.log("locale dir: " + localeDirName + "\n");
+console.log("Output dir: " + toDir + "\n");
 
-if (!fs.existsSync(localeDirName)) {
-    util.error("Could not access locale data directory " + localeDirName);
+if (!fs.existsSync(toDir)) {
+    util.error("Could not access Output directory " + toDir);
     usage();
 }
 
 var filename, root, json, suppData, languageData, digitsData, scripts = {};
 
 function calcLocalePath(language, script, region, filename) {
-    var pathName = localeDirName;
+    var pathName = toDir;
     if (language) {
         pathName = path.join(pathName, language);
     }


### PR DESCRIPTION
### Checklist

* [ ] At least one test case is included for this feature or bug fix.
* [ ] `ReleaseNotes` has added or is not needed.
* [ ] This PR has passed all of the test cases on `Nodejs` and `Chrome Browser`.
* [ ] This PR has passed all of the test cases on `QT/QML`.
* [ ] This is an API breaking change.
* [ ] Requires a major version change.


### Issue Resolved / Feature Added
* Updated `currency.json`, `currency.jf` and `numfmt.jf` files to CLDR 36
* Fixed `gennumfmt.js` and `gencurrencies.js` tool code to use correctly.
* `root/currency.jf, zxx/currency.jf` will generate automatically even though CLDR doesn't have information.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

### Links
[//]: # (Related issues, references)
