### PR TITLE
Update copyrigyt mark to (c) and reschedule to trigger copyrigyt year action

### DIFF
--- a/.github/workflows/update-copyright-years.yml
+++ b/.github/workflows/update-copyright-years.yml
@@ -2,7 +2,7 @@ name: Update copyright year(s) in license file
 
 on:
   schedule:
-    - cron: "00 7 19 3 *"
+    - cron: "00 7 20 3 *"
 
 jobs:
   run:

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ section about webpack for links.
 Copyright and License
 -------
 
-Copyright &copy; 2011-2019, JEDLSoft
+Copyright (c) 2011-2019, JEDLSoft
 
 Ilib is licensed under the Apache License, Version 2.0 (the "License");
 you may not use this library except in compliance with the License.


### PR DESCRIPTION
### Checklist

* [ ] At least one test case is included for this feature or bug fix.
* [ ] `ReleaseNotes` has added or is not needed.
* [ ] This PR has passed all of the test cases on `Nodejs` and `Chrome Browser`.
* [ ] This PR has passed all of the test cases on `QT/QML`.
* [ ] This is an API breaking change.
* [ ] Requires a major version change.


### Issue Resolved / Feature Added
* Reschedule to trigger copyrigyt year again
* Update copyright mark to (c). it looks like it couldn't filter &copy; text

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

### Links
[//]: # (Related issues, references)
