### PR TITLE
Add ruby & template style escaping for pseudo localization

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version=14.8.0
+version=14.9.0

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -3,9 +3,15 @@ Release Notes for Version 14
 
 Build 014
 -------
-Published as version 14.8.1
+Published as version 14.9.0
 
 New Features:
+* Add ruby & template style escaping for pseudo localization.
+    * Here is an example of `%RUBY%` substitution parameters.
+    * Here is an example of template substitution parameters:
+    `<% code here %>`
+    * Also added Objective-C/Swift substitution parameter support
+      for the "c" style of escaping
 
 Bug Fixes:
 * Updated `iddarea.json`, `phoneloc.json`, and `numplan.json` from phonenumber library based on metadata version 4.0.0 which are used in PhoneNumber formatting.
@@ -19,7 +25,7 @@ New Features:
   script, region) are valid ISO codes.
 * Supported additional mt-MT, tg-TJ, tk-TM, wo-SN, zu-ZA locales
     * validated locale data and added many test cases
-    
+
 Bug Fixes:
 * Fixed a bug which a default script for `tk` should be `Latin` instead of `Arabic`
 * Fixed a bug which a default script for `tg` should be `Cyrl` instead of `Arabic`
@@ -127,7 +133,7 @@ Build 007
 Published as version 14.4.0
 
 New Features:
-* Updated `iddarea.json` and `phoneloc.json` which are used in `PhoneNumber` information and wrote a script file to automatically generate it.
+* Updated `iddarea.json` and 'phoneloc.json' which are used in `PhoneNumber` information and wrote a script file to automatically generate it.
 * Added LocaleMatch.getLikelyLocaleMinimal() method which returns the same thing as the getLikelyLocale method but without the script
 part of the locale specifier if it has a very common/default value
     * For languages such as Chinese which are commonly written in multiple scripts, the script is always given

--- a/js/lib/ResBundle.js
+++ b/js/lib/ResBundle.js
@@ -405,7 +405,29 @@ ResBundle.prototype = {
                             i += m[0].length;
                         }
                     }
