### PR TITLE
Added guard code for edge case in JSUtils.merge not to throw an error

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -21,6 +21,7 @@ Bug Fixes:
     the wrong date components in some cases
     * Also affects date range formatting as well so that the year-month and the year alone
     ranges can use the stand-alone formats independently of each other
+* Added guard code to consider when the object is undefined in JSUtil.merge at least not to throw an error
 
 Build 011
 -------

--- a/js/lib/JSUtils.js
+++ b/js/lib/JSUtils.js
@@ -210,6 +210,12 @@ JSUtils.isDate = function(object) {
  * @return {Object} the merged object
  */
 JSUtils.merge = function (object1, object2, replace, name1, name2) {
+    if (!object1 && object2) {
+        return object2;
+    }
+    if (object1 && !object2) {
+        return object1;
+    }
     var prop = undefined,
         newObj = {};
     for (prop in object1) {

--- a/js/test/util/testutils.js
+++ b/js/test/util/testutils.js
@@ -721,6 +721,28 @@ module.exports.testutils = {
         test.deepEqual(actual, expected);
         test.done();
     },
+
+    testMergeUndefined: function(test) {
+        test.expect(1);
+        var object1 = undefined,
+            object2 = {"a": 1, "b": 2};
+
+        var expected = {"a": 1, "b": 2};
+        var actual = JSUtils.merge(object1, object2);
+        test.deepEqual(actual, expected);
+        test.done();
+    },
+
+    testMergeUndefined2: function(test) {
+        test.expect(1);
+        var object1 = {"a": 1, "b": 2},
+            object2 = undefined;
+
+        var expected = {"a": 1, "b": 2};
+        var actual = JSUtils.merge(object1, object2);
+        test.deepEqual(actual, expected);
+        test.done();
+    },
     
     testIsEmptyFalse: function(test) {
         test.expect(1);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib",
-    "version": "14.6.2",
+    "version": "14.7.0",
     "main": "js/index.js",
     "description": "iLib is a cross-engine library of internationalization (i18n) classes written in pure JS",
     "keywords": [


### PR DESCRIPTION
### Checklist

* [ ] At least one test case is included for this feature or bug fix.
* [x] `ReleaseNotes` has added or is not needed.
* [x] This PR has passed all of the test cases on `Nodejs` and `Chrome Browser`.
* [x] This PR has passed all of the test cases on `QT/QML`.
* [ ] This is an API breaking change.
* [ ] Requires a major version change.


### Issue Resolved / Feature Added
Added guard code to consider when the object is `undefined` in `JSUtil.merge`  at least not to throw an error.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

### Links
[//]: # (Related issues, references)
