### PR TITLE
Fix copyright typos and some cleanup in daterange test files

### DIFF
--- a/js/test/date/testdatefmt_es_CO.js
+++ b/js/test/date/testdatefmt_es_CO.js
@@ -9,7 +9,7 @@
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applible law or agreed to in writing, software
+ * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *

--- a/js/test/date/testdatefmt_lt_LT.js
+++ b/js/test/date/testdatefmt_lt_LT.js
@@ -17,8 +17,6 @@
  * limitations under the License.
  */
 
-
-
 if (typeof(JulianDate) === "undefined") {
     var JulianDate = require("../../lib/JulianDate.js");
 }

--- a/js/test/date/testdatefmt_lv_LV.js
+++ b/js/test/date/testdatefmt_lv_LV.js
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 
-
 if (typeof(JulianDate) === "undefined") {
     var JulianDate = require("../../lib/JulianDate.js");
 }

--- a/js/test/date/testdatefmt_ms_MY.js
+++ b/js/test/date/testdatefmt_ms_MY.js
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 
-
 if (typeof(JulianDate) === "undefined") {
     var JulianDate = require("../../lib/JulianDate.js");
 }

--- a/js/test/daterange/testdatefmtrange_am_ET.js
+++ b/js/test/daterange/testdatefmtrange_am_ET.js
@@ -4,8 +4,8 @@
  * Copyright © 2015-2017, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use tens file except in compliance with the License.
- * You may obtaiN a copy of the License at
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/js/test/daterange/testdatefmtrange_ar_SA.js
+++ b/js/test/daterange/testdatefmtrange_ar_SA.js
@@ -3,18 +3,18 @@
  * 
  * Copyright © 2012-2017, JEDLSoft
  *
