### PR TITLE
Fix a bug which a default script for hausa should be Latin

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -9,6 +9,7 @@ New Features:
 Bug Fixes:
 * Fixed a build error that occurs on `Qt 6.1` and fixed some warning messages that reported from the latest Qt version.
 * Added new `plurals.json` files in some locales from cldr 37
+* Fixed a bug which a default script for `ha` should be `Latin` instead of `Arabic`
 
 Build 014
 -------

--- a/js/data/locale/ha/scripts.jf
+++ b/js/data/locale/ha/scripts.jf
@@ -1,7 +1,7 @@
 {
     "scripts": [
-        "Arab",
-        "Latn"
+        "Latn",
+        "Arab"
     ],
     "generated": true
 }

--- a/js/test/root/testscriptinfo.js
+++ b/js/test/root/testscriptinfo.js
@@ -2335,5 +2335,15 @@ module.exports.testscriptinfo = {
         test.equal(li.getScript(), "Latn");
         test.equal(scinfo.getScriptDirection(), "ltr");
         test.done();
+    },
+    testScriptInfo_ha: function(test) {
+        test.expect(4);
+        var li = new LocaleInfo("ha");
+        var scinfo = new ScriptInfo(li.getScript());
+        test.ok(li !== null);
+        test.ok(scinfo !== null);
+        test.equal(li.getScript(), "Latn");
+        test.equal(scinfo.getScriptDirection(), "ltr");
+        test.done();
     }
 };

--- a/tools/cldr/genlangscripts.js
+++ b/tools/cldr/genlangscripts.js
@@ -107,7 +107,7 @@ for (var language in scripts) {
             fs.mkdirSync(filename);
         }
         // special cases where we disagree with CLDR
-        if (language === 'ms' || language === 'kk' || language === 'pa'|| language === 'tk') {
+        if (language === 'ms' || language === 'kk' || language === 'pa'|| language === 'tk'|| language === 'ha') {
             scripts[language] = scripts[language].reverse();
         } else if (language == 'ky'|| language == 'tg') {
             var lang = scripts[language];


### PR DESCRIPTION
### Checklist

* [ ] At least one test case is included for this feature or bug fix.
* [x] `ReleaseNotes` has added or is not needed.
* [x] This PR has passed all of the test cases on `Nodejs` and `Chrome Browser`.
* [x] This PR has passed all of the test cases on `QT/QML`.
* [ ] This is an API breaking change.
* [ ] Requires a major version change.


### Issue Resolved / Feature Added
Fixed a bug which a default script for `ha (Hausa)` should be `Latin` instead of `Arabic`

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

### Links
[//]: # (Related issues, references)
