### PR TITLE
Put base option back on ResBundle

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -9,6 +9,7 @@ New Features:
 
 Bug Fixes:
 * Updated to IANA time zone data 2020a
+* Put base option back on ResBundle
 
 Build 009
 -------

--- a/js/lib/ResBundle.js
+++ b/js/lib/ResBundle.js
@@ -250,8 +250,8 @@ var ResBundle = function (options) {
 
         if (typeof(options.loadParams) !== 'undefined') {
             this.loadParams = options.loadParams;
-            if (typeof (options.loadParams.root) !== 'undefined') {
-                this.path = options.loadParams.root;
+            if (typeof (options.loadParams.base) !== 'undefined') {
+                this.path = options.loadParams.base;
             }
         }
         if (typeof(options.missing) !== 'undefined') {

--- a/js/lib/ResBundle.js
+++ b/js/lib/ResBundle.js
@@ -250,7 +250,9 @@ var ResBundle = function (options) {
 
         if (typeof(options.loadParams) !== 'undefined') {
             this.loadParams = options.loadParams;
-            if (typeof (options.loadParams.base) !== 'undefined') {
+            if (typeof (options.loadParams.root) !== 'undefined') {
+                this.path = options.loadParams.root;
+            } else if (typeof (options.loadParams.base) !== 'undefined') {
                 this.path = options.loadParams.base;
             }
         }

--- a/js/lib/ResBundle.js
+++ b/js/lib/ResBundle.js
@@ -250,10 +250,12 @@ var ResBundle = function (options) {
 
         if (typeof(options.loadParams) !== 'undefined') {
             this.loadParams = options.loadParams;
-            if (typeof (options.loadParams.root) !== 'undefined') {
-                this.path = options.loadParams.root;
-            } else if (typeof (options.loadParams.base) !== 'undefined') {
-                this.path = options.loadParams.base;
+            if (!this.path) {
+                if (typeof (options.loadParams.root) !== 'undefined') {
+                    this.path = options.loadParams.root;
+                } else if (typeof (options.loadParams.base) !== 'undefined') {
+                    this.path = options.loadParams.base;
+                }
             }
         }
         if (typeof(options.missing) !== 'undefined') {


### PR DESCRIPTION
Restore base option on ResBundle.
But I guess that base option is supported by loader before, we need to add base option to other feature (like DateFmt, DurationFmt..) or modify loader to support base option.
I think it is good idea to allow the use of base option in ResBundle only.

### Checklist

* [ ] At least one test case is included for this feature or bug fix.
* [x] `ReleaseNotes` has added or is not needed.
* [x] This PR has passed all of the test cases on `Nodejs` and `Chrome Browser`.
* [ ] This PR has passed all of the test cases on `QT/QML`.
* [ ] This is an API breaking change.
* [ ] Requires a major version change.


### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

### Links
[//]: # (Related issues, references)
