### PR TITLE
Fix DateRng formatting to present standAlone case

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -1,6 +1,15 @@
 Release Notes for Version 14
 ============================
 
+Build 011
+-------
+Published as version 14.6.2
+
+New Features:
+
+Bug Fixes:
+* Fixed a DateRange Formatting to present standAlone case properly
+
 Build 010
 -------
 Published as version 14.6.1

--- a/js/lib/DateFmt.js
+++ b/js/lib/DateFmt.js
@@ -1,7 +1,7 @@
 /*
  * DateFmt.js - Date formatter definition
  *
- * Copyright © 2012-2015, 2018, JEDLSoft
+ * Copyright © 2012-2015, 2018, 2020 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1306,7 +1306,8 @@ DateFmt.prototype = {
                 case 'LLL':
                 case 'LLLL':
                     key = templateArr[i] + (date.month || 1);
-                    str += (this.sysres.getString(undefined, key + "-" + this.calName) || this.sysres.getString(undefined, key));
+                    str += (this.sysres.getString(undefined, key + "-" + this.calName) || this.sysres.getString(undefined, key) ||
+                           this.sysres.getString(undefined, key.replace(/L/g,"M") + "-" + this.calName) || this.sysres.getString(undefined, key.replace(/L/g,"M")));
                     break;
 
                 case 'E':

--- a/js/lib/DateRngFmt.js
+++ b/js/lib/DateRngFmt.js
@@ -374,6 +374,13 @@ DateRngFmt.prototype = {
         monthTemplate = this.dateFmt._tokenize(this.dateFmt._getFormatInternal(formats, "m", this.length) || "MM");
         dayTemplate = this.dateFmt._tokenize(this.dateFmt._getFormatInternal(formats, "d", this.length) || "dd");
 
+
+        /*
+        * Some languages use two different forms of strings (standlone and format) depending on the context.
+        * Typically the standalone version is the nominative form of the word,
+        * and the format version is in the genitive (or related form).
+        * In c20 case, It should present standAlone form, In order to support that, the format symbol is changed.
+        */
         if (isStandAlone && monthTemplate[0].length >= 3) {
             monthTemplate[0] = monthTemplate[0].replace(/M/g,"L");
         }