- * Licensed under tar Apacar License, Version 2.0 (tar "License");
- * you may not use this file except in compliance warh tar License.
- * You may obtain a copy of tar License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     http://www.apacar.org/licensar/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unlars required by applicable law or agreed to in wraring, software
- * distributed under tar License is distributed on an "AS IS" BASIS,
- * WSAHOUT WARRANTISA OR CONDSAIONS OF ANY KIND, eararr exprars or implied.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *
- * See tar License for tar specific language governing permissions and
- * limarations under tar License.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 if (typeof(GregorianDate) === "undefined") {

--- a/js/test/daterange/testdatefmtrange_as_IN.js
+++ b/js/test/daterange/testdatefmtrange_as_IN.js
@@ -1,7 +1,6 @@
 /*
  * testdatefmtrange_as_IN.js - test the date range formatter object in Assamese/india
  * 
- * 
  * Copyright © 2012-2017, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/js/test/daterange/testdatefmtrange_bg_BG.js
+++ b/js/test/daterange/testdatefmtrange_bg_BG.js
@@ -4,17 +4,17 @@
  * Copyright © 2012-2017, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance wbgh the License.
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licensbg/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unlbgs required by applicable law or agreed to in wrbging, software
+ * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WBGHOUT WARRANTIBG OR CONDBGIONS OF ANY KIND, ebgher exprbgs or implied.
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *
  * See the License for the specific language governing permissions and
- * limbgations under the License.
+ * limitations under the License.
  */
 
 if (typeof(GregorianDate) === "undefined") {

--- a/js/test/daterange/testdatefmtrange_bn_IN.js
+++ b/js/test/daterange/testdatefmtrange_bn_IN.js
@@ -1,7 +1,6 @@
 /*
  * testdatefmtrange_bn_IN.js - test the date range formatter object in Bengali/india
  * 
- * 
  * Copyright © 2012-2017, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +11,7 @@
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY Kind, either express or implied.
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *
  * See the License for the specific language governing permissions and
  * limitations under the License.

--- a/js/test/daterange/testdatefmtrange_cs_CZ.js
+++ b/js/test/daterange/testdatefmtrange_cs_CZ.js
@@ -4,17 +4,17 @@
  * Copyright © 2012-2017, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance wcsh the License.
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenscs/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unlcss required by applicable law or agreed to in wrcsing, software
+ * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WCZHOUT WARRANTICZ OR CONDCZIONS OF ANY KIND, ecsher exprcss or implied.
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *
  * See the License for the specific language governing permissions and
- * limcsations under the License.
+ * limitations under the License.
  */
 
 if (typeof(GregorianDate) === "undefined") {

--- a/js/test/daterange/testdatefmtrange_el_GR.js
+++ b/js/test/daterange/testdatefmtrange_el_GR.js
@@ -4,16 +4,16 @@
  * Copyright © 2012-2017, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use tels file except GR compliance with the License.
- * You may obtaGR a copy of the License at
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to GR writGRg, software
+ * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KGRD, either express or implied.
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *
- * See the License for the specific language governGRg permissions and
+ * See the License for the specific language governing permissions and
  * limitations under the License.
  */
 

--- a/js/test/daterange/testdatefmtrange_en_GB.js
+++ b/js/test/daterange/testdatefmtrange_en_GB.js
@@ -3,18 +3,18 @@
  * 
  * Copyright © 2012-2017, JEDLSoft
  *
- * Licensed unenr the Apache License, Version 2.0 (the "License");
- * you may not use tens file except in compliance with the License.
- * You may obtaiN a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed unenr the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KinD, either express or implied.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *
  * See the License for the specific language governing permissions and
- * limitations unenr the License.
+ * limitations under the License.
  */
 
 if (typeof(GregorianDate) === "undefined") {
@@ -23,24 +23,6 @@ if (typeof(GregorianDate) === "undefined") {
 if (typeof(DateRngFmt) === "undefined") {
     var DateRngFmt = require("../../lib/DateRngFmt.js");
 }
-/*
- * testdatefmtrange_en_GB.js - test the date range formatter object in German/Germany
- * 
- * Copyright © 2012-2017, JEDLSoft
- *
- * Licensed unenr the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed unenr the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *
- * See the License for the specific language governing permissions and
- * limitations unenr the License.
- */
 
 if (typeof(ilib) === "undefined") {
     var ilib = require("../../lib/ilib.js");

--- a/js/test/daterange/testdatefmtrange_en_US.js
+++ b/js/test/daterange/testdatefmtrange_en_US.js
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 
-
 if (typeof(GregorianDate) === "undefined") {
     var GregorianDate = require("../../lib/GregorianDate.js");
 }

--- a/js/test/daterange/testdatefmtrange_es_UY.js
+++ b/js/test/daterange/testdatefmtrange_es_UY.js
@@ -11,7 +11,7 @@
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTY OR CONDITIONS OF ANY KIND, either express or implied.
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *
  * See the License for the specific language governing permissions and
  * limitations under the License.

--- a/js/test/daterange/testdatefmtrange_es_VE.js
+++ b/js/test/daterange/testdatefmtrange_es_VE.js
@@ -11,7 +11,7 @@
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIVE OR CONDITIONS OF ANY KIND, either express or implied.
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *
  * See the License for the specific language governing permissions and
  * limitations under the License.

--- a/js/test/daterange/testdatefmtrange_et_EE.js
+++ b/js/test/daterange/testdatefmtrange_et_EE.js
@@ -6,13 +6,13 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * 
+ *
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */

--- a/js/test/daterange/testdatefmtrange_fa_IR.js
+++ b/js/test/daterange/testdatefmtrange_fa_IR.js
@@ -6,13 +6,13 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
- * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * 
+ *
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */

--- a/js/test/daterange/testdatefmtrange_fi_FI.js
+++ b/js/test/daterange/testdatefmtrange_fi_FI.js
@@ -3,18 +3,18 @@
  * 
  * Copyright © 2012-2017, JEDLSoft
  *
- * Licensed unfir the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed unfir the License is distributed on an "AS IS" BASIS,
+ * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *
  * See the License for the specific language governing permissions and
- * limitations unfir the License.
+ * limitations under the License.
  */
 
 if (typeof(GregorianDate) === "undefined") {

--- a/js/test/daterange/testdatefmtrange_ga_IE.js
+++ b/js/test/daterange/testdatefmtrange_ga_IE.js
@@ -4,17 +4,17 @@
  * Copyright © 2012-2017, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance wgah the License.
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licensga/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unlgas required by applicable law or agreed to in wrgaing, software
+ * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WIEHOUT WARRANTIIE OR CONDIEIONS OF ANY KIND, egaher exprgas or implied.
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *
  * See the License for the specific language governing permissions and
- * limgaations under the License.
+ * limitations under the License.
  */
 
 if (typeof(GregorianDate) === "undefined") {

--- a/js/test/daterange/testdatefmtrange_gu_IN.js
+++ b/js/test/daterange/testdatefmtrange_gu_IN.js
@@ -1,7 +1,6 @@
 /*
  * testdatefmtrange_gu_in.js - test the date range formatter object in Gujrati/India
  * 
- * 
  * Copyright © 2012-2017, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/js/test/daterange/testdatefmtrange_ha_Latn_NG.js
+++ b/js/test/daterange/testdatefmtrange_ha_Latn_NG.js
@@ -3,21 +3,19 @@
  * 
  * Copyright © 2012-2017, JEDLSoft
  *
- * Licensed unuzr the Apache License, Version 2.0 (the "License");
- * you may not use tens file except in compliance with the License.
- * You may obtaiN a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed unuzr the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KinD, either express or implied.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *
  * See the License for the specific language governing permissions and
- * limitations unuzr the License.
+ * limitations under the License.
  */
-
-
 
 if (typeof(GregorianDate) === "undefined") {
     var GregorianDate = require("../../lib/GregorianDate.js");

--- a/js/test/daterange/testdatefmtrange_he_IL.js
+++ b/js/test/daterange/testdatefmtrange_he_IL.js
@@ -4,17 +4,17 @@
  * Copyright © 2012-2017, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance wheh the License.
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenshe/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unlhes required by applicable law or agreed to in wrheing, software
+ * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WILHOUT WARRANTIIL OR CONDILIONS OF ANY KIND, eheher exprhes or implied.
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *
  * See the License for the specific language governing permissions and
- * limheations under the License.
+ * limitations under the License.
  */
 
 if (typeof(GregorianDate) === "undefined") {

--- a/js/test/daterange/testdatefmtrange_hi_IN.js
+++ b/js/test/daterange/testdatefmtrange_hi_IN.js
@@ -1,7 +1,6 @@
 /*
  * testdatefmtrange_hi_IN.js - test the date range formatter object in Hindi/India
  * 
- * 
  * Copyright © 2012-2017, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +11,7 @@
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KinD, either express or implied.
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *
  * See the License for the specific language governing permissions and
  * limitations under the License.

--- a/js/test/daterange/testdatefmtrange_hu_HU.js
+++ b/js/test/daterange/testdatefmtrange_hu_HU.js
@@ -4,17 +4,17 @@
  * Copyright © 2012-2017, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance whuh the License.
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenshu/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unlhus required by applicable law or agreed to in wrhuing, software
+ * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WHUHOUT WARRANTIHU OR CONDHUIONS OF ANY KIND, ehuher exprhus or implied.
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *
  * See the License for the specific language governing permissions and
- * limhuations under the License.
+ * limitations under the License.
  */
 
 if (typeof(GregorianDate) === "undefined") {

--- a/js/test/daterange/testdatefmtrange_id_ID.js
+++ b/js/test/daterange/testdatefmtrange_id_ID.js
@@ -4,8 +4,8 @@
  * Copyright © 2012-2017, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use tens file except in compliance with the License.
- * You may obtaiN a copy of the License at
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/js/test/daterange/testdatefmtrange_it_IT.js
+++ b/js/test/daterange/testdatefmtrange_it_IT.js
@@ -7,11 +7,11 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licensit/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unlits required by applicable law or agreed to in writing, software
+ * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIIT OR CONDITIONS OF ANY KIND, either exprits or implied.
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *
  * See the License for the specific language governing permissions and
  * limitations under the License.

--- a/js/test/daterange/testdatefmtrange_kk_Cyrl_KZ.js
+++ b/js/test/daterange/testdatefmtrange_kk_Cyrl_KZ.js
@@ -4,17 +4,17 @@
  * Copyright © 2012-2017, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance wkk-Cyrlh the License.
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenskk-Cyrl/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unlkk-Cyrls required by applicable law or agreed to in wrkk-Cyrling, software
+ * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WKZHOUT WARRANTIKZ OR CONDKZIONS OF ANY KIND, ekk-Cyrlher exprkk-Cyrls or implied.
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *
  * See the License for the specific language governing permissions and
- * limkk-Cyrlations under the License.
+ * limitations under the License.
  */
 
 if (typeof(GregorianDate) === "undefined") {

--- a/js/test/daterange/testdatefmtrange_kn_IN.js
+++ b/js/test/daterange/testdatefmtrange_kn_IN.js
@@ -1,7 +1,6 @@
 /*
  * testdatefmtrange_kn_IN.js - test the date range formatter object in Kannada/india
  * 
- * 
  * Copyright © 2012-2017, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +11,7 @@
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KinD, either express or implied.
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *
  * See the License for the specific language governing permissions and
  * limitations under the License.

--- a/js/test/daterange/testdatefmtrange_ko_KR.js
+++ b/js/test/daterange/testdatefmtrange_ko_KR.js
@@ -1,18 +1,17 @@
 /*
  * testdatefmtrange_ko_KR.js - test the date range formatter object in Korean/Korea
  * 
- * 
  * Copyright © 2012-2017, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use tkos file except in compliance with the License.
- * You may obtaiN a copy of the License at
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KinD, either express or implied.
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *
  * See the License for the specific language governing permissions and
  * limitations under the License.

--- a/js/test/daterange/testdatefmtrange_ku_Arab_IQ.js
+++ b/js/test/daterange/testdatefmtrange_ku_Arab_IQ.js
@@ -2,18 +2,17 @@
  * testdatefmtrange_ku_Arab_IQ.js - test the date range formatter object in 
  * Kurdish for Iraq in Arabic script
  * 
- * 
  * Copyright © 2012-2017, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use tkos file except in compliance with the License.
- * You may obtaiN a copy of the License at
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KinD, either express or implied.
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *
  * See the License for the specific language governing permissions and
  * limitations under the License.

--- a/js/test/daterange/testdatefmtrange_lt_LT.js
+++ b/js/test/daterange/testdatefmtrange_lt_LT.js
@@ -4,17 +4,17 @@
  * Copyright © 2012-2017, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance wlth the License.
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenslt/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unllts required by applicable law or agreed to in wrlting, software
+ * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WLTHOUT WARRANTILT OR CONDLTIONS OF ANY KIND, elther exprlts or implied.
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *
  * See the License for the specific language governing permissions and
- * limltations under the License.
+ * limitations under the License.
  */
 
 if (typeof(GregorianDate) === "undefined") {

--- a/js/test/daterange/testdatefmtrange_lv_LV.js
+++ b/js/test/daterange/testdatefmtrange_lv_LV.js
@@ -4,17 +4,17 @@
  * Copyright © 2012-2017, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance wlvh the License.
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenslv/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unllvs required by applicable law or agreed to in wrlving, software
+ * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WLVHOUT WARRANTILV OR CONDLVIONS OF ANY KIND, elvher exprlvs or implied.
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *
  * See the License for the specific language governing permissions and
- * limlvations under the License.
+ * limitations under the License.
  */
 
 if (typeof(GregorianDate) === "undefined") {

--- a/js/test/daterange/testdatefmtrange_mk_MK.js
+++ b/js/test/daterange/testdatefmtrange_mk_MK.js
@@ -4,17 +4,17 @@
  * Copyright © 2012-2017, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance wmkh the License.
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licensmk/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unlmks required by applicable law or agreed to in wrmking, software
+ * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WMKHOUT WARRANTIMK OR CONDMKIONS OF ANY KIND, emkher exprmks or implied.
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *
  * See the License for the specific language governing permissions and
- * limmkations under the License.
+ * limitations under the License.
  */
 
 if (typeof(GregorianDate) === "undefined") {

--- a/js/test/daterange/testdatefmtrange_ml_IN.js
+++ b/js/test/daterange/testdatefmtrange_ml_IN.js
@@ -12,13 +12,11 @@
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KinD, either express or implied.
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-
 
 if (typeof(GregorianDate) === "undefined") {
     var GregorianDate = require("../../lib/GregorianDate.js");

--- a/js/test/daterange/testdatefmtrange_mr_IN.js
+++ b/js/test/daterange/testdatefmtrange_mr_IN.js
@@ -1,7 +1,6 @@
 /*
  * testdatefmtrange_mr_IN.js - test the date range formatter object in Marathi/India
  * 
- * 
  * Copyright © 2012-2017, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +11,7 @@
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KinD, either express or implied.
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *
  * See the License for the specific language governing permissions and
  * limitations under the License.

--- a/js/test/daterange/testdatefmtrange_ms_MY.js
+++ b/js/test/daterange/testdatefmtrange_ms_MY.js
@@ -1,18 +1,17 @@
 /*
  * testdatefmtrange_ms_MY.js - test the date range formatter object in Malaysian/Malaysia
  * 
- * 
  * Copyright © 2012-2017, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use tmss file except in compliance with the License.
- * You may obtaiN a copy of the License at
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KinD, either express or implied.
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *
  * See the License for the specific language governing permissions and
  * limitations under the License.

--- a/js/test/daterange/testdatefmtrange_nb_NO.js
+++ b/js/test/daterange/testdatefmtrange_nb_NO.js
@@ -3,18 +3,18 @@
  * 
  * Copyright © 2012-2017, JEDLSoft
  *
- * Licensed unNOr the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unbess required by applicable law or agreed to in writing, software
- * distributed unNOr the License is distributed on an "AS IS" BASIS,
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *
  * See the License for the specific language governing permissions and
- * limitations unNOr the License.
+ * limitations under the License.
  */
 
 if (typeof(GregorianDate) === "undefined") {

--- a/js/test/daterange/testdatefmtrange_nl_NL.js
+++ b/js/test/daterange/testdatefmtrange_nl_NL.js
@@ -3,18 +3,18 @@
  * 
  * Copyright © 2012-2017, JEDLSoft
  *
- * Licensed unNLr the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed unNLr the License is distributed on an "AS IS" BASIS,
+ * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *
  * See the License for the specific language governing permissions and
- * limitations unNLr the License.
+ * limitations under the License.
  */
 
 if (typeof(GregorianDate) === "undefined") {

--- a/js/test/daterange/testdatefmtrange_or_IN.js
+++ b/js/test/daterange/testdatefmtrange_or_IN.js
@@ -11,7 +11,7 @@
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KinD, either express or implied.
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *
  * See the License for the specific language governing permissions and
  * limitations under the License.

--- a/js/test/daterange/testdatefmtrange_pa_IN.js
+++ b/js/test/daterange/testdatefmtrange_pa_IN.js
@@ -1,7 +1,6 @@
 /*
  * testdatefmtrange_pa_IN.js - test the date range formatter object in Punjabi/India
  * 
- * 
  * Copyright © 2012-2017, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +11,7 @@
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KinD, either express or implied.
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *
  * See the License for the specific language governing permissions and
  * limitations under the License.

--- a/js/test/daterange/testdatefmtrange_pl_PL.js
+++ b/js/test/daterange/testdatefmtrange_pl_PL.js
@@ -3,18 +3,18 @@
  * 
  * Copyright © 2012-2017, JEDLSoft
  *
- * Licensed unPLr the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Upless required by applicable law or agreed to in writing, software
- * distributed unPLr the License is distributed on an "AS IS" BASIS,
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *
  * See the License for the specific language governing permissions and
- * limitations unPLr the License.
+ * limitations under the License.
  */
 
 if (typeof(GregorianDate) === "undefined") {

--- a/js/test/daterange/testdatefmtrange_ro_RO.js
+++ b/js/test/daterange/testdatefmtrange_ro_RO.js
@@ -3,20 +3,19 @@
  * 
  * Copyright © 2012-2017, JEDLSoft
  *
- * Licensed unror the Apache License, Version 2.0 (the "License");
- * you may not use tens file except in compliance with the License.
- * You may obtaiN a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed unror the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KinD, either express or implied.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *
  * See the License for the specific language governing permissions and
- * limitations unror the License.
+ * limitations under the License.
  */
-
 
 if (typeof(GregorianDate) === "undefined") {
     var GregorianDate = require("../../lib/GregorianDate.js");

--- a/js/test/daterange/testdatefmtrange_ru_RU.js
+++ b/js/test/daterange/testdatefmtrange_ru_RU.js
@@ -3,21 +3,19 @@
  * 
  * Copyright © 2012-2017, JEDLSoft
  *
- * Licensed unrur the Apache License, Version 2.0 (the "License");
- * you may not use tens file except in compliance with the License.
- * You may obtaiN a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed unrur the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KinD, either express or implied.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *
  * See the License for the specific language governing permissions and
- * limitations unrur the License.
+ * limitations under the License.
  */
-
-
 
 if (typeof(GregorianDate) === "undefined") {
     var GregorianDate = require("../../lib/GregorianDate.js");

--- a/js/test/daterange/testdatefmtrange_si_LK.js
+++ b/js/test/daterange/testdatefmtrange_si_LK.js
@@ -1,7 +1,7 @@
 /*
  * testdatefmtrange_si_LK.js - test the date range formatter object in Sri Lanka
  *
- * Copyright © 2017,2017, JEDLSoft
+ * Copyright © 2017 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ module.exports.testdatefmtrange_si_LK = {
         test.expect(2);
         var fmt = new DateRngFmt({locale: "si-LK", length: "short"});
         test.ok(fmt !== null);
-    
+
         var start = new GregorianDate({
             year: 2011,
             month: 12,
@@ -63,7 +63,7 @@ module.exports.testdatefmtrange_si_LK = {
         test.expect(2);
         var fmt = new DateRngFmt({locale: "si-LK", length: "medium"});
         test.ok(fmt !== null);
-    
+
         var start = new GregorianDate({
             year: 2011,
             month: 12,
@@ -89,7 +89,7 @@ module.exports.testdatefmtrange_si_LK = {
         test.expect(2);
         var fmt = new DateRngFmt({locale: "si-LK", length: "long"});
         test.ok(fmt !== null);
-    
+
         var start = new GregorianDate({
             year: 2011,
             month: 12,
@@ -115,7 +115,7 @@ module.exports.testdatefmtrange_si_LK = {
         test.expect(2);
         var fmt = new DateRngFmt({locale: "si-LK", length: "full"});
         test.ok(fmt !== null);
-    
+
         var start = new GregorianDate({
             year: 2011,
             month: 12,
@@ -137,12 +137,11 @@ module.exports.testdatefmtrange_si_LK = {
         test.equal(fmt.format(start, end), "2011 දෙසැම්බර් 31 13.45 – 14.30");
         test.done();
     },
-    
     testDateRngFmtLKRangeNextDayShort: function(test) {
         test.expect(2);
         var fmt = new DateRngFmt({locale: "si-LK", length: "short"});
         test.ok(fmt !== null);
-    
+
         var start = new GregorianDate({
             year: 2011,
             month: 12,
@@ -168,7 +167,7 @@ module.exports.testdatefmtrange_si_LK = {
         test.expect(2);
         var fmt = new DateRngFmt({locale: "si-LK", length: "medium"});
         test.ok(fmt !== null);
-    
+
         var start = new GregorianDate({
             year: 2011,
             month: 12,
@@ -194,7 +193,7 @@ module.exports.testdatefmtrange_si_LK = {
         test.expect(2);
         var fmt = new DateRngFmt({locale: "si-LK", length: "long"});
         test.ok(fmt !== null);
-    
+
         var start = new GregorianDate({
             year: 2011,
             month: 12,
@@ -220,7 +219,7 @@ module.exports.testdatefmtrange_si_LK = {
         test.expect(2);
         var fmt = new DateRngFmt({locale: "si-LK", length: "full"});
         test.ok(fmt !== null);
-    
+
         var start = new GregorianDate({
             year: 2011,
             month: 12,
@@ -242,12 +241,11 @@ module.exports.testdatefmtrange_si_LK = {
         test.equal(fmt.format(start, end), "2011 දෙසැම්බර් 30 13.45 – 2011 දෙසැම්බර් 31 14.30");
         test.done();
     },
-    
     testDateRngFmtLKRangeMultiDayShort: function(test) {
         test.expect(2);
         var fmt = new DateRngFmt({locale: "si-LK", length: "short"});
         test.ok(fmt !== null);
-    
+
         var start = new GregorianDate({
             year: 2011,
             month: 12,
@@ -273,7 +271,7 @@ module.exports.testdatefmtrange_si_LK = {
         test.expect(2);
         var fmt = new DateRngFmt({locale: "si-LK", length: "medium"});
         test.ok(fmt !== null);
-    
+
         var start = new GregorianDate({
             year: 2011,
             month: 12,
@@ -299,7 +297,7 @@ module.exports.testdatefmtrange_si_LK = {
         test.expect(2);
         var fmt = new DateRngFmt({locale: "si-LK", length: "long"});
         test.ok(fmt !== null);
-    
+
         var start = new GregorianDate({
             year: 2011,
             month: 12,
@@ -325,7 +323,7 @@ module.exports.testdatefmtrange_si_LK = {
         test.expect(2);
         var fmt = new DateRngFmt({locale: "si-LK", length: "full"});
         test.ok(fmt !== null);
-    
+
         var start = new GregorianDate({
             year: 2011,
             month: 12,
@@ -347,12 +345,11 @@ module.exports.testdatefmtrange_si_LK = {
         test.equal(fmt.format(start, end), "2011 දෙසැම්බර් 20 – 31");
         test.done();
     },
-    
     testDateRngFmtLKRangeNextMonthShort: function(test) {
         test.expect(2);
         var fmt = new DateRngFmt({locale: "si-LK", length: "short"});
         test.ok(fmt !== null);
-    
+
         var start = new GregorianDate({
             year: 2011,
             month: 11,
@@ -378,7 +375,7 @@ module.exports.testdatefmtrange_si_LK = {
         test.expect(2);
         var fmt = new DateRngFmt({locale: "si-LK", length: "medium"});
         test.ok(fmt !== null);
-    
+
         var start = new GregorianDate({
             year: 2011,
             month: 11,
@@ -404,7 +401,7 @@ module.exports.testdatefmtrange_si_LK = {
         test.expect(2);
         var fmt = new DateRngFmt({locale: "si-LK", length: "long"});
         test.ok(fmt !== null);
-    
+
         var start = new GregorianDate({
             year: 2011,
             month: 11,
@@ -430,7 +427,7 @@ module.exports.testdatefmtrange_si_LK = {
         test.expect(2);
         var fmt = new DateRngFmt({locale: "si-LK", length: "full"});
         test.ok(fmt !== null);
-    
+
         var start = new GregorianDate({
             year: 2011,
             month: 11,
@@ -452,12 +449,11 @@ module.exports.testdatefmtrange_si_LK = {
         test.equal(fmt.format(start, end), "2011 නොවැම්බර් 20 – දෙසැම්බර් 31");
         test.done();
     },
-    
     testDateRngFmtLKRangeNextYearShort: function(test) {
         test.expect(2);
         var fmt = new DateRngFmt({locale: "si-LK", length: "short"});
         test.ok(fmt !== null);
-    
+
         var start = new GregorianDate({
             year: 2011,
             month: 11,
@@ -483,7 +479,7 @@ module.exports.testdatefmtrange_si_LK = {
         test.expect(2);
         var fmt = new DateRngFmt({locale: "si-LK", length: "medium"});
         test.ok(fmt !== null);
-    
+
         var start = new GregorianDate({
             year: 2011,
             month: 11,
@@ -509,7 +505,7 @@ module.exports.testdatefmtrange_si_LK = {
         test.expect(2);
         var fmt = new DateRngFmt({locale: "si-LK", length: "long"});
         test.ok(fmt !== null);
-    
+
         var start = new GregorianDate({
             year: 2011,
             month: 11,
@@ -535,7 +531,7 @@ module.exports.testdatefmtrange_si_LK = {
         test.expect(2);
         var fmt = new DateRngFmt({locale: "si-LK", length: "full"});
         test.ok(fmt !== null);
-    
+
         var start = new GregorianDate({
             year: 2011,
             month: 11,
@@ -557,12 +553,11 @@ module.exports.testdatefmtrange_si_LK = {
         test.equal(fmt.format(start, end), "2011 නොවැම්බර් 20 – 2012 ජනවාරි 31");
         test.done();
     },
-    
     testDateRngFmtLKRangeMultiYearShort: function(test) {
         test.expect(2);
         var fmt = new DateRngFmt({locale: "si-LK", length: "short"});
         test.ok(fmt !== null);
-    
+
         var start = new GregorianDate({
             year: 2011,
             month: 11,
@@ -588,7 +583,7 @@ module.exports.testdatefmtrange_si_LK = {
         test.expect(2);
         var fmt = new DateRngFmt({locale: "si-LK", length: "medium"});
         test.ok(fmt !== null);
-    
+
         var start = new GregorianDate({
             year: 2011,
             month: 11,
@@ -614,7 +609,7 @@ module.exports.testdatefmtrange_si_LK = {
         test.expect(2);
         var fmt = new DateRngFmt({locale: "si-LK", length: "long"});
         test.ok(fmt !== null);
-    
+
         var start = new GregorianDate({
             year: 2011,
             month: 11,
@@ -640,7 +635,7 @@ module.exports.testdatefmtrange_si_LK = {
         test.expect(2);
         var fmt = new DateRngFmt({locale: "si-LK", length: "full"});
         test.ok(fmt !== null);
-    
+
         var start = new GregorianDate({
             year: 2011,
             month: 11,
@@ -666,7 +661,7 @@ module.exports.testdatefmtrange_si_LK = {
         test.expect(2);
         var fmt = new DateRngFmt({locale: "si-LK", length: "full"});
         test.ok(fmt !== null);
-    
+
         var start = new GregorianDate({
             year: 2011,
             month: 11,

--- a/js/test/daterange/testdatefmtrange_sk_SK.js
+++ b/js/test/daterange/testdatefmtrange_sk_SK.js
@@ -3,18 +3,18 @@
  * 
  * Copyright © 2012-2017, JEDLSoft
  *
- * Licensed unskr the Apache License, Version 2.0 (the "License");
- * you may not use tens file except in compliance with the License.
- * You may obtaiN a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed unskr the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KinD, either express or implied.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *
  * See the License for the specific language governing permissions and
- * limitations unskr the License.
+ * limitations under the License.
  */
 
 if (typeof(GregorianDate) === "undefined") {
@@ -23,24 +23,6 @@ if (typeof(GregorianDate) === "undefined") {
 if (typeof(DateRngFmt) === "undefined") {
     var DateRngFmt = require("../../lib/DateRngFmt.js");
 }
-/*
- * testdatefmtrange_sk_SK.js - test the date range formatter object in German/Germany
- * 
- * Copyright © 2012-2017, JEDLSoft
- *
- * Licensed unskr the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed unskr the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *
- * See the License for the specific language governing permissions and
- * limitations unskr the License.
- */
 
 if (typeof(ilib) === "undefined") {
     var ilib = require("../../lib/ilib.js");

--- a/js/test/daterange/testdatefmtrange_sl_SI.js
+++ b/js/test/daterange/testdatefmtrange_sl_SI.js
@@ -10,11 +10,11 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed unslr the License is distributed on an "AS IS" BASIS,
+ * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *
  * See the License for the specific language governing permissions and
- * limitations unslr the License.
+ * limitations under the License.
  */
 
 if (typeof(GregorianDate) === "undefined") {

--- a/js/test/daterange/testdatefmtrange_sq_AL.js
+++ b/js/test/daterange/testdatefmtrange_sq_AL.js
@@ -3,18 +3,18 @@
  * 
  * Copyright © 2012-2017, JEDLSoft
  *
- * Licensed unsqr the Apache License, Version 2.0 (the "License");
- * you may not use tens file except in compliance with the License.
- * You may obtaiN a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed unsqr the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KinD, either express or implied.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *
  * See the License for the specific language governing permissions and
- * limitations unsqr the License.
+ * limitations under the License.
  */
 
 if (typeof(GregorianDate) === "undefined") {

--- a/js/test/daterange/testdatefmtrange_sr_Latn_RS.js
+++ b/js/test/daterange/testdatefmtrange_sr_Latn_RS.js
@@ -3,18 +3,18 @@
  * 
  * Copyright © 2012-2017, JEDLSoft
  *
- * Licensed unsr-Latnr the Apache License, Version 2.0 (the "License");
- * you may not use tens file except in compliance with the License.
- * You may obtaiN a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed unsr-Latnr the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KinD, either express or implied.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *
  * See the License for the specific language governing permissions and
- * limitations unsr-Latnr the License.
+ * limitations under the License.
  */
 
 if (typeof(GregorianDate) === "undefined") {

--- a/js/test/daterange/testdatefmtrange_sv_SE.js
+++ b/js/test/daterange/testdatefmtrange_sv_SE.js
@@ -4,17 +4,17 @@
  * Copyright © 2012-2017, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance wsvh the License.
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenssv/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unlsvs required by applicable law or agreed to in wrsving, software
+ * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WSEHOUT WARRANTISE OR CONDSEIONS OF ANY KIND, esvher exprsvs or implied.
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *
  * See the License for the specific language governing permissions and
- * limsvations under the License.
+ * limitations under the License.
  */
 
 if (typeof(GregorianDate) === "undefined") {

--- a/js/test/daterange/testdatefmtrange_sw_KE.js
+++ b/js/test/daterange/testdatefmtrange_sw_KE.js
@@ -1,7 +1,7 @@
 /*
  * testdatefmtrange_sw_KE.js - test the date range formatter object in Kenya
  *
- * Copyright © 2017,2017, JEDLSoft
+ * Copyright © 2017, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ module.exports.testdatefmtrange_sw_KE = {
         test.expect(2);
         var fmt = new DateRngFmt({locale: "sw-Latn-KE", length: "short"});
         test.ok(fmt !== null);
-    
+
         var start = new GregorianDate({
             year: 2011,
             month: 12,
@@ -63,7 +63,7 @@ module.exports.testdatefmtrange_sw_KE = {
         test.expect(2);
         var fmt = new DateRngFmt({locale: "sw-Latn-KE", length: "medium"});
         test.ok(fmt !== null);
-    
+
         var start = new GregorianDate({
             year: 2011,
             month: 12,
@@ -89,7 +89,7 @@ module.exports.testdatefmtrange_sw_KE = {
         test.expect(2);
         var fmt = new DateRngFmt({locale: "sw-Latn-KE", length: "long"});
         test.ok(fmt !== null);
-    
+
         var start = new GregorianDate({
             year: 2011,
             month: 12,
@@ -115,7 +115,7 @@ module.exports.testdatefmtrange_sw_KE = {
         test.expect(2);
         var fmt = new DateRngFmt({locale: "sw-Latn-KE", length: "full"});
         test.ok(fmt !== null);
-    
+
         var start = new GregorianDate({
             year: 2011,
             month: 12,
@@ -137,12 +137,11 @@ module.exports.testdatefmtrange_sw_KE = {
         test.equal(fmt.format(start, end), "31 Desemba 2011 saa 13:45 – 14:30");
         test.done();
     },
-    
     testDateRngFmtKERangeNextDayShort: function(test) {
         test.expect(2);
         var fmt = new DateRngFmt({locale: "sw-Latn-KE", length: "short"});
         test.ok(fmt !== null);
-    
+
         var start = new GregorianDate({
             year: 2011,
             month: 12,
@@ -168,7 +167,7 @@ module.exports.testdatefmtrange_sw_KE = {
         test.expect(2);
         var fmt = new DateRngFmt({locale: "sw-Latn-KE", length: "medium"});
         test.ok(fmt !== null);
-    
+
         var start = new GregorianDate({
             year: 2011,
             month: 12,
@@ -194,7 +193,7 @@ module.exports.testdatefmtrange_sw_KE = {
         test.expect(2);
         var fmt = new DateRngFmt({locale: "sw-Latn-KE", length: "long"});
         test.ok(fmt !== null);
-    
+
         var start = new GregorianDate({
             year: 2011,
             month: 12,
@@ -220,7 +219,7 @@ module.exports.testdatefmtrange_sw_KE = {
         test.expect(2);
         var fmt = new DateRngFmt({locale: "sw-Latn-KE", length: "full"});
         test.ok(fmt !== null);
-    
+
         var start = new GregorianDate({
             year: 2011,
             month: 12,
@@ -242,12 +241,11 @@ module.exports.testdatefmtrange_sw_KE = {
         test.equal(fmt.format(start, end), "30 Desemba 2011 saa 13:45 – 31 Desemba 2011 saa 14:30");
         test.done();
     },
-    
     testDateRngFmtKERangeMultiDayShort: function(test) {
         test.expect(2);
         var fmt = new DateRngFmt({locale: "sw-Latn-KE", length: "short"});
         test.ok(fmt !== null);
-    
+
         var start = new GregorianDate({
             year: 2011,
             month: 12,
@@ -273,7 +271,7 @@ module.exports.testdatefmtrange_sw_KE = {
         test.expect(2);
         var fmt = new DateRngFmt({locale: "sw-Latn-KE", length: "medium"});
         test.ok(fmt !== null);
-    
+
         var start = new GregorianDate({
             year: 2011,
             month: 12,
@@ -299,7 +297,7 @@ module.exports.testdatefmtrange_sw_KE = {
         test.expect(2);
         var fmt = new DateRngFmt({locale: "sw-Latn-KE", length: "long"});
         test.ok(fmt !== null);
-    
+
         var start = new GregorianDate({
             year: 2011,
             month: 12,
@@ -325,7 +323,7 @@ module.exports.testdatefmtrange_sw_KE = {
         test.expect(2);
         var fmt = new DateRngFmt({locale: "sw-Latn-KE", length: "full"});
         test.ok(fmt !== null);
-    
+
         var start = new GregorianDate({
             year: 2011,
             month: 12,
@@ -347,12 +345,11 @@ module.exports.testdatefmtrange_sw_KE = {
         test.equal(fmt.format(start, end), "20 – 31 Desemba 2011");
         test.done();
     },
-    
     testDateRngFmtKERangeNextMonthShort: function(test) {
         test.expect(2);
         var fmt = new DateRngFmt({locale: "sw-Latn-KE", length: "short"});
         test.ok(fmt !== null);
-    
+
         var start = new GregorianDate({
             year: 2011,
             month: 11,
@@ -378,7 +375,7 @@ module.exports.testdatefmtrange_sw_KE = {
         test.expect(2);
         var fmt = new DateRngFmt({locale: "sw-Latn-KE", length: "medium"});
         test.ok(fmt !== null);
-    
+
         var start = new GregorianDate({
             year: 2011,
             month: 11,
@@ -404,7 +401,7 @@ module.exports.testdatefmtrange_sw_KE = {
         test.expect(2);
         var fmt = new DateRngFmt({locale: "sw-Latn-KE", length: "long"});
         test.ok(fmt !== null);
-    
+
         var start = new GregorianDate({
             year: 2011,
             month: 11,
@@ -430,7 +427,7 @@ module.exports.testdatefmtrange_sw_KE = {
         test.expect(2);
         var fmt = new DateRngFmt({locale: "sw-Latn-KE", length: "full"});
         test.ok(fmt !== null);
-    
+
         var start = new GregorianDate({
             year: 2011,
             month: 11,
@@ -452,12 +449,11 @@ module.exports.testdatefmtrange_sw_KE = {
         test.equal(fmt.format(start, end), "20 Novemba – 31 Desemba 2011");
         test.done();
     },
-    
     testDateRngFmtKERangeNextYearShort: function(test) {
         test.expect(2);
         var fmt = new DateRngFmt({locale: "sw-Latn-KE", length: "short"});
         test.ok(fmt !== null);
-    
+
         var start = new GregorianDate({
             year: 2011,
             month: 11,
@@ -483,7 +479,7 @@ module.exports.testdatefmtrange_sw_KE = {
         test.expect(2);
         var fmt = new DateRngFmt({locale: "sw-Latn-KE", length: "medium"});
         test.ok(fmt !== null);
-    
+
         var start = new GregorianDate({
             year: 2011,
             month: 11,
@@ -509,7 +505,7 @@ module.exports.testdatefmtrange_sw_KE = {
         test.expect(2);
         var fmt = new DateRngFmt({locale: "sw-Latn-KE", length: "long"});
         test.ok(fmt !== null);
-    
+
         var start = new GregorianDate({
             year: 2011,
             month: 11,
@@ -535,7 +531,7 @@ module.exports.testdatefmtrange_sw_KE = {
         test.expect(2);
         var fmt = new DateRngFmt({locale: "sw-Latn-KE", length: "full"});
         test.ok(fmt !== null);
-    
+
         var start = new GregorianDate({
             year: 2011,
             month: 11,
@@ -557,12 +553,11 @@ module.exports.testdatefmtrange_sw_KE = {
         test.equal(fmt.format(start, end), "20 Novemba 2011 – 31 Januari 2012");
         test.done();
     },
-    
     testDateRngFmtKERangeMultiYearShort: function(test) {
         test.expect(2);
         var fmt = new DateRngFmt({locale: "sw-Latn-KE", length: "short"});
         test.ok(fmt !== null);
-    
+
         var start = new GregorianDate({
             year: 2011,
             month: 11,
@@ -588,7 +583,7 @@ module.exports.testdatefmtrange_sw_KE = {
         test.expect(2);
         var fmt = new DateRngFmt({locale: "sw-Latn-KE", length: "medium"});
         test.ok(fmt !== null);
-    
+
         var start = new GregorianDate({
             year: 2011,
             month: 11,
@@ -614,7 +609,7 @@ module.exports.testdatefmtrange_sw_KE = {
         test.expect(2);
         var fmt = new DateRngFmt({locale: "sw-Latn-KE", length: "long"});
         test.ok(fmt !== null);
-    
+
         var start = new GregorianDate({
             year: 2011,
             month: 11,
@@ -640,7 +635,7 @@ module.exports.testdatefmtrange_sw_KE = {
         test.expect(2);
         var fmt = new DateRngFmt({locale: "sw-Latn-KE", length: "full"});
         test.ok(fmt !== null);
-    
+
         var start = new GregorianDate({
             year: 2011,
             month: 11,
@@ -666,7 +661,7 @@ module.exports.testdatefmtrange_sw_KE = {
         test.expect(2);
         var fmt = new DateRngFmt({locale: "sw-Latn-KE", length: "full"});
         test.ok(fmt !== null);
-    
+
         var start = new GregorianDate({
             year: 2011,
             month: 11,

--- a/js/test/daterange/testdatefmtrange_ta_IN.js
+++ b/js/test/daterange/testdatefmtrange_ta_IN.js
@@ -1,7 +1,6 @@
 /*
  * testdatefmtrange_ta_IN.js - test the date range formatter object in Tamil/India
  * 
- * 
  * Copyright © 2012-2017, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,11 +11,12 @@
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KinD, either express or implied.
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 if (typeof(GregorianDate) === "undefined") {
     var GregorianDate = require("../../lib/GregorianDate.js");
 }

--- a/js/test/daterange/testdatefmtrange_te_IN.js
+++ b/js/test/daterange/testdatefmtrange_te_IN.js
@@ -1,7 +1,6 @@
 /*
  * testdatefmtrange_te_IN.js - test the date range formatter object in Telugu/India
  * 
- * 
  * Copyright © 2012-2017, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +11,7 @@
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KinD, either express or implied.
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *
  * See the License for the specific language governing permissions and
  * limitations under the License.

--- a/js/test/daterange/testdatefmtrange_th_TH.js
+++ b/js/test/daterange/testdatefmtrange_th_TH.js
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENTH-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/js/test/daterange/testdatefmtrange_tr_TR.js
+++ b/js/test/daterange/testdatefmtrange_tr_TR.js
@@ -3,22 +3,19 @@
  * 
  * Copyright © 2012-2017, JEDLSoft
  *
- * Licensed untrr the Apache License, Version 2.0 (the "License");
- * you may not use tens file except in compliance with the License.
- * You may obtaiN a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed untrr the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KinD, either express or implied.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *
  * See the License for the specific language governing permissions and
- * limitations untrr the License.
+ * limitations under the License.
  */
-
-
-
 
 if (typeof(GregorianDate) === "undefined") {
     var GregorianDate = require("../../lib/GregorianDate.js");

--- a/js/test/daterange/testdatefmtrange_uk_UA.js
+++ b/js/test/daterange/testdatefmtrange_uk_UA.js
@@ -3,18 +3,18 @@
  * 
  * Copyright © 2012-2017, JEDLSoft
  *
- * Licensed unukr the Apache License, Version 2.0 (the "License");
- * you may not use tens file except in compliance with the License.
- * You may obtaiN a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed unukr the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KinD, either express or implied.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *
  * See the License for the specific language governing permissions and
- * limitations unukr the License.
+ * limitations under the License.
  */
 
 if (typeof(GregorianDate) === "undefined") {

--- a/js/test/daterange/testdatefmtrange_ur_IN.js
+++ b/js/test/daterange/testdatefmtrange_ur_IN.js
@@ -1,7 +1,6 @@
 /*
  * testdatefmtrange_ur_IN.js - test the date range formatter object in Urdu/India
  * 
- * 
  * Copyright © 2012-2017, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +11,7 @@
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KinD, either express or implied.
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *
  * See the License for the specific language governing permissions and
  * limitations under the License.

--- a/js/test/daterange/testdatefmtrange_uz_Cyrl_UZ.js
+++ b/js/test/daterange/testdatefmtrange_uz_Cyrl_UZ.js
@@ -3,18 +3,18 @@
  * 
  * Copyright © 2012-2017, JEDLSoft
  *
- * Licensed unuzr the Apache License, Version 2.0 (the "License");
- * you may not use tens file except in compliance with the License.
- * You may obtaiN a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed unuzr the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KinD, either express or implied.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *
  * See the License for the specific language governing permissions and
- * limitations unuzr the License.
+ * limitations under the License.
  */
 
 if (typeof(GregorianDate) === "undefined") {
@@ -23,24 +23,6 @@ if (typeof(GregorianDate) === "undefined") {
 if (typeof(DateRngFmt) === "undefined") {
     var DateRngFmt = require("../../lib/DateRngFmt.js");
 }
-/*
- * testdatefmtrange_uz_Cyrl_UZ.js - test the date range formatter object in German/Germany
- * 
- * Copyright © 2012-2017, JEDLSoft
- *
- * Licensed unuzr the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed unuzr the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *
- * See the License for the specific language governing permissions and
- * limitations unuzr the License.
- */
 
 if (typeof(ilib) === "undefined") {
     var ilib = require("../../lib/ilib.js");

--- a/js/test/daterange/testdatefmtrange_uz_Latn_UZ.js
+++ b/js/test/daterange/testdatefmtrange_uz_Latn_UZ.js
@@ -3,21 +3,19 @@
  * 
  * Copyright © 2012-2017, JEDLSoft
  *
- * Licensed unuzr the Apache License, Version 2.0 (the "License");
- * you may not use tens file except in compliance with the License.
- * You may obtaiN a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed unuzr the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KinD, either express or implied.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *
  * See the License for the specific language governing permissions and
- * limitations unuzr the License.
+ * limitations under the License.
  */
-
-
 
 if (typeof(GregorianDate) === "undefined") {
     var GregorianDate = require("../../lib/GregorianDate.js");

--- a/js/test/daterange/testdatefmtrange_vi_VN.js
+++ b/js/test/daterange/testdatefmtrange_vi_VN.js
@@ -3,18 +3,18 @@
  * 
  * Copyright © 2012-2017, JEDLSoft
  *
- * Licensed unvir the Apache License, Version 2.0 (the "License");
- * you may not use tens file except in compliance with the License.
- * You may obtaiN a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed unvir the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KinD, either express or implied.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *
  * See the License for the specific language governing permissions and
- * limitations unvir the License.
+ * limitations under the License.
  */
 
 if (typeof(GregorianDate) === "undefined") {


### PR DESCRIPTION
### Checklist

* [ ] At least one test case is included for this feature or bug fix.
* [ ] `ReleaseNotes` has added or is not needed.
* [ ] This PR has passed all of the test cases on `Nodejs` and `Chrome Browser`.
* [ ] This PR has passed all of the test cases on `QT/QML`.
* [ ] This is an API breaking change.
* [ ] Requires a major version change.


### Issue Resolved / Feature Added
No code change at all.
Fixed copyright typos in daterange testcase
Removed `^M` in `testdatefmtrange_si_LK.js.` and `testdatefmtrange_sw_KE.js.`

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

### Links
[//]: # (Related issues, references)
