### PR TITLE
Remove IString dynamic length

### DIFF
--- a/js/lib/IString.js
+++ b/js/lib/IString.js
@@ -532,6 +532,7 @@ IString.prototype = {
      * console.log("String is " + str._length() + " characters long.");
      * </pre>
      * @private
+     * @deprecated
      */
     _length: function () {
         return this.str.length;

--- a/js/lib/IString.js
+++ b/js/lib/IString.js
@@ -1444,10 +1444,4 @@ IString.prototype = {
     }
 };
 
-Object.defineProperty(IString, 'length', {
-    get: function() {
-        return this._length();
-    }
-});
-
 module.exports = IString;


### PR DESCRIPTION
### Checklist

* [ ] At least one test case is included for this feature or bug fix.
* [X] `ReleaseNotes` has added or is not needed.
* [X] This PR has passed all of the test cases on `Nodejs` and `Chrome Browser`.
* [X] This PR has passed all of the test cases on `QT/QML`.
* [ ] This is an API breaking change.
* [ ] Requires a major version change.


### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
The IString implementation breaks on webOS 3.x devices (WebKit 537.36) with the following error: `Cannot redefine property: length`.
This happens while loading the file.
![image](https://user-images.githubusercontent.com/2428395/94301327-4a7ff880-ff62-11ea-9cca-1cf0ead9a4e8.png)

User agent: `Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/537.36 (KHTML, like Gecko) QtWebEngine/5.2.1 Chrome/38.0.2125.122 Safari/537.36 WebAppManager`


### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Since the string is a constant, there is no need to define a getter for this. The value computed in the constructor should be enough and no break changes were done.