--- a/js/lib/DateRngFmt.js
+++ b/js/lib/DateRngFmt.js
@@ -1,7 +1,7 @@
 /*
  * DateRngFmt.js - Date formatter definition
  *
- * Copyright © 2012-2015, 2018, JEDLSoft
+ * Copyright © 2012-2015, 2018, 2020 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -304,6 +304,7 @@ DateRngFmt.prototype = {
 
         var start = DateFactory._dateToIlib(startDateLike, thisZoneName, this.locale);
         var end = DateFactory._dateToIlib(endDateLike, thisZoneName, this.locale);
+        var isStandAlone = false;
 
         if (typeof(start) !== 'object' || !start.getCalendar || start.getCalendar() !== this.calName || (this.timezone && start.timezone && start.timezone !== this.timezone)) {
             start = DateFactory({
@@ -363,6 +364,7 @@ DateRngFmt.prototype = {
             }
         } else if (endRd - startRd < 3650) {
             fmt = new IString(this.dateFmt._getFormat(this.dateFmt.formats.range, "c20", this.length));
+            isStandAlone = true;
         } else {
             fmt = new IString(this.dateFmt._getFormat(this.dateFmt.formats.range, "c30", this.length));
         }
@@ -371,6 +373,10 @@ DateRngFmt.prototype = {
         yearTemplate = this.dateFmt._tokenize(this.dateFmt._getFormatInternal(formats, "y", this.length) || "yyyy");
         monthTemplate = this.dateFmt._tokenize(this.dateFmt._getFormatInternal(formats, "m", this.length) || "MM");
         dayTemplate = this.dateFmt._tokenize(this.dateFmt._getFormatInternal(formats, "d", this.length) || "dd");
+
+        if (isStandAlone && monthTemplate[0].length >= 3) {
+            monthTemplate[0] = monthTemplate[0].replace(/M/g,"L");
+        }
 
         /*
         console.log("fmt is " + fmt.toString());

--- a/js/test/daterange/testdatefmtrange_az_Latn_AZ.js
+++ b/js/test/daterange/testdatefmtrange_az_Latn_AZ.js
@@ -633,7 +633,7 @@ module.exports.testdatefmtrange_az_Latn_AZ = {
             second: 0,
             millisecond: 0
         });
-        test.equal(fmt.format(start, end), "noyabr 2011 – yanvar 2014");
+        test.equal(fmt.format(start, end), "Noyabr 2011 – yanvar 2014");
         test.done();
     },
     testDateRngFmtAZRangeMultiYearFull: function(test) {
@@ -659,7 +659,7 @@ module.exports.testdatefmtrange_az_Latn_AZ = {
             second: 0,
             millisecond: 0
         });
-        test.equal(fmt.format(start, end), "noyabr 2011 – yanvar 2014");
+        test.equal(fmt.format(start, end), "Noyabr 2011 – yanvar 2014");
         test.done();
     },
     testDateRngFmtAZManyYearsFull: function(test) {

--- a/js/test/daterange/testdatefmtrange_be_BY.js
+++ b/js/test/daterange/testdatefmtrange_be_BY.js
@@ -634,7 +634,7 @@ module.exports.testdatefmtrange_be_BY = {
             second: 0,
             millisecond: 0
         });
-        test.equal(fmt.format(start, end), "лістапада 2011 г. – студзеня 2014 г.");
+        test.equal(fmt.format(start, end), "лістапад 2011 г. – студзень 2014 г.");
         test.done();
     },
     testDateRngFmtbeBYRangeMultiYearFull: function(test) {
@@ -660,7 +660,7 @@ module.exports.testdatefmtrange_be_BY = {
             second: 0,
             millisecond: 0
         });
-        test.equal(fmt.format(start, end), "лістапада 2011 г. – студзеня 2014 г.");
+        test.equal(fmt.format(start, end), "лістапад 2011 г. – студзень 2014 г.");
         test.done();
     },
     testDateRngFmtbeBYManyYearsFull: function(test) {

--- a/js/test/daterange/testdatefmtrange_ca.js
+++ b/js/test/daterange/testdatefmtrange_ca.js
@@ -608,7 +608,7 @@ module.exports.testdatefmtrange_ca = {
             second: 0,
             millisecond: 0
         });
-        test.equal(fmt.format(start, end), "de nov. 2011 – de gen. 2014");
+        test.equal(fmt.format(start, end), "nov. 2011 – gen. 2014");
         test.done();
     },
     testDateRngFmtcaADRangeMultiYearLong: function(test) {
@@ -634,7 +634,7 @@ module.exports.testdatefmtrange_ca = {
             second: 0,
             millisecond: 0
         });
-        test.equal(fmt.format(start, end), "de novembre de 2011 – de gener de 2014");
+        test.equal(fmt.format(start, end), "novembre de 2011 – gener de 2014");
         test.done();
     },
     testDateRngFmtcaADRangeMultiYearFull: function(test) {
@@ -660,7 +660,7 @@ module.exports.testdatefmtrange_ca = {
             second: 0,
             millisecond: 0
         });
-        test.equal(fmt.format(start, end), "de novembre de 2011 – de gener de 2014");
+        test.equal(fmt.format(start, end), "novembre de 2011 – gener de 2014");
         test.done();
     },
     testDateRngFmtcaADManyYearsFull: function(test) {
@@ -1264,7 +1264,7 @@ module.exports.testdatefmtrange_ca = {
             second: 0,
             millisecond: 0
         });
-        test.equal(fmt.format(start, end), "de nov. 2011 – de gen. 2014");
+        test.equal(fmt.format(start, end), "nov. 2011 – gen. 2014");
         test.done();
     },
     testDateRngFmtcaESRangeMultiYearLong: function(test) {
@@ -1290,7 +1290,7 @@ module.exports.testdatefmtrange_ca = {
             second: 0,
             millisecond: 0
         });
-        test.equal(fmt.format(start, end), "de novembre de 2011 – de gener de 2014");
+        test.equal(fmt.format(start, end), "novembre de 2011 – gener de 2014");
         test.done();
     },
     testDateRngFmtcaESRangeMultiYearFull: function(test) {
@@ -1316,7 +1316,7 @@ module.exports.testdatefmtrange_ca = {
             second: 0,
             millisecond: 0
         });
-        test.equal(fmt.format(start, end), "de novembre de 2011 – de gener de 2014");
+        test.equal(fmt.format(start, end), "novembre de 2011 – gener de 2014");
         test.done();
     },
     testDateRngFmtcaESManyYearsFull: function(test) {

--- a/js/test/daterange/testdatefmtrange_cs_CZ.js
+++ b/js/test/daterange/testdatefmtrange_cs_CZ.js
@@ -1,7 +1,7 @@
 /*
  * testdatefmtrange_cs_CZ.js - test the date range formatter object in Czech/Czech-Republic
  * 
- * Copyright © 2012-2017, JEDLSoft
+ * Copyright © 2012-2017, 2020 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -633,7 +633,7 @@ module.exports.testdatefmtrange_cs_CZ = {
             second: 0,
             millisecond: 0
         });
-        test.equal(fmt.format(start, end), "listopadu 2011 – ledna 2014");
+        test.equal(fmt.format(start, end), "listopad 2011 – leden 2014");
         test.done();
     },
     testDateRngFmtCZRangeMultiYearFull: function(test) {
@@ -659,7 +659,7 @@ module.exports.testdatefmtrange_cs_CZ = {
             second: 0,
             millisecond: 0
         });
-        test.equal(fmt.format(start, end), "listopadu 2011 – ledna 2014");
+        test.equal(fmt.format(start, end), "listopad 2011 – leden 2014");
         test.done();
     },
     testDateRngFmtCZManyYearsFull: function(test) {

--- a/js/test/daterange/testdatefmtrange_el_GR.js
+++ b/js/test/daterange/testdatefmtrange_el_GR.js
@@ -1,7 +1,7 @@
 /*
  * testdatefmtGR_GR_GR.js - test the date GR formatter object GR GRench/GRance
  * 
- * Copyright © 2012-2017, JEDLSoft
+ * Copyright © 2012-2017, 2020 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -607,7 +607,7 @@ module.exports.testdatefmtrange_el_GR = {
             second: 0,
             millisecond: 0
         });
-        test.equal(fmt.format(start, end), "Νοε 2011 – Ιαν 2014");
+        test.equal(fmt.format(start, end), "Νοέ 2011 – Ιαν 2014");
         test.done();
     },
     testDateRngFmtGRMultiYearLong: function(test) {
@@ -633,7 +633,7 @@ module.exports.testdatefmtrange_el_GR = {
             second: 0,
             millisecond: 0
         });
-        test.equal(fmt.format(start, end), "Νοεμβρίου 2011 – Ιανουαρίου 2014");
+        test.equal(fmt.format(start, end), "Νοέμβριος 2011 – Ιανουάριος 2014");
         test.done();
     },
     testDateRngFmtGRMultiYearFull: function(test) {
@@ -659,7 +659,7 @@ module.exports.testdatefmtrange_el_GR = {
             second: 0,
             millisecond: 0
         });
-        test.equal(fmt.format(start, end), "Νοεμβρίου 2011 – Ιανουαρίου 2014");
+        test.equal(fmt.format(start, end), "Νοέμβριος 2011 – Ιανουάριος 2014");
         test.done();
     },
     testDateRngFmtGRManyYearsFull: function(test) {

--- a/js/test/daterange/testdatefmtrange_es_UY.js
+++ b/js/test/daterange/testdatefmtrange_es_UY.js
@@ -1,7 +1,7 @@
 /*
  * testdatefmtrange_es_UY.js - test the date range formatter object in French/France
  *
- * Copyright © 2012-2017, JEDLSoft
+ * Copyright © 2012-2017, 2020 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -607,7 +607,7 @@ module.exports.testdatefmtrange_es_UY = {
             second: 0,
             millisecond: 0
         });
-        test.equal(fmt.format(start, end), "nov. 2011 – ene. 2014");
+        test.equal(fmt.format(start, end), "Nov. 2011 – Ene. 2014");
         test.done();
     },
     testDateRngFmtUYRangeMultiYearLong: function(test) {
@@ -633,7 +633,7 @@ module.exports.testdatefmtrange_es_UY = {
             second: 0,
             millisecond: 0
         });
-        test.equal(fmt.format(start, end), "noviembre de 2011 – enero de 2014");
+        test.equal(fmt.format(start, end), "Noviembre de 2011 – Enero de 2014");
         test.done();
     },
     testDateRngFmtUYRangeMultiYearFull: function(test) {
@@ -659,7 +659,7 @@ module.exports.testdatefmtrange_es_UY = {
             second: 0,
             millisecond: 0
         });
-        test.equal(fmt.format(start, end), "noviembre de 2011 – enero de 2014");
+        test.equal(fmt.format(start, end), "Noviembre de 2011 – Enero de 2014");
         test.done();
     },
     testDateRngFmtUYManyYearsFull: function(test) {

--- a/js/test/daterange/testdatefmtrange_fa_IR.js
+++ b/js/test/daterange/testdatefmtrange_fa_IR.js
@@ -1,7 +1,7 @@
 /*
  * testdatefmtrange_fa_IR.js - test date range formatter object in Farsi/Iran
  * 
- * Copyright © 2012-2017, JEDLSoft
+ * Copyright © 2012-2017, 2020 JEDLSoft
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -702,7 +702,7 @@ module.exports.testdatefmtrange_fa_IR = {
             second: 0,
             millisecond: 0
         });
-        test.equal(fmt.format(start, end), "نوامبر ۲۰۱۱ – ژانویهٔ ۲۰۱۴");
+        test.equal(fmt.format(start, end), 'نوامبر ۲۰۱۱ – ژانویه ۲۰۱۴');
         test.done();
     },
     testDateRngFmtIRRangeMultiYearLong: function(test) {
@@ -732,7 +732,7 @@ module.exports.testdatefmtrange_fa_IR = {
             second: 0,
             millisecond: 0
         });
-        test.equal(fmt.format(start, end), "نوامبر ۲۰۱۱ – ژانویهٔ ۲۰۱۴");
+        test.equal(fmt.format(start, end), 'نوامبر ۲۰۱۱ – ژانویه ۲۰۱۴');
         test.done();
     },
     testDateRngFmtIRRangeMultiYearFull: function(test) {
@@ -762,7 +762,7 @@ module.exports.testdatefmtrange_fa_IR = {
             second: 0,
             millisecond: 0
         });
-        test.equal(fmt.format(start, end), "نوامبر ۲۰۱۱ – ژانویهٔ ۲۰۱۴");
+        test.equal(fmt.format(start, end), 'نوامبر ۲۰۱۱ – ژانویه ۲۰۱۴');
         test.done();
     
     },
@@ -1461,7 +1461,7 @@ module.exports.testdatefmtrange_fa_IR = {
             second: 0,
             millisecond: 0
         });
-        test.equal(fmt.format(start, end), 'بهمن ۱۳۹۳ – فروردین ۱۳۹۶');
+        test.equal(fmt.format(start, end), 'نوامبر ۱۳۹۳ – ژانویه ۱۳۹۶');
         test.done();
     },
     testDateRngFmtPersRangeMultiYearLong_fa_IR: function(test) {
@@ -1491,7 +1491,7 @@ module.exports.testdatefmtrange_fa_IR = {
             second: 0,
             millisecond: 0
         });
-        test.equal(fmt.format(start, end), 'بهمن ۱۳۹۳ – فروردین ۱۳۹۶');
+        test.equal(fmt.format(start, end), 'نوامبر ۱۳۹۳ – ژانویه ۱۳۹۶');
         test.done();
     },
     testDateRngFmtPersRangeMultiYearFull_fa_IR: function(test) {
@@ -1521,7 +1521,7 @@ module.exports.testdatefmtrange_fa_IR = {
             second: 0,
             millisecond: 0
         });
-        test.equal(fmt.format(start, end), '‏۱۳۹۳ بهمن – ‏۱۳۹۶ فروردین');
+        test.equal(fmt.format(start, end), '‏۱۳۹۳ نوامبر – ‏۱۳۹۶ ژانویه');
         test.done();
     },
     testDateRngFmtPersManyYearsFull_fa_IR: function(test) {

--- a/js/test/daterange/testdatefmtrange_fi_FI.js
+++ b/js/test/daterange/testdatefmtrange_fi_FI.js
@@ -1,7 +1,7 @@
 /*
  * testdatefmtrange_fi_FI.js - test the date range formatter object in Finnish/Finland
  * 
- * Copyright © 2012-2017, JEDLSoft
+ * Copyright © 2012-2017, 2020 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -633,7 +633,7 @@ module.exports.testdatefmtrange_fi_FI = {
             second: 0,
             millisecond: 0
         });
-        test.equal(fmt.format(start, end), "marraskuuta 2011 – tammikuuta 2014");
+        test.equal(fmt.format(start, end), "marraskuu 2011 – tammikuu 2014");
         test.done();
     },
     testDateRngFmtFIRangeMultiYearFull: function(test) {
@@ -659,7 +659,7 @@ module.exports.testdatefmtrange_fi_FI = {
             second: 0,
             millisecond: 0
         });
-        test.equal(fmt.format(start, end), "marraskuuta 2011 – tammikuuta 2014");
+        test.equal(fmt.format(start, end), "marraskuu 2011 – tammikuu 2014");
         test.done();
     },
     testDateRngFmtFIManyYearsFull: function(test) {

--- a/js/test/daterange/testdatefmtrange_gl_ES.js
+++ b/js/test/daterange/testdatefmtrange_gl_ES.js
@@ -608,7 +608,7 @@ module.exports.testdatefmtrange_gl_ES = {
             second: 0,
             millisecond: 0
         });
-        test.equal(fmt.format(start, end), "nov. de 2011 – xan. de 2014");
+        test.equal(fmt.format(start, end), "Nov. de 2011 – Xan. de 2014");
         test.done();
     },
     testDateRngFmtglESRangeMultiYearLong: function(test) {
@@ -634,7 +634,7 @@ module.exports.testdatefmtrange_gl_ES = {
             second: 0,
             millisecond: 0
         });
-        test.equal(fmt.format(start, end), "novembro de 2011 – xaneiro de 2014");
+        test.equal(fmt.format(start, end), "Novembro de 2011 – Xaneiro de 2014");
         test.done();
     },
     testDateRngFmtglESRangeMultiYearFull: function(test) {
@@ -660,7 +660,7 @@ module.exports.testdatefmtrange_gl_ES = {
             second: 0,
             millisecond: 0
         });
-        test.equal(fmt.format(start, end), "novembro de 2011 – xaneiro de 2014");
+        test.equal(fmt.format(start, end), "Novembro de 2011 – Xaneiro de 2014");
         test.done();
     },
     testDateRngFmtglESManyYearsFull: function(test) {

--- a/js/test/daterange/testdatefmtrange_hr_HR.js
+++ b/js/test/daterange/testdatefmtrange_hr_HR.js
@@ -1,7 +1,7 @@
 /*
  * testdatefmtrange_hr_HR.js - test the date range formatter object in Croation/Croatia
  * 
- * Copyright © 2012-2017, JEDLSoft
+ * Copyright © 2012-2017, 2020 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -633,7 +633,7 @@ module.exports.testdatefmtrange_hr_HR = {
             second: 0,
             millisecond: 0
         });
-        test.equal(fmt.format(start, end), "studenoga 2011. – siječnja 2014.");
+        test.equal(fmt.format(start, end), "studeni 2011. – siječanj 2014.");
         test.done();
     },
     testDateRngFmtHRRangeMultiYearFull: function(test) {
@@ -659,7 +659,7 @@ module.exports.testdatefmtrange_hr_HR = {
             second: 0,
             millisecond: 0
         });
-        test.equal(fmt.format(start, end), "studenoga 2011. – siječnja 2014.");
+        test.equal(fmt.format(start, end), "studeni 2011. – siječanj 2014.");
         test.done();
     },
     testDateRngFmtHRManyYearsFull: function(test) {

--- a/js/test/daterange/testdatefmtrange_hy_AM.js
+++ b/js/test/daterange/testdatefmtrange_hy_AM.js
@@ -634,7 +634,7 @@ module.exports.testdatefmtrange_hy_AM = {
             second: 0,
             millisecond: 0
         });
-        test.equal(fmt.format(start, end), "նոյեմբերի, 2011 թ. – հունվարի, 2014 թ.");
+        test.equal(fmt.format(start, end), "նոյեմբեր, 2011 թ. – հունվար, 2014 թ.");
         test.done();
     },
     testDateRngFmthyAMRangeMultiYearFull: function(test) {
@@ -660,7 +660,7 @@ module.exports.testdatefmtrange_hy_AM = {
             second: 0,
             millisecond: 0
         });
-        test.equal(fmt.format(start, end), "2011 թ. նոյեմբերի – 2014 թ. հունվարի");
+        test.equal(fmt.format(start, end), "2011 թ. նոյեմբեր – 2014 թ. հունվար");
         test.done();
     },
     testDateRngFmthyAMManyYearsFull: function(test) {

--- a/js/test/daterange/testdatefmtrange_kk_Cyrl_KZ.js
+++ b/js/test/daterange/testdatefmtrange_kk_Cyrl_KZ.js
@@ -1,7 +1,7 @@
 /*
  * testdatefmtrange_kk-Cyrl_KZ.js - test the date range formatter object in Kazakh/Kazakhstan
  * 
- * Copyright © 2012-2017, JEDLSoft
+ * Copyright © 2012-2017, 2020 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -633,7 +633,7 @@ module.exports.testdatefmtrange_kk_Cyrl_KZ = {
             second: 0,
             millisecond: 0
         });
-        test.equal(fmt.format(start, end), "2011 ж. қараша – 2014 ж. қаңтар");
+        test.equal(fmt.format(start, end), "2011 ж. Қараша – 2014 ж. Қаңтар");
         test.done();
     },
     testDateRngFmtKZRangeMultiYearFull: function(test) {
@@ -659,7 +659,7 @@ module.exports.testdatefmtrange_kk_Cyrl_KZ = {
             second: 0,
             millisecond: 0
         });
-        test.equal(fmt.format(start, end), "2011 ж. қараша – 2014 ж. қаңтар");
+        test.equal(fmt.format(start, end), "2011 ж. Қараша – 2014 ж. Қаңтар");
         test.done();
     },
     testDateRngFmtKZManyYearsFull: function(test) {

--- a/js/test/daterange/testdatefmtrange_ky_KG.js
+++ b/js/test/daterange/testdatefmtrange_ky_KG.js
@@ -608,7 +608,7 @@ module.exports.testdatefmtrange_ky_KG = {
             second: 0,
             millisecond: 0
         });
-        test.equal(fmt.format(start, end), "2011-ж., ноя. – 2014-ж., янв.");
+        test.equal(fmt.format(start, end), "2011-ж., Ноя – 2014-ж., Янв");
         test.done();
     },
     testDateRngFmtkyKGRangeMultiYearLong: function(test) {
@@ -634,7 +634,7 @@ module.exports.testdatefmtrange_ky_KG = {
             second: 0,
             millisecond: 0
         });
-        test.equal(fmt.format(start, end), "2011-ж., ноябрь – 2014-ж., январь");
+        test.equal(fmt.format(start, end), "2011-ж., Ноябрь – 2014-ж., Январь");
         test.done();
     },
     testDateRngFmtkyKGRangeMultiYearFull: function(test) {
@@ -660,7 +660,7 @@ module.exports.testdatefmtrange_ky_KG = {
             second: 0,
             millisecond: 0
         });
-        test.equal(fmt.format(start, end), "2011-ж., ноябрь – 2014-ж., январь");
+        test.equal(fmt.format(start, end), "2011-ж., Ноябрь – 2014-ж., Январь");
         test.done();
     },
     testDateRngFmtkyKGManyYearsFull: function(test) {

--- a/js/test/daterange/testdatefmtrange_lt_LT.js
+++ b/js/test/daterange/testdatefmtrange_lt_LT.js
@@ -1,7 +1,7 @@
 /*
  * testdatefmtrange_lt_LT.js - test the date range formatter object in Lithuanian/Lithuania
  * 
- * Copyright © 2012-2017, JEDLSoft
+ * Copyright © 2012-2017, 2020 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -633,7 +633,7 @@ module.exports.testdatefmtrange_lt_LT = {
             second: 0,
             millisecond: 0
         });
-        test.equal(fmt.format(start, end), "2011 m. lapkričio – 2014 m. sausio");
+        test.equal(fmt.format(start, end), "2011 m. lapkritis – 2014 m. sausis");
         test.done();
     },
     testDateRngFmtLTRangeMultiYearFull: function(test) {
@@ -659,7 +659,7 @@ module.exports.testdatefmtrange_lt_LT = {
             second: 0,
             millisecond: 0
         });
-        test.equal(fmt.format(start, end), "2011 m. lapkričio – 2014 m. sausio");
+        test.equal(fmt.format(start, end), "2011 m. lapkritis – 2014 m. sausis");
         test.done();
     },
     testDateRngFmtLTManyYearsFull: function(test) {

--- a/js/test/daterange/testdatefmtrange_mn_Cyrl_MN.js
+++ b/js/test/daterange/testdatefmtrange_mn_Cyrl_MN.js
@@ -1,7 +1,7 @@
 /*
  * testdatefmtrange_mn-Cyrl_MN.js - test the date range formatter object in Mongolian/Mongolia for Cyrillic script.
  *
- * Copyright © 2012-2017, JEDLSoft
+ * Copyright © 2012-2017, 2020 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -633,7 +633,7 @@ module.exports.testdatefmtrange_mn_Cyrl_MN = {
             second: 0,
             millisecond: 0
         });
-        test.equal(fmt.format(start, end), '2011 оны арван нэгдүгээр сар – 2014 оны нэгдүгээр сар');
+        test.equal(fmt.format(start, end), '2011 оны Арван нэгдүгээр сар – 2014 оны Нэгдүгээр сар');
         test.done();
     },
     testDateRngFmtMNRangeMultiYearFull: function(test) {
@@ -659,7 +659,7 @@ module.exports.testdatefmtrange_mn_Cyrl_MN = {
             second: 0,
             millisecond: 0
         });
-        test.equal(fmt.format(start, end), '2011 оны арван нэгдүгээр сар – 2014 оны нэгдүгээр сар');
+        test.equal(fmt.format(start, end), '2011 оны Арван нэгдүгээр сар – 2014 оны Нэгдүгээр сар');
         test.done();
     },
     testDateRngFmtMNManyYearsFull: function(test) {

--- a/js/test/daterange/testdatefmtrange_pl_PL.js
+++ b/js/test/daterange/testdatefmtrange_pl_PL.js
@@ -1,7 +1,7 @@
 /*
  * testdatefmtrange_pl_PL.js - test the date range formatter object in Polish/Poland
  * 
- * Copyright © 2012-2017, JEDLSoft
+ * Copyright © 2012-2017, 2020 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -633,7 +633,7 @@ module.exports.testdatefmtrange_pl_PL = {
             second: 0,
             millisecond: 0
         });
-        test.equal(fmt.format(start, end), "listopada 2011 – stycznia 2014");
+        test.equal(fmt.format(start, end), "listopad 2011 – styczeń 2014");
         test.done();
     },
     testDateRngFmtPLRangeMultiYearFull: function(test) {
@@ -659,7 +659,7 @@ module.exports.testdatefmtrange_pl_PL = {
             second: 0,
             millisecond: 0
         });
-        test.equal(fmt.format(start, end), "listopada 2011 – stycznia 2014");
+        test.equal(fmt.format(start, end), "listopad 2011 – styczeń 2014");
         test.done();
     },
     testDateRngFmtPLManyYearsFull: function(test) {

--- a/js/test/daterange/testdatefmtrange_ru_RU.js
+++ b/js/test/daterange/testdatefmtrange_ru_RU.js
@@ -1,7 +1,7 @@
 /*
  * testdatefmtrange_ru_RU.js - test the date range formatter object Russian/Russia
  * 
- * Copyright © 2012-2017, JEDLSoft
+ * Copyright © 2012-2017, 2020 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -633,7 +633,7 @@ module.exports.testdatefmtrange_ru_RU = {
             second: 0,
             millisecond: 0
         });
-        test.equal(fmt.format(start, end), "ноября 2011 г. – января 2014 г.");
+        test.equal(fmt.format(start, end), "ноябрь 2011 г. – январь 2014 г.");
         test.done();
     },
     testDateRngFmtRURangeMultiYearFull: function(test) {
@@ -659,7 +659,7 @@ module.exports.testdatefmtrange_ru_RU = {
             second: 0,
             millisecond: 0
         });
-        test.equal(fmt.format(start, end), "ноября 2011 г. – января 2014 г.");
+        test.equal(fmt.format(start, end), "ноябрь 2011 г. – январь 2014 г.");
         test.done();
     },
     testDateRngFmtRUManyYearsFull: function(test) {

--- a/js/test/daterange/testdatefmtrange_sk_SK.js
+++ b/js/test/daterange/testdatefmtrange_sk_SK.js
@@ -1,7 +1,7 @@
 /*
  * testdatefmtrange_sk_SK.js - test the date range formatter object Slovak/Slovakia
  * 
- * Copyright © 2012-2017, JEDLSoft
+ * Copyright © 2012-2017, 2020 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -634,7 +634,7 @@ module.exports.testdatefmtrange_sk_SK = {
             second: 0,
             millisecond: 0
         });
-        test.equal(fmt.format(start, end), "novembra 2011 – januára 2014");
+        test.equal(fmt.format(start, end), "november 2011 – január 2014");
         test.done();
     },
     testDateRngFmtSKRangeMultiYearFull: function(test) {
@@ -660,7 +660,7 @@ module.exports.testdatefmtrange_sk_SK = {
             second: 0,
             millisecond: 0
         });
-        test.equal(fmt.format(start, end), "novembra 2011 – januára 2014");
+        test.equal(fmt.format(start, end), "november 2011 – január 2014");
         test.done();
     },
     testDateRngFmtSKManyYearsFull: function(test) {

--- a/js/test/daterange/testdatefmtrange_uk_UA.js
+++ b/js/test/daterange/testdatefmtrange_uk_UA.js
@@ -1,7 +1,7 @@
 /*
  * testdatefmtrange_uk_UA.js - test the date range formatter object Russian/Russia
  * 
- * Copyright © 2012-2017, JEDLSoft
+ * Copyright © 2012-2017, 2020 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -608,7 +608,7 @@ module.exports.testdatefmtrange_uk_UA = {
             second: 0,
             millisecond: 0
         });
-        test.equal(fmt.format(start, end), "лист. 2011 р. – січ. 2014 р.");
+        test.equal(fmt.format(start, end), "лис 2011 р. – січ 2014 р.");
         test.done();
     },
     testDateRngFmtUARangeMultiYearLong: function(test) {
@@ -634,7 +634,7 @@ module.exports.testdatefmtrange_uk_UA = {
             second: 0,
             millisecond: 0
         });
-        test.equal(fmt.format(start, end), "листопада 2011 р. – січня 2014 р.");
+        test.equal(fmt.format(start, end), "листопад 2011 р. – січень 2014 р.");
         test.done();
     },
     testDateRngFmtUARangeMultiYearFull: function(test) {
@@ -660,7 +660,7 @@ module.exports.testdatefmtrange_uk_UA = {
             second: 0,
             millisecond: 0
         });
-        test.equal(fmt.format(start, end), "листопада 2011 р. – січня 2014 р.");
+        test.equal(fmt.format(start, end), "листопад 2011 р. – січень 2014 р.");
         test.done();
     },
     testDateRngFmtUAManyYearsFull: function(test) {

--- a/js/test/daterange/testdatefmtrange_uz_Cyrl_UZ.js
+++ b/js/test/daterange/testdatefmtrange_uz_Cyrl_UZ.js
@@ -1,7 +1,7 @@
 /*
  * testdatefmtrange_uz_Cyrl_UZ.js - test the date range formatter object Uzbek/Uzbekistan for Cyrillic script
  * 
- * Copyright © 2012-2017, JEDLSoft
+ * Copyright © 2012-2017, 2020 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -608,7 +608,7 @@ module.exports.testdatefmtrange_uz_Cyrl_UZ = {
             second: 0,
             millisecond: 0
         });
-        test.equal(fmt.format(start, end), "ноя, 2011 – янв, 2014");
+        test.equal(fmt.format(start, end), "Ноя, 2011 – Янв, 2014");
         test.done();
     },
     testDateRngFmtCyrl_UZRangeMultiYearLong: function(test) {
@@ -634,7 +634,7 @@ module.exports.testdatefmtrange_uz_Cyrl_UZ = {
             second: 0,
             millisecond: 0
         });
-        test.equal(fmt.format(start, end), "ноябр, 2011 – январ, 2014");
+        test.equal(fmt.format(start, end), "Ноябр, 2011 – Январ, 2014");
         test.done();
     },
     testDateRngFmtCyrl_UZRangeMultiYearFull: function(test) {
@@ -660,7 +660,7 @@ module.exports.testdatefmtrange_uz_Cyrl_UZ = {
             second: 0,
             millisecond: 0
         });
-        test.equal(fmt.format(start, end), "ноябр, 2011 – январ, 2014");
+        test.equal(fmt.format(start, end), "Ноябр, 2011 – Январ, 2014");
         test.done();
     },
     testDateRngFmtCyrl_UZManyYearsFull: function(test) {

--- a/js/test/daterange/testdatefmtrange_uz_Latn_UZ.js
+++ b/js/test/daterange/testdatefmtrange_uz_Latn_UZ.js
@@ -1,7 +1,7 @@
 /*
  * testdatefmtrange_Latn_UZ.js - test the date range formatter object Uzbek/Uzbekistan for Latin script
  * 
- * Copyright © 2012-2017, JEDLSoft
+ * Copyright © 2012-2017, 2020 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -607,7 +607,7 @@ module.exports.testdatefmtrange_uz_Latn_UZ = {
             second: 0,
             millisecond: 0
         });
-        test.equal(fmt.format(start, end), "noy, 2011 – yan, 2014");
+        test.equal(fmt.format(start, end), "Noy, 2011 – Yan, 2014");
         test.done();
     },
     testDateRngFmtLatn_UZRangeMultiYearLong: function(test) {
@@ -633,7 +633,7 @@ module.exports.testdatefmtrange_uz_Latn_UZ = {
             second: 0,
             millisecond: 0
         });
-        test.equal(fmt.format(start, end), "noyabr, 2011 – yanvar, 2014");
+        test.equal(fmt.format(start, end), "Noyabr, 2011 – Yanvar, 2014");
         test.done();
     },
     testDateRngFmtLatn_UZRangeMultiYearFull: function(test) {
@@ -659,7 +659,7 @@ module.exports.testdatefmtrange_uz_Latn_UZ = {
             second: 0,
             millisecond: 0
         });
-        test.equal(fmt.format(start, end), "noyabr, 2011 – yanvar, 2014");
+        test.equal(fmt.format(start, end), "Noyabr, 2011 – Yanvar, 2014");
         test.done();
     },
     testDateRngFmtLatn_UZManyYearsFull: function(test) {

--- a/js/test/daterange/testdatefmtrange_vi_VN.js
+++ b/js/test/daterange/testdatefmtrange_vi_VN.js
@@ -1,7 +1,7 @@
 /*
  * testdatefmtrange_vi_VN.js - test the date range formatter object Vietnamese/Vietnam
  * 
- * Copyright © 2012-2017, JEDLSoft
+ * Copyright © 2012-2017, 2020 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -608,7 +608,7 @@ module.exports.testdatefmtrange_vi_VN = {
             second: 0,
             millisecond: 0
         });
-        test.equal(fmt.format(start, end), "thg 11, 2011 – thg 1, 2014");
+        test.equal(fmt.format(start, end), "Thg 11, 2011 – Thg 1, 2014");
         test.done();
     },
     testDateRngFmtVNRangeMultiYearLong: function(test) {
@@ -634,7 +634,7 @@ module.exports.testdatefmtrange_vi_VN = {
             second: 0,
             millisecond: 0
         });
-        test.equal(fmt.format(start, end), "tháng 11, 2011 – tháng 1, 2014");
+        test.equal(fmt.format(start, end), "Tháng 11, 2011 – Tháng 1, 2014");
         test.done();
     },
     testDateRngFmtVNRangeMultiYearFull: function(test) {
@@ -660,7 +660,7 @@ module.exports.testdatefmtrange_vi_VN = {
             second: 0,
             millisecond: 0
         });
-        test.equal(fmt.format(start, end), "tháng 11, 2011 – tháng 1, 2014");
+        test.equal(fmt.format(start, end), "Tháng 11, 2011 – Tháng 1, 2014");
         test.done();
     },
     testDateRngFmtVNManyYearsFull: function(test) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib",
-    "version": "14.6.1",
+    "version": "14.6.2",
     "main": "js/index.js",
     "description": "iLib is a cross-engine library of internationalization (i18n) classes written in pure JS",
     "keywords": [


### PR DESCRIPTION
### Checklist

* [ ] At least one test case is included for this feature or bug fix.
* [x] `ReleaseNotes` has added or is not needed.
* [x] This PR has passed all of the test cases on `Nodejs` and `Chrome Browser`.
* [x] This PR has passed all of the test cases on `QT/QML`.
* [ ] This is an API breaking change.
* [ ] Requires a major version change.


### Issue Resolved / Feature Added
According to DateRange Formatting spec, https://github.com/iLib-js/iLib/blob/development/docs/DateRangeFormatSpec.md
When the Month and Year are displayed as like the case 'c20`, it should present the standAlone value of the month if it exists.
I've made fixed to support that and fixed unit tests.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

### Links
[//]: # (Related issues, references)
http://cldr.unicode.org/translation/date-time-1/date-time-patterns#TOC-When-to-use-Standalone-vs.-Formatting
http://cldr.unicode.org/translation/date-time-1/date-time