### PR TITLE
Allow the time zone methods to take non-IDate dates

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -7,7 +7,12 @@ Published as version 14.6.0
 
 New Features:
 * Updated all locale data to CLDR 36 and Unicode Character Database 13.0
-
+* The methods of the TimeZone object that take dates as parameters can now
+  take any date types, such as a unix time number, an intrinsic Javascript
+  Date object, or an ilib IDate instance. Previously, they only took
+  IDate instances.
+    * updated methods are: getDisplayName, getOffset, getOffsetStr, 
+    getOffsetMillis, and inDaylightTime
 
 Build 008
 -------

--- a/js/lib/TimeZone.js
+++ b/js/lib/TimeZone.js
@@ -30,6 +30,7 @@ var LocaleInfo = require("./LocaleInfo.js");
 var GregRataDie = require("./GregRataDie.js");
 var CalendarFactory = require("./CalendarFactory.js");
 var IString = require("./IString.js");
+var DateFactory = require("./DateFactory.js");
 
 /**
  * @class
@@ -479,7 +480,7 @@ TimeZone.prototype._offsetStringToObj = function (str) {
  * Returns the offset of this time zone from UTC at the given date/time. If daylight saving
  * time is in effect at the given date/time, this method will return the offset value
  * adjusted by the amount of daylight saving.
- * @param {IDate=} date the date for which the offset is needed
+ * @param {IDate|Object|JulianDay|Date|string|number=} date the date for which the offset is needed
  * @return {Object.<{h:number,m:number}>} an object giving the offset for the zone at
  * the given date/time, in hours, minutes, and seconds
  */
@@ -508,7 +509,7 @@ TimeZone.prototype.getOffset = function (date) {
  * adjusted by the amount of daylight saving. Negative numbers indicate offsets west
  * of UTC and conversely, positive numbers indicate offset east of UTC.
  *
- * @param {IDate=} date the date for which the offset is needed, or null for the
+ * @param {IDate|Object|JulianDay|Date|string|number=} date the date for which the offset is needed, or null for the
  * present date
  * @return {number} the number of milliseconds of offset from UTC that the given date is
  */
@@ -777,7 +778,7 @@ TimeZone.prototype._getDSTEndRule = function (year) {
  * next year. This method will correctly calculate the start and end of DST for any
  * location.
  *
- * @param {IDate=} date a date for which the info about daylight time is being sought,
+ * @param {IDate|Object|JulianDay|Date|string|number=} date a date for which the info about daylight time is being sought,
  * or undefined to tell whether we are currently in daylight savings time
  * @param {boolean=} wallTime if true, then the given date is in wall time. If false or
  * undefined, it is in the usual UTC time.
@@ -786,7 +787,10 @@ TimeZone.prototype._getDSTEndRule = function (year) {
  */
 TimeZone.prototype.inDaylightTime = function (date, wallTime) {
     var rd, startRd, endRd, year;
-
+    if (date) {
+        // need an IDate instance, so convert as necessary
+        date = DateFactory._dateToIlib(date, this.id, this.locale);
+    }
     if (this.isLocal) {
         // check if the dst property is defined -- the intrinsic JS Date object doesn't work so
         // well if we are in the overlap time at the end of DST, so we have to work around that

--- a/js/lib/TimeZone.js
+++ b/js/lib/TimeZone.js
@@ -382,7 +382,7 @@ TimeZone.prototype.getId = function () {
  * <li>long - returns the long name of the zone in English
  * </ol>
  *
- * @param {IDate=} date a date to determine if it is in daylight time or standard time
+ * @param {IDate|Object|JulianDay|Date|string|number=} date a date to determine if it is in daylight time or standard time
  * @param {string=} style one of "standard" or "rfc822". Default if not specified is "standard"
  * @return {string} the name of the time zone, abbreviated according to the style
  */
@@ -536,7 +536,7 @@ TimeZone.prototype.getOffsetMillis = function (date) {
  * Return the offset in milliseconds when the date has an RD number in wall
  * time rather than in UTC time.
  * @protected
- * @param date the date to check in wall time
+ * @param {IDate|Object|JulianDay|Date|string|number} date the date to check in wall time
  * @returns {number} the number of milliseconds of offset from UTC that the given date is
  */
 TimeZone.prototype._getOffsetMillisWallTime = function (date) {
@@ -555,7 +555,7 @@ TimeZone.prototype._getOffsetMillisWallTime = function (date) {
  * Returns the offset of this time zone from UTC at the given date/time. If daylight saving
  * time is in effect at the given date/time, this method will return the offset value
  * adjusted by the amount of daylight saving.
- * @param {IDate=} date the date for which the offset is needed
+ * @param {IDate|Object|JulianDay|Date|string|number=} date the date for which the offset is needed
  * @return {string} the offset for the zone at the given date/time as a string in the
  * format "h:m:s"
  */

--- a/js/test/calendar/testtimezone.js
+++ b/js/test/calendar/testtimezone.js
@@ -257,7 +257,17 @@ module.exports.testtimezone = {
         test.equal(tz.getDisplayName(gd, 'standard'), "PDT");
         test.done();
     },
-    
+
+    testTZDisplayNameDSTStandardStyleNonIDate: function(test) {
+        test.expect(2);
+        var tz = new TimeZone({id: "America/Los_Angeles"});
+        test.ok(tz !== null);
+
+        var gd = new Date(2011, 7, 1);
+        test.equal(tz.getDisplayName(gd, 'standard'), "PDT");
+        test.done();
+    },
+
     testTZDisplayNameDSTDefaultStyle: function(test) {
         test.expect(2);
         var tz = new TimeZone({id: "America/Los_Angeles"});
@@ -271,7 +281,17 @@ module.exports.testtimezone = {
         test.equal(tz.getDisplayName(gd), "PDT");
         test.done();
     },
-    
+
+    testTZDisplayNameDSTDefaultStyleNonIDate: function(test) {
+        test.expect(2);
+        var tz = new TimeZone({id: "America/Los_Angeles"});
+        test.ok(tz !== null);
+
+        var gd = new Date(2011, 7, 1);
+        test.equal(tz.getDisplayName(gd), "PDT");
+        test.done();
+    },
+
     testTZDisplayNameDSTStyleRFC: function(test) {
         test.expect(2);
         var tz = new TimeZone({id: "America/Los_Angeles"});
@@ -285,7 +305,17 @@ module.exports.testtimezone = {
         test.equal(tz.getDisplayName(gd, 'rfc822'), "UTC-0700");
         test.done();
     },
-    
+
+    testTZDisplayNameDSTStyleRFCNonIDate: function(test) {
+        test.expect(2);
+        var tz = new TimeZone({id: "America/Los_Angeles"});
+        test.ok(tz !== null);
+
+        var gd = new Date(2011, 7, 1);
+        test.equal(tz.getDisplayName(gd, 'rfc822'), "UTC-0700");
+        test.done();
+    },
+
     testTZDisplayNameDSTDaylightStandardStyle: function(test) {
         test.expect(2);
         var tz = new TimeZone({id: "America/Los_Angeles"});
@@ -313,7 +343,17 @@ module.exports.testtimezone = {
         test.equal(tz.getDisplayName(gd, 'long'), "Pacific Daylight Time");
         test.done();
     },
-    
+
+    testTZDisplayNameDSTDaylightLongStyleNonIDate: function(test) {
+        test.expect(2);
+        var tz = new TimeZone({id: "America/Los_Angeles"});
+        test.ok(tz !== null);
+
+        var gd = new Date(2011, 7, 1);
+        test.equal(tz.getDisplayName(gd, 'long'), "Pacific Daylight Time");
+        test.done();
+    },
+
     testTZDisplayNameStandardTime: function(test) {
         test.expect(2);
         var tz = new TimeZone({id: "America/Los_Angeles"});
@@ -327,7 +367,17 @@ module.exports.testtimezone = {
         test.equal(tz.getDisplayName(gd, 'standard'), "PST");
         test.done();
     },
-    
+
+    testTZDisplayNameStandardTimeNonIDate: function(test) {
+        test.expect(2);
+        var tz = new TimeZone({id: "America/Los_Angeles"});
+        test.ok(tz !== null);
+
+        var gd = new Date(2011, 11, 1);
+        test.equal(tz.getDisplayName(gd, 'standard'), "PST");
+        test.done();
+    },
+
     testTZDisplayNameStandardTimeAmbiguous: function(test) {
         test.expect(2);
         var tz = new TimeZone({id: "America/Los_Angeles"});
@@ -393,7 +443,17 @@ module.exports.testtimezone = {
         test.equal(tz.getDisplayName(gd, 'long'), "Pacific Standard Time");
         test.done();
     },
-    
+
+    testTZDisplayNameStandardTimeLongNonIDate: function(test) {
+        test.expect(2);
+        var tz = new TimeZone({id: "America/Los_Angeles"});
+        test.ok(tz !== null);
+
+        var gd = new Date(2011, 11, 1);
+        test.equal(tz.getDisplayName(gd, 'long'), "Pacific Standard Time");
+        test.done();
+    },
+
     testTZDisplayNameStandardTimeESWithNoDST: function(test) {
         test.expect(2);
         var tz = new TimeZone({id: "Europe/Madrid"});
@@ -407,6 +467,17 @@ module.exports.testtimezone = {
         test.equal(tz.getDisplayName(gd, 'standard'), "CET");
         test.done();
     },
+
+    testTZDisplayNameStandardTimeESWithNoDSTNonIDate: function(test) {
+        test.expect(2);
+        var tz = new TimeZone({id: "Europe/Madrid"});
+        test.ok(tz !== null);
+
+        var gd = new Date(2011, 11, 1);
+        test.equal(tz.getDisplayName(gd, 'standard'), "CET");
+        test.done();
+    },
+
     testTZDisplayNameStandardTimeESWithDST: function(test) {
         test.expect(2);
         var tz = new TimeZone({id: "Europe/Madrid"});
@@ -420,7 +491,17 @@ module.exports.testtimezone = {
         test.equal(tz.getDisplayName(gd, 'standard'), "CEST");
         test.done();
     },
-    
+
+    testTZDisplayNameStandardTimeESWithDSTNonIDate: function(test) {
+        test.expect(2);
+        var tz = new TimeZone({id: "Europe/Madrid"});
+        test.ok(tz !== null);
+
+        var gd = new Date(2011, 5, 1);
+        test.equal(tz.getDisplayName(gd, 'standard'), "CEST");
+        test.done();
+    },
+
     testTZDisplayNameNoDST1: function(test) {
         test.expect(2);
         var tz = new TimeZone({id: "America/Phoenix"});
@@ -434,11 +515,22 @@ module.exports.testtimezone = {
         test.equal(tz.getDisplayName(gd, 'standard'), "MST");
         test.done();
     },
+
+    testTZDisplayNameNoDST1NonIDate: function(test) {
+        test.expect(2);
+        var tz = new TimeZone({id: "America/Phoenix"});
+        test.ok(tz !== null);
+
+        var gd = new Date(2011, 7, 1);
+        test.equal(tz.getDisplayName(gd, 'standard'), "MST");
+        test.done();
+    },
+
     testTZDisplayNameNoDST2: function(test) {
         test.expect(2);
         var tz = new TimeZone({id: "America/Phoenix"});
         test.ok(tz !== null);
-        
+
         var gd = new GregorianDate({
             year: 2011,
             month: 12,
@@ -447,7 +539,17 @@ module.exports.testtimezone = {
         test.equal(tz.getDisplayName(gd, 'standard'), "MST");
         test.done();
     },
-    
+
+    testTZDisplayNameNoDST2NonIDate: function(test) {
+        test.expect(2);
+        var tz = new TimeZone({id: "America/Phoenix"});
+        test.ok(tz !== null);
+
+        var gd = new Date(2011, 11, 1);
+        test.equal(tz.getDisplayName(gd, 'standard'), "MST");
+        test.done();
+    },
+
     testTZDisplayNameEasternRFCWithDST: function(test) {
         test.expect(2);
         var tz = new TimeZone({id: "Australia/Broken_Hill"});
@@ -505,7 +607,18 @@ module.exports.testtimezone = {
         test.deepEqual(tz.getOffset(gd), {h:-7});
         test.done();
     },
-    
+
+    testTZGetOffsetDSTNonIDate: function(test) {
+        test.expect(2);
+        var tz = new TimeZone({id: "America/Los_Angeles"});
+        test.ok(tz !== null);
+
+        var gd = new Date(2011, 7, 1);
+
+        test.deepEqual(tz.getOffset(gd), {h:-7});
+        test.done();
+    },
+
     testTZGetOffsetRightBeforeDSTStart: function(test) {
         test.expect(2);
         var tz = new TimeZone({id: "America/Los_Angeles"});
@@ -519,7 +632,18 @@ module.exports.testtimezone = {
         test.deepEqual(tz.getOffset(date), {h:-8});
         test.done();
     },
-    
+
+    testTZGetOffsetRightBeforeDSTStartNonIDate: function(test) {
+        test.expect(2);
+        var tz = new TimeZone({id: "America/Los_Angeles"});
+        test.ok(tz !== null);
+
+        var date = new Date(1394359140000); // this is 3/9/2014 at 1:59am
+
+        test.deepEqual(tz.getOffset(date), {h:-8});
+        test.done();
+    },
+
     testTZGetOffsetRightAfterDSTStart: function(test) {
         test.expect(2);
         var tz = new TimeZone({id: "America/Los_Angeles"});
@@ -534,7 +658,19 @@ module.exports.testtimezone = {
         test.deepEqual(tz.getOffset(date), {h:-7});
         test.done();
     },
-    
+
+    testTZGetOffsetRightAfterDSTStartNonIDate: function(test) {
+        test.expect(2);
+        var tz = new TimeZone({id: "America/Los_Angeles"});
+        test.ok(tz !== null);
+
+        var date = new Date(1394359260000);
+
+        // 2 minutes later
+        test.deepEqual(tz.getOffset(date), {h:-7});
+        test.done();
+    },
+
     testTZGetOffsetRightBeforeDSTEnd: function(test) {
         test.expect(2);
         var tz = new TimeZone({id: "America/Los_Angeles"});
@@ -548,7 +684,18 @@ module.exports.testtimezone = {
         test.deepEqual(tz.getOffset(date), {h:-7});
         test.done();
     },
-    
+
+    testTZGetOffsetRightBeforeDSTEndNonIDate: function(test) {
+        test.expect(2);
+        var tz = new TimeZone({id: "America/Los_Angeles"});
+        test.ok(tz !== null);
+
+        var date = new Date(1414918740000); // this is 11/2/2014 at 1:59am
+
+        test.deepEqual(tz.getOffset(date), {h:-7});
+        test.done();
+    },
+
     testTZGetOffsetRightAfterDSTEnd: function(test) {
         test.expect(2);
         var tz = new TimeZone({id: "America/Los_Angeles"});
@@ -563,7 +710,19 @@ module.exports.testtimezone = {
         test.deepEqual(tz.getOffset(date), {h:-8});
         test.done();
     },
-    
+
+    testTZGetOffsetRightAfterDSTEnd: function(test) {
+        test.expect(2);
+        var tz = new TimeZone({id: "America/Los_Angeles"});
+        test.ok(tz !== null);
+
+        var date = new Date(1414918860000);
+
+        // 2 minutes later
+        test.deepEqual(tz.getOffset(date), {h:-8});
+        test.done();
+    },
+
     testTZGetOffsetRightAfterDST: function(test) {
         test.expect(2);
         var tz = new TimeZone({id: "America/Los_Angeles"});
@@ -594,7 +753,17 @@ module.exports.testtimezone = {
         test.equal(tz.getOffsetStr(gd), "-7:0");
         test.done();
     },
-    
+
+    testTZGetOffsetDSTStrNonIDate: function(test) {
+        test.expect(2);
+        var tz = new TimeZone({id: "America/Los_Angeles"});
+        test.ok(tz !== null);
+
+        var gd = new Date(2011, 7, 1);
+        test.equal(tz.getOffsetStr(gd), "-7:0");
+        test.done();
+    },
+
     testTZGetOffsetNoDST: function(test) {
         test.expect(2);
         var tz = new TimeZone({id: "America/Los_Angeles"});
@@ -621,7 +790,17 @@ module.exports.testtimezone = {
         test.equal(tz.getOffsetStr(gd), "-8:0");
         test.done();
     },
-    
+
+    testTZGetOffsetNoDSTStrNonIDate: function(test) {
+        test.expect(2);
+        var tz = new TimeZone({id: "America/Los_Angeles"});
+        test.ok(tz !== null);
+
+        var gd = new Date(2011, 11, 1);
+        test.equal(tz.getOffsetStr(gd), "-8:0");
+        test.done();
+    },
+
     testTZGetOffsetNonDSTZone1: function(test) {
         test.expect(2);
         var tz = new TimeZone({id: "America/Phoenix"});
@@ -808,7 +987,26 @@ module.exports.testtimezone = {
         test.ok(!tz.inDaylightTime(gd));
         test.done();
     },
-    
+
+    testTZInDaylightTimeTrueNonIDate: function(test) {
+        test.expect(2);
+        var tz = new TimeZone({id: "America/Los_Angeles"});
+        test.ok(tz !== null);
+
+        var d = new Date(2011, 6, 1);
+        test.ok(tz.inDaylightTime(d));
+        test.done();
+    },
+    testTZInDaylightTimeFalseNonIDate: function(test) {
+        test.expect(2);
+        var tz = new TimeZone({id: "America/Los_Angeles"});
+        test.ok(tz !== null);
+
+        var d = new Date(2011, 11, 1);
+        test.ok(!tz.inDaylightTime(d));
+        test.done();
+    },
+
     testTZInDaylightTimeLocalTrue: function(test) {
         var summer = new Date(2014, 6, 1);
         var winter = new Date(2014, 0, 1);
@@ -1336,7 +1534,38 @@ module.exports.testtimezone = {
        test.equal(offset.m, 30);
        test.done();
     },
+
+    testTZOffsetGetOffsetWinterNonIDate: function(test) {
+        test.expect(4);
+       var tz = new TimeZone({offset: 450});
+       test.ok(tz !== null);
+
+       var date = new Date(2012, 0, 1);
+
+       var offset = tz.getOffset(date);
+       test.ok(typeof(offset) !== "undefined");
+
+       test.equal(offset.h, 7);
+       test.equal(offset.m, 30);
+       test.done();
+    },
     
+    testTZOffsetGetOffsetSummerNonIDate: function(test) {
+        test.expect(4);
+       var tz = new TimeZone({offset: 450});
+       test.ok(tz !== null);
+
+       var date = new Date(2012, 5, 1);
+
+       var offset = tz.getOffset(date);
+       test.ok(typeof(offset) !== "undefined");
+
+       // should be the same as winter because we can't determine DST
+       test.equal(offset.h, 7);
+       test.equal(offset.m, 30);
+       test.done();
+    },
+
     testTZOffsetGetDisplayNameStandard: function(test) {
         test.expect(2);
        var tz = new TimeZone({offset: 450});
@@ -1475,7 +1704,17 @@ module.exports.testtimezone = {
         test.equal(tz.getOffsetMillis(gd), -25200000);
         test.done();
     },
-    
+
+    testTZGetOffsetMillisDSTNonIDate: function(test) {
+        test.expect(2);
+        var tz = new TimeZone({id: "America/Los_Angeles"});
+        test.ok(tz !== null);
+
+        var gd = new Date(2011, 7, 1);
+        test.equal(tz.getOffsetMillis(gd), -25200000);
+        test.done();
+    },
+
     testTZGetOffsetMillisNoDST: function(test) {
         test.expect(2);
         var tz = new TimeZone({id: "America/Los_Angeles"});
@@ -1489,7 +1728,17 @@ module.exports.testtimezone = {
         test.equal(tz.getOffsetMillis(gd), -28800000);
         test.done();
     },
-    
+
+    testTZGetOffsetMillisNoDSTNonIDate: function(test) {
+        test.expect(2);
+        var tz = new TimeZone({id: "America/Los_Angeles"});
+        test.ok(tz !== null);
+
+        var gd = new Date(2011, 11, 1);
+        test.equal(tz.getOffsetMillis(gd), -28800000);
+        test.done();
+    },
+
     testTZGetOffsetMillisDSTSouthern: function(test) {
         test.expect(2);
         var tz = new TimeZone({id: "Australia/Sydney"});


### PR DESCRIPTION
For those time zone methods that take a date as a parameter, now the dates can be of any date time including: intrinsic Dates, unix times, strings, IDates, or JulianDay.

Previously, these methods only took instances of IDate subclasses and would silently fail if you
passed in any other type.

### Checklist

* [x] At least one test case is included for this feature or bug fix.
* [x] `ReleaseNotes` has added or is not needed.
* [x] This PR has passed all of the test cases on `Nodejs` and `Chrome Browser`.
* [x] This PR has passed all of the test cases on `QT/QML`.
* [ ] This is an API breaking change.
* [ ] Requires a major version change.


### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

### Links
[//]: # (Related issues, references)