-
+                } else if (this.type === "ruby") {
+                    if (str.charAt(i) === "%") {
+                        ret += str.charAt(i++);
+                        while (i < str.length && str.charAt(i) !== '%') {
+                            ret += str.charAt(i++);
+                        }
+                    }
+                } else if (this.type === "template") {
+                    if (str.charAt(i) === '<' && str.charAt(i+1) === '%') {
+                        ret += str.charAt(i++);
+                        ret += str.charAt(i++);
+                        while (i < str.length && (str.charAt(i) !== '>' || str.charAt(i-1) !== '%')) {
+                            ret += str.charAt(i++);
+                        }
+                    } else if (str.charAt(i) === '&') {
+                        ret += str.charAt(i++);
+                        while (i < str.length && str.charAt(i) !== ';' && str.charAt(i) !== ' ') {
+                            ret += str.charAt(i++);
+                        }
+                    } else if (str.charAt(i) === '\\' && str.charAt(i+1) === "u") {
+                        ret += str.substring(i, i+6);
+                        i += 6;
+                    }
                 }
                 if (i < str.length) {
                     if (str.charAt(i) === '{') {

--- a/js/lib/ResBundle.js
+++ b/js/lib/ResBundle.js
@@ -45,15 +45,17 @@ var IString = require("./IString.js");
  * base name is "resources".
  *
  * <li><i>type</i> - Name the type of strings this bundle contains. Valid values are
- * "xml", "html", "text", "c", or "raw". The default is "text". If the type is "xml" or "html",
+ * "xml", "html", "text", "c", "raw", "ruby", or "template". The default is "text".
+ * If the type is "xml" or "html",
  * then XML/HTML entities and tags are not pseudo-translated. During a real translation,
  * HTML character entities are translated to their corresponding characters in a source
  * string before looking that string up in the translations. Also, the characters "<", ">",
  * and "&" are converted to entities again in the output, but characters are left as they
- * are. If the type is "xml", "html", or "text" types, then the replacement parameter names
+ * are. If the type is "xml", "html", "ruby", or "text" types, then the replacement parameter names
  * are not pseudo-translated as well so that the output can be used for formatting with
  * the IString class. If the type is "c" then all C language style printf replacement
- * parameters (eg. "%s" and "%d") are skipped automatically. If the type is raw, all characters
+ * parameters (eg. "%s" and "%d") are skipped automatically. This includes iOS/Objective-C/Swift
+ * substitution parameters like "%@" or "%1$@". If the type is raw, all characters
  * are pseudo-translated, including replacement parameters as well as XML/HTML tags and entities.
  *
  * <li><i>lengthen</i> - when pseudo-translating the string, tell whether or not to
@@ -368,7 +370,7 @@ ResBundle.prototype = {
         return this.type;
     },
 
-    percentRE: new RegExp("%(\\d+\\$)?([\\-#\\+ 0,\\(])?(\\d+)?(\\.\\d+)?[bBhHsScCdoxXeEfgGaAtT%n]"),
+    percentRE: new RegExp("%(\\d+\\$)?([\\-#\\+ 0,\\(])*(\\d+)?(\\.\\d+)?(h|hh|l|ll|j|z|t|L|q)?[diouxXfFeEgGaAcspnCS%@]"),
 
     /**
      * @private

--- a/js/lib/ResBundle.js
+++ b/js/lib/ResBundle.js
@@ -408,7 +408,7 @@ ResBundle.prototype = {
                         }
                     }
                 } else if (this.type === "ruby") {
-                    if (str.charAt(i) === "%") {
+                    if (str.charAt(i) === "%" && i < str.length && str.charAt(i+1) !== "{") {
                         ret += str.charAt(i++);
                         while (i < str.length && str.charAt(i) !== '%') {
                             ret += str.charAt(i++);

--- a/js/package.json.template
+++ b/js/package.json.template
@@ -50,12 +50,6 @@
         "type": "git",
         "url": "git@github.com:iLib-js/iLib.git"
     },
-    "repositories": [
-        {
-            "type": "git",
-            "url": "git@github.com:iLib-js/iLib.git"
-        }
-    ],
     "scripts": {
        "test": "ant test"
     },

--- a/js/test/root/testglobal.js
+++ b/js/test/root/testglobal.js
@@ -74,7 +74,7 @@ module.exports.testglobal = {
             return;
         }
         test.expect(1);
-        test.equal(ilib.getVersion().substring(0,4), "14.8");
+        test.equal(ilib.getVersion().substring(0,4), "14.9");
         test.done();
     },
     

--- a/js/test/root/testresources.js
+++ b/js/test/root/testresources.js
@@ -1230,6 +1230,20 @@ module.exports.testresources = {
        test.done();
     },
 
+    testResBundleGetStringPseudoHtmlEscapeHaml: function(test) {
+        test.expect(2);
+       var rb = new ResBundle({
+           name: "asdfasdffoobar",
+           locale: "zxx-XX",
+           type: "ruby"
+       });
+
+       test.ok(rb !== null);
+
+       test.equal(rb.getStringJS("Hello from %{city}, city of #{description}."), "Ħëľľõ fŕõm %{city}, çíţÿ õf #{description}.");
+       test.done();
+    },
+
     testResBundleGetStringPseudoHtmlEscapeJS: function(test) {
         test.expect(2);
        var rb = new ResBundle({

--- a/js/test/root/testresources.js
+++ b/js/test/root/testresources.js
@@ -517,20 +517,21 @@ module.exports.testresources = {
     },
     
     testResBundleGetStringOtherBundlePseudoC: function(test) {
-        test.expect(38);
+        test.expect(48);
         var rb = new ResBundle({
             name: "tester",
             locale: "zxx-XX",
             type: "c",
             lengthen: true
         });
-        
+
         test.ok(rb !== null);
-        
+
         // should not pseudo-ize the C style replacement parameters
+        // now follows the IEEE printf specification:
+        // https://pubs.opengroup.org/onlinepubs/009695399/functions/printf.html
         test.equal(rb.getStringJS("actual %s "), "àçţüàľ %s 43210");
         test.equal(rb.getStringJS("actual %b "), "àçţüàľ %b 43210");
-        test.equal(rb.getStringJS("actual %h "), "àçţüàľ %h 43210");
         test.equal(rb.getStringJS("actual %c "), "àçţüàľ %c 43210");
         test.equal(rb.getStringJS("actual %d "), "àçţüàľ %d 43210");
         test.equal(rb.getStringJS("actual %o "), "àçţüàľ %o 43210");
@@ -539,21 +540,18 @@ module.exports.testresources = {
         test.equal(rb.getStringJS("actual %f "), "àçţüàľ %f 43210");
         test.equal(rb.getStringJS("actual %g "), "àçţüàľ %g 43210");
         test.equal(rb.getStringJS("actual %a "), "àçţüàľ %a 43210");
-        test.equal(rb.getStringJS("actual %t "), "àçţüàľ %t 43210");
         test.equal(rb.getStringJS("actual %% "), "àçţüàľ %% 43210");
         test.equal(rb.getStringJS("actual %n "), "àçţüàľ %n 43210");
-        
+        test.equal(rb.getStringJS("actual %p "), "àçţüàľ %p 43210");
+
         test.equal(rb.getStringJS("actual %S "), "àçţüàľ %S 43210");
-        test.equal(rb.getStringJS("actual %B "), "àçţüàľ %B 43210");
-        test.equal(rb.getStringJS("actual %H "), "àçţüàľ %H 43210");
         test.equal(rb.getStringJS("actual %C "), "àçţüàľ %C 43210");
         test.equal(rb.getStringJS("actual %X "), "àçţüàľ %X 43210");
         test.equal(rb.getStringJS("actual %E "), "àçţüàľ %E 43210");
         test.equal(rb.getStringJS("actual %G "), "àçţüàľ %G 43210");
         test.equal(rb.getStringJS("actual %A "), "àçţüàľ %A 43210");
-        test.equal(rb.getStringJS("actual %T "), "àçţüàľ %T 43210");
         test.equal(rb.getStringJS("actual %% "), "àçţüàľ %% 43210");
-        
+
         test.equal(rb.getStringJS("actual %2$s "), "àçţüàľ %2$s 543210");
         test.equal(rb.getStringJS("actual %-d "), "àçţüàľ %-d 543210");
         test.equal(rb.getStringJS("actual %#d "), "àçţüàľ %#d 543210");
@@ -563,11 +561,33 @@ module.exports.testresources = {
         test.equal(rb.getStringJS("actual %.2d "), "àçţüàľ %.2d 543210");
         test.equal(rb.getStringJS("actual %(2d "), "àçţüàľ %(2d 543210");
         test.equal(rb.getStringJS("actual %4$-2.2d "), "àçţüàľ %4$-2.2d 76543210");
-        
+
         test.equal(rb.getStringJS("actual %N "), "àçţüàľ %Ň 43210");
         test.equal(rb.getStringJS("actual %F "), "àçţüàľ %F 43210");
         test.equal(rb.getStringJS("actual %D "), "àçţüàľ %Ð 43210");
         test.equal(rb.getStringJS("actual %O "), "àçţüàľ %Ø 43210");
+
+        test.equal(rb.getStringJS("actual %hd "), "àçţüàľ %hd 543210");
+        test.equal(rb.getStringJS("actual %hhd "), "àçţüàľ %hhd 543210");
+        test.equal(rb.getStringJS("actual %ld "), "àçţüàľ %ld 543210");
+        test.equal(rb.getStringJS("actual %lld "), "àçţüàľ %lld 543210");
+        test.equal(rb.getStringJS("actual %Af "), "àçţüàľ %Af 543210");
+        test.equal(rb.getStringJS("actual %zd "), "àçţüàľ %zd 543210");
+        test.equal(rb.getStringJS("actual %td "), "àçţüàľ %td 543210");
+        test.equal(rb.getStringJS("actual %jd "), "àçţüàľ %jd 543210");
+        test.equal(rb.getStringJS("actual %% "), "àçţüàľ %% 43210");
+
+        // now everything at once!
+        test.equal(rb.getStringJS("actual %2$+0.4lld "), "àçţüàľ %2$+0.4lld 876543210");
+
+        // now some extended format specifiers to support Swift/Objective-C
+        // from https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/Strings/Articles/formatSpecifiers.html#//apple_ref/doc/uid/TP40004265-SW1
+        // %@ means format an objective-C or swift object
+        test.equal(rb.getStringJS("actual %@ "), "àçţüàľ %@ 43210");
+        test.equal(rb.getStringJS("actual %2$@ "), "àçţüàľ %2$@ 543210");
+        test.equal(rb.getStringJS("actual %2$0ll@ "), "àçţüàľ %2$0ll@ 76543210");
+        test.equal(rb.getStringJS("actual %qd "), "àçţüàľ %qd 543210");
+
         test.done();
     },
     

--- a/js/test/root/testresources.js
+++ b/js/test/root/testresources.js
@@ -397,7 +397,7 @@ module.exports.testresources = {
     },
     
     
-    testResBundleGetStringOtherBundlePsuedoRaw: function(test) {
+    testResBundleGetStringOtherBundlePseudoRaw: function(test) {
         test.expect(4);
         var rb = new ResBundle({
             name: "tester",
@@ -414,7 +414,7 @@ module.exports.testresources = {
         test.done();
     },
     
-    testResBundleGetStringOtherBundlePsuedoText: function(test) {
+    testResBundleGetStringOtherBundlePseudoText: function(test) {
         test.expect(4);
         var rb = new ResBundle({
             name: "tester",
@@ -431,7 +431,7 @@ module.exports.testresources = {
         test.done();
     },
     
-    testResBundleGetStringOtherBundlePsuedoHtml: function(test) {
+    testResBundleGetStringOtherBundlePseudoHtml: function(test) {
         test.expect(4);
         var rb = new ResBundle({
             name: "tester",
@@ -448,7 +448,7 @@ module.exports.testresources = {
         test.done();
     },
     
-    testResBundleGetStringOtherBundlePsuedoHtmlWithTags: function(test) {
+    testResBundleGetStringOtherBundlePseudoHtmlWithTags: function(test) {
         test.expect(4);
         var rb = new ResBundle({
             name: "tester",
@@ -465,7 +465,7 @@ module.exports.testresources = {
         test.done();
     },
     
-    testResBundleGetStringOtherBundlePsuedoHtmlWithMultipleTags: function(test) {
+    testResBundleGetStringOtherBundlePseudoHtmlWithMultipleTags: function(test) {
         test.expect(4);
         var rb = new ResBundle({
             name: "tester",
@@ -482,7 +482,7 @@ module.exports.testresources = {
         test.done();
     },
     
-    testResBundleGetStringOtherBundlePsuedoHtmlWithTagsAndEntities: function(test) {
+    testResBundleGetStringOtherBundlePseudoHtmlWithTagsAndEntities: function(test) {
         test.expect(4);
         var rb = new ResBundle({
             name: "tester",
@@ -499,7 +499,7 @@ module.exports.testresources = {
         test.done();
     },
     
-    testResBundleGetStringOtherBundlePsuedoXml: function(test) {
+    testResBundleGetStringOtherBundlePseudoXml: function(test) {
         test.expect(4);
         var rb = new ResBundle({
             name: "tester",
@@ -516,7 +516,7 @@ module.exports.testresources = {
         test.done();
     },
     
-    testResBundleGetStringOtherBundlePsuedoC: function(test) {
+    testResBundleGetStringOtherBundlePseudoC: function(test) {
         test.expect(38);
         var rb = new ResBundle({
             name: "tester",
@@ -571,7 +571,7 @@ module.exports.testresources = {
         test.done();
     },
     
-    testResBundleGetStringOtherBundlePsuedoDefault: function(test) {
+    testResBundleGetStringOtherBundlePseudoDefault: function(test) {
         test.expect(4);
         var rb = new ResBundle({
             name: "tester",
@@ -587,7 +587,7 @@ module.exports.testresources = {
         test.done();
     },
     
-    testResBundleGetStringMissingBundlePsuedoHtml: function(test) {
+    testResBundleGetStringMissingBundlePseudoHtml: function(test) {
         test.expect(4);
         var rb = new ResBundle({
             name: "asdfasdffoobar",
@@ -604,7 +604,7 @@ module.exports.testresources = {
         test.done();
     },
     
-    testResBundleGetStringPsuedoHtmlLengthenShort: function(test) {
+    testResBundleGetStringPseudoHtmlLengthenShort: function(test) {
         test.expect(2);
         var rb = new ResBundle({
             name: "asdfasdffoobar",
@@ -620,7 +620,7 @@ module.exports.testresources = {
         test.done();
     },
     
-    testResBundleGetStringPsuedoHtmlLengthenMedium: function(test) {
+    testResBundleGetStringPseudoHtmlLengthenMedium: function(test) {
         test.expect(2);
         var rb = new ResBundle({
             name: "asdfasdffoobar",
@@ -636,7 +636,7 @@ module.exports.testresources = {
         test.done();
     },
     
-    testResBundleGetStringPsuedoHtmlLengthenLong: function(test) {
+    testResBundleGetStringPseudoHtmlLengthenLong: function(test) {
         test.expect(2);
         var rb = new ResBundle({
             name: "asdfasdffoobar",
@@ -652,7 +652,7 @@ module.exports.testresources = {
         test.done();
     },
     
-    testResBundleGetStringPsuedoLeaveHTMLTags: function(test) {
+    testResBundleGetStringPseudoLeaveHTMLTags: function(test) {
         test.expect(2);
         var rb = new ResBundle({
             name: "tester",
@@ -666,7 +666,7 @@ module.exports.testresources = {
         test.done();
     },
     
-    testResBundleGetStringPsuedoLeaveHTMLTags2: function(test) {
+    testResBundleGetStringPseudoLeaveHTMLTags2: function(test) {
         test.expect(2);
         var rb = new ResBundle({
             name: "tester",
@@ -680,7 +680,7 @@ module.exports.testresources = {
         test.done();
     },
     
-    testResBundleGetStringPsuedoNotLeaveHTMLTagsRaw: function(test) {
+    testResBundleGetStringPseudoNotLeaveHTMLTagsRaw: function(test) {
         test.expect(2);
         var rb = new ResBundle({
             name: "tester",
@@ -694,7 +694,7 @@ module.exports.testresources = {
         test.done();
     },
     
-    testResBundleGetStringPsuedoNotLeaveHTMLTagsText: function(test) {
+    testResBundleGetStringPseudoNotLeaveHTMLTagsText: function(test) {
         test.expect(2);
         var rb = new ResBundle({
             name: "tester",
@@ -708,7 +708,7 @@ module.exports.testresources = {
         test.done();
     },
     
-    testResBundleGetStringPsuedoLeaveHTMLEntities: function(test) {
+    testResBundleGetStringPseudoLeaveHTMLEntities: function(test) {
         test.expect(2);
         var rb = new ResBundle({
             name: "tester",
@@ -722,7 +722,7 @@ module.exports.testresources = {
         test.done();
     },
     
-    testResBundleGetStringPsuedoNotLeaveHTMLEntitiesRaw: function(test) {
+    testResBundleGetStringPseudoNotLeaveHTMLEntitiesRaw: function(test) {
         test.expect(2);
         var rb = new ResBundle({
             name: "tester",
@@ -736,7 +736,7 @@ module.exports.testresources = {
         test.done();
     },
     
-    testResBundleGetStringPsuedoNotLeaveHTMLEntitiesText: function(test) {
+    testResBundleGetStringPseudoNotLeaveHTMLEntitiesText: function(test) {
         test.expect(2);
         var rb = new ResBundle({
             name: "tester",
@@ -750,7 +750,7 @@ module.exports.testresources = {
         test.done();
     },
     
-    testResBundleGetStringMissingBundlePsuedoXml: function(test) {
+    testResBundleGetStringMissingBundlePseudoXml: function(test) {
         test.expect(4);
         var rb = new ResBundle({
             name: "asdfasdffoobar",
@@ -767,7 +767,7 @@ module.exports.testresources = {
         test.done();
     },
     
-    testResBundleGetStringPsuedoXmlLengthenShort: function(test) {
+    testResBundleGetStringPseudoXmlLengthenShort: function(test) {
         test.expect(2);
         var rb = new ResBundle({
             name: "asdfasdffoobar",
@@ -783,7 +783,7 @@ module.exports.testresources = {
         test.done();
     },
     
-    testResBundleGetStringPsuedoXmlLengthenMedium: function(test) {
+    testResBundleGetStringPseudoXmlLengthenMedium: function(test) {
         test.expect(2);
         var rb = new ResBundle({
             name: "asdfasdffoobar",
@@ -799,7 +799,7 @@ module.exports.testresources = {
         test.done();
     },
     
-    testResBundleGetStringPsuedoXmlLengthenLong: function(test) {
+    testResBundleGetStringPseudoXmlLengthenLong: function(test) {
         test.expect(2);
         var rb = new ResBundle({
             name: "asdfasdffoobar",
@@ -815,7 +815,7 @@ module.exports.testresources = {
         test.done();
     },
     
-    testResBundleGetStringPsuedoLeaveXmlTags: function(test) {
+    testResBundleGetStringPseudoLeaveXmlTags: function(test) {
         test.expect(2);
         var rb = new ResBundle({
             name: "tester",
@@ -829,7 +829,7 @@ module.exports.testresources = {
         test.done();
     },
     
-    testResBundleGetStringPsuedoLeaveXmlEntities: function(test) {
+    testResBundleGetStringPseudoLeaveXmlEntities: function(test) {
         test.expect(2);
         var rb = new ResBundle({
             name: "tester",
@@ -1153,7 +1153,7 @@ module.exports.testresources = {
        test.done();
     },
     
-    testResBundleGetStringPsuedoHtmlNoEscape: function(test) {
+    testResBundleGetStringPseudoHtmlNoEscape: function(test) {
         test.expect(2);
        var rb = new ResBundle({
            name: "asdfasdffoobar",
@@ -1167,7 +1167,7 @@ module.exports.testresources = {
        test.done();
     },
     
-    testResBundleGetStringPsuedoHtmlEscapeHtml: function(test) {
+    testResBundleGetStringPseudoHtmlEscapeHtml: function(test) {
         test.expect(2);
        var rb = new ResBundle({
            name: "asdfasdffoobar",
@@ -1180,8 +1180,37 @@ module.exports.testresources = {
        test.equal(rb.getString("Hello from <a href=\"asdf\">Paris</a>, city of lights.", undefined, "html").toString(), "Ħëľľõ fŕõm &lt;a href=\"asdf\"&gt;Pàŕíš&lt;/a&gt;, çíţÿ õf ľíğĥţš.");
        test.done();
     },
-    
-    testResBundleGetStringPsuedoHtmlEscapeJS: function(test) {
+
+    testResBundleGetStringPseudoHtmlEscapeJst: function(test) {
+        test.expect(2);
+       var rb = new ResBundle({
+           name: "asdfasdffoobar",
+           locale: "zxx-XX",
+           type: "template"
+       });
+
+       test.ok(rb !== null);
+
+       test.equal(rb.getStringJS("Hello from <%= (i > 4) ? RB.getStringJS(\"Las Vegas\") : RB.getStringJS(\"Paris\") %>, city of lights.", undefined, "none"),
+           "Ħëľľõ fŕõm <%= (i > 4) ? RB.getStringJS(\"Las Vegas\") : RB.getStringJS(\"Paris\") %>, çíţÿ õf ľíğĥţš.");
+       test.done();
+    },
+
+    testResBundleGetStringPseudoHtmlEscapeRuby: function(test) {
+        test.expect(2);
+       var rb = new ResBundle({
+           name: "asdfasdffoobar",
+           locale: "zxx-XX",
+           type: "ruby"
+       });
+
+       test.ok(rb !== null);
+
+       test.equal(rb.getStringJS("Hello from %PARIS%, city of lights.", undefined, "html"), "Ħëľľõ fŕõm %PARIS%, çíţÿ õf ľíğĥţš.");
+       test.done();
+    },
+
+    testResBundleGetStringPseudoHtmlEscapeJS: function(test) {
         test.expect(2);
        var rb = new ResBundle({
            name: "asdfasdffoobar",
@@ -1473,7 +1502,7 @@ module.exports.testresources = {
     },
     
     
-    testResBundleGetStringCyrlPsuedoRaw: function(test) {
+    testResBundleGetStringCyrlPseudoRaw: function(test) {
         test.expect(4);
         var rb = new ResBundle({
             name: "tester",
@@ -1490,7 +1519,7 @@ module.exports.testresources = {
         test.done();
     },
     
-    testResBundleGetStringCyrlPsuedoText: function(test) {
+    testResBundleGetStringCyrlPseudoText: function(test) {
         test.expect(4);
         var rb = new ResBundle({
             name: "tester",
@@ -1507,7 +1536,7 @@ module.exports.testresources = {
         test.done();
     },
     
-    testResBundleGetStringCyrlPsuedoHtml: function(test) {
+    testResBundleGetStringCyrlPseudoHtml: function(test) {
         test.expect(4);
         var rb = new ResBundle({
             name: "tester",
@@ -1524,7 +1553,7 @@ module.exports.testresources = {
         test.done();
     },
     
-    testResBundleGetStringCyrlPsuedoXml: function(test) {
+    testResBundleGetStringCyrlPseudoXml: function(test) {
         test.expect(4);
         var rb = new ResBundle({
             name: "tester",
@@ -1541,7 +1570,7 @@ module.exports.testresources = {
         test.done();
     },
     
-    testResBundleGetStringCyrlPsuedoDefault: function(test) {
+    testResBundleGetStringCyrlPseudoDefault: function(test) {
         test.expect(4);
         var rb = new ResBundle({
             name: "tester",
@@ -1557,7 +1586,7 @@ module.exports.testresources = {
         test.done();
     },
     
-    testResBundleGetStringHansPsuedoText: function(test) {
+    testResBundleGetStringHansPseudoText: function(test) {
         test.expect(4);
         var rb = new ResBundle({
             name: "tester",
@@ -1575,7 +1604,7 @@ module.exports.testresources = {
         test.done();
     },
     
-    testResBundleGetStringHebrPsuedoText: function(test) {
+    testResBundleGetStringHebrPseudoText: function(test) {
         test.expect(4);
         var rb = new ResBundle({
             name: "tester",
@@ -1700,7 +1729,7 @@ module.exports.testresources = {
         test.done();
     },
     
-    testResBundleGetStringLatnMissingPsuedo: function(test) {
+    testResBundleGetStringLatnMissingPseudo: function(test) {
         test.expect(4);
         var rb = new ResBundle({
             name: "tester2",
@@ -1717,7 +1746,7 @@ module.exports.testresources = {
         test.done();
     },
     
-    testResBundleGetStringCyrlMissingPsuedo: function(test) {
+    testResBundleGetStringCyrlMissingPseudo: function(test) {
         test.expect(4);
         var rb = new ResBundle({
             name: "tester2",
@@ -1734,7 +1763,7 @@ module.exports.testresources = {
         test.done();
     },
     
-    testResBundleGetStringHebrMissingPsuedo: function(test) {
+    testResBundleGetStringHebrMissingPseudo: function(test) {
         test.expect(4);
         var rb = new ResBundle({
             name: "tester2",
@@ -1751,7 +1780,7 @@ module.exports.testresources = {
         test.done();
     },
     
-    testResBundleGetStringHansMissingPsuedo: function(test) {
+    testResBundleGetStringHansMissingPseudo: function(test) {
         test.expect(4);
         var rb = new ResBundle({
             name: "tester2",
@@ -1836,7 +1865,7 @@ module.exports.testresources = {
         var rb = new ResBundle({
             locale:'eu-ES'
         });
-        test.equal(rb.getString("This is psuedo string test").toString(), "Ťĥíš íš þšüëðõ šţŕíñğ ţëšţ");
+        test.equal(rb.getStringJS("This is pseudo string test"), "Ťĥíš íš þšëüðõ šţŕíñğ ţëšţ");
         test.done();
         ilib.clearPseudoLocales();
     },
@@ -1848,7 +1877,8 @@ module.exports.testresources = {
         var rb = new ResBundle({
             locale:'ps-AF'
         });
-        test.equal(rb.getString("This is psuedo string test").toString(), "טהִס ִס פסֶֻדֹ סטרִנג טֶסט");
+        test.equal(rb.getStringJS("This is pseudo string test"), 'טהִס ִס פסֶֻדֹ סטרִנג טֶסט');
+
         test.done();
         ilib.clearPseudoLocales();
     },
@@ -1860,7 +1890,7 @@ module.exports.testresources = {
         var rb = new ResBundle({
             locale:'de-DE'
         });
-        test.equal(rb.getString("This is psuedo string test").toString(), "Ťĥíš íš þšüëðõ šţŕíñğ ţëšţ");
+        test.equal(rb.getStringJS("This is pseudo string test"), "Ťĥíš íš þšëüðõ šţŕíñğ ţëšţ");
         test.done();
         ilib.clearPseudoLocales();
     },
@@ -1886,19 +1916,19 @@ module.exports.testresources = {
         ilib.clearPseudoLocales();
     },
     
-    testResBundlePsuedo_EMPTY: function(test) {
+    testResBundlePseudo_EMPTY: function(test) {
         test.expect(1);
         ilib.clearPseudoLocales();
         ilib.setAsPseudoLocale("");
         var rb = new ResBundle({
             locale:""
         });
-        test.equal(rb.getString("This is psuedo string test").toString(), "This is psuedo string test");
+        test.equal(rb.getStringJS("This is pseudo string test"), "This is pseudo string test");
         test.done();
         ilib.clearPseudoLocales();
     },
     
-    testResBundlePsuedoEmptyNothingAdded: function(test) {
+    testResBundlePseudoEmptyNothingAdded: function(test) {
         test.expect(2);
         ilib.clearPseudoLocales();
         test.equal(ilib.pseudoLocales.length, 4);
@@ -1908,7 +1938,7 @@ module.exports.testresources = {
         ilib.clearPseudoLocales();
     },
     
-    testResBundlePsuedoUndefinedNothingAdded: function(test) {
+    testResBundlePseudoUndefinedNothingAdded: function(test) {
         test.expect(2);
         ilib.clearPseudoLocales();
         test.equal(ilib.pseudoLocales.length, 4);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib",
-    "version": "14.8.1",
+    "version": "14.9.0",
     "main": "js/index.js",
     "description": "iLib is a cross-engine library of internationalization (i18n) classes written in pure JS",
     "keywords": [


### PR DESCRIPTION
* Add ruby & template style escaping for pseudo localization. Here are `%RUBY%` substitution parameters. For template, it is `<% code here %>`
* Added Objective-C/Swift substitution parameter support during escaping

### Checklist

* [x] At least one test case is included for this feature or bug fix.
* [x] `ReleaseNotes` has added or is not needed.
* [x] This PR has passed all of the test cases on `Nodejs` and `Chrome Browser`.
* [ ] This PR has passed all of the test cases on `QT/QML`.
* [ ] This is an API breaking change.
* [ ] Requires a major version change.


### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

### Links
[//]: # (Related issues, references)
