### PR TITLE
Fix locale parsing in ilib.getLocale()

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -10,6 +10,12 @@ Bug Fixes:
 * Fixed a build error that occurs on `Qt 6.1` and fixed some warning messages that reported from the latest Qt version.
 * Added new `plurals.json` files in some locales from cldr 37
 * Fixed a bug which a default script for `ha` should be `Latin` instead of `Arabic`
+* Fixed various bugs parsing the platform locales in ilib.getLocale()
+    * Locales with a script code such as "zh-Hans-CN"
+    * The posix "C" default locale
+    * Platforms where the region code is not upper-case
+    * Platforms that don't use a dash to separate the components
+    * Platforms that include a dot and a charset name after the specifier
 
 Build 014
 -------

--- a/js/lib/ilib.js
+++ b/js/lib/ilib.js
@@ -288,7 +288,7 @@ ilib.setLocale = function (spec) {
  * @private
  */
 function parseLocale(str) {
-    if (!str || str === "C") return str;
+    if (!str) return str;
 
     // take care of the libc style locale with a dot + script at the end
     var dot = str.indexOf('.')
@@ -299,6 +299,7 @@ function parseLocale(str) {
     // handle the posix default locale
     if (str === "C") return "en-US";
 
+    // full locale
     if (str.length >= 10) {
         return [
             str.substring(0,2).toLowerCase(),
@@ -307,6 +308,15 @@ function parseLocale(str) {
         ].join("-");
     }
 
+    // language + script
+    if (str.length >= 7) {
+        return [
+            str.substring(0,2).toLowerCase(),
+            str[3].toUpperCase() + str.substring(4,7).toLowerCase()
+        ].join("-");
+    }
+
+    // language + region
     if (str.length >= 5) {
         return [
             str.substring(0,2).toLowerCase(),
@@ -314,6 +324,7 @@ function parseLocale(str) {
         ].join("-");
     }
 
+    // language only
     if (str.length < 3) {
         return str.toLowerCase();
     }

--- a/js/lib/ilib.js
+++ b/js/lib/ilib.js
@@ -285,6 +285,43 @@ ilib.setLocale = function (spec) {
 };
 
 /**
+ * @private
+ */
+function parseLocale(str) {
+    if (!str || str === "C") return str;
+
+    // take care of the libc style locale with a dot + script at the end
+    var dot = str.indexOf('.')
+    if (dot > -1) {
+        str = str.substring(0, dot);
+    }
+
+    // handle the posix default locale
+    if (str === "C") return "en-US";
+
+    if (str.length >= 10) {
+        return [
+            str.substring(0,2).toLowerCase(),
+            str[3].toUpperCase() + str.substring(4,7).toLowerCase(),
+            str.substring(8,10).toUpperCase()
+        ].join("-");
+    }
+
+    if (str.length >= 5) {
+        return [
+            str.substring(0,2).toLowerCase(),
+            str.substring(3,5).toUpperCase()
+        ].join("-");
+    }
+
+    if (str.length < 3) {
+        return str.toLowerCase();
+    }
+
+    return str;
+}
+
+/**
  * Return the default locale for all of ilib if one has been set. This
  * locale will be used when no explicit locale is passed to any ilib
  * class. If the default
@@ -304,7 +341,7 @@ ilib.getLocale = function () {
             case 'browser':
                 // running in a browser
                 if(typeof(navigator.language) !== 'undefined') {
-                    ilib.locale = (navigator.language.length > 3) ? navigator.language.substring(0,3) + navigator.language.substring(3,5).toUpperCase() : navigator.language;  // FF/Opera/Chrome/Webkit
+                    ilib.locale = parseLocale(navigator.language);  // FF/Opera/Chrome/Webkit
                 }
                 if (!ilib.locale) {
                     // IE on Windows
@@ -317,7 +354,7 @@ ilib.getLocale = function () {
                                             undefined));
                     if (typeof(lang) !== 'undefined' && lang) {
                         // for some reason, MS uses lower case region tags
-                        ilib.locale = (lang.length > 3) ? lang.substring(0,3) + lang.substring(3,5).toUpperCase() : lang;
+                        ilib.locale = parseLocale(lang);
                     } else {
                         ilib.locale = undefined;
                     }
@@ -329,9 +366,9 @@ ilib.getLocale = function () {
                 if (typeof(PalmSystem.locales) !== 'undefined' &&
                     typeof(PalmSystem.locales.UI) != 'undefined' &&
                     PalmSystem.locales.UI.length > 0) {
-                    ilib.locale = PalmSystem.locales.UI;
+                    ilib.locale = parseLocale(PalmSystem.locales.UI);
                 } else if (typeof(PalmSystem.locale) !== 'undefined') {
-                    ilib.locale = PalmSystem.locale;
+                    ilib.locale = parseLocale(PalmSystem.locale);
                 } else {
                     ilib.locale = undefined;
                 }
@@ -339,10 +376,11 @@ ilib.getLocale = function () {
             case 'rhino':
                 if (typeof(environment) !== 'undefined' && environment.user && typeof(environment.user.language) === 'string' && environment.user.language.length > 0) {
                     // running under plain rhino
-                    ilib.locale = environment.user.language;
+                    var l = [environment.user.language];
                     if (typeof(environment.user.country) === 'string' && environment.user.country.length > 0) {
-                        ilib.locale += '-' + environment.user.country;
+                        l.push(environment.user.country);
                     }
+                    ilib.locale = l.join("-");
                 }
                 break;
             case "trireme":
@@ -351,15 +389,7 @@ ilib.getLocale = function () {
                 // the LANG variable on unix is in the form "lang_REGION.CHARSET"
                 // where language and region are the correct ISO codes separated by
                 // an underscore. This translate it back to the BCP-47 form.
-                if (lang && typeof(lang) !== 'undefined') {
-                    dot = lang.indexOf('.');
-                    if (dot > -1) {
-                        lang = lang.substring(0, dot);
-                    }
-                    ilib.locale = (lang.length > 3) ? lang.substring(0,2).toLowerCase() + '-' + lang.substring(3,5).toUpperCase() : lang;
-                } else {
-                    ilib.locale = undefined;
-                }
+                ilib.locale = parseLocale(lang);
                 break;
             case 'nodejs':
                 // running under nodejs
@@ -367,22 +397,15 @@ ilib.getLocale = function () {
                 // the LANG variable on unix is in the form "lang_REGION.CHARSET"
                 // where language and region are the correct ISO codes separated by
                 // an underscore. This translate it back to the BCP-47 form.
-                if (lang && typeof(lang) !== 'undefined') {
-                    dot = lang.indexOf('.');
-                    if (dot > -1) {
-                        lang = lang.substring(0, dot);
-                    }
-                    ilib.locale = (lang.length > 3) ? lang.substring(0,2).toLowerCase() + '-' + lang.substring(3,5).toUpperCase() : lang;
-                } else {
-                    ilib.locale = undefined;
-                }
+                ilib.locale = parseLocale(lang);
                 break;
             case 'qt':
                 // running in the Javascript engine under Qt/QML
                 var locobj = Qt.locale();
-                lang = locobj.name && locobj.name.replace("_", "-") || "en-US";
+                ilib.locale = parseLocale(locobj.name || "en-US");
                 break;
         }
+        // test for posix "C" locale
         ilib.locale = typeof(ilib.locale) === 'string' && ilib.locale.length && ilib.locale !== "C" ? ilib.locale : 'en-US';
         if (ilib.locale === "en") {
             ilib.locale = "en-US"; // hack to get various platforms working correctly

--- a/js/test/root/testglobal.js
+++ b/js/test/root/testglobal.js
@@ -244,7 +244,7 @@ module.exports.testglobal = {
             test.done();
             return;
         }
-        
+
         ilib.locale = undefined;
         if (!process.env) process.env = {};
         
@@ -253,30 +253,535 @@ module.exports.testglobal = {
         test.expect(1);
         test.equal(ilib.getLocale(), "th-TH");
         test.done();
-        
+
         process.env.LANG = "";
         ilib.locale = undefined;
     },
-    
+
     testGetLocaleNodejs2: function(test) {
         if (ilib._getPlatform() !== "nodejs") {
             // only test this in node
             test.done();
             return;
         }
-        
+
         ilib.locale = undefined;
-    
+
         process.env.LC_ALL = "th-TH";
-        
+
         test.expect(1);
         test.equal(ilib.getLocale(), "th-TH");
         test.done();
-        
+
         process.env.LC_ALL = "";
         ilib.locale = undefined;
     },
-    
+
+    testGetLocaleNodejsPosixLocale: function(test) {
+        if (ilib._getPlatform() !== "nodejs") {
+            // only test this in node
+            test.done();
+            return;
+        }
+
+        ilib.locale = undefined;
+
+        process.env.LC_ALL = "C";
+
+        test.expect(1);
+        test.equal(ilib.getLocale(), "en-US");
+        test.done();
+
+        process.env.LC_ALL = "";
+        ilib.locale = undefined;
+    },
+
+    testGetLocaleNodejsPosixLocaleFull: function(test) {
+        if (ilib._getPlatform() !== "nodejs") {
+            // only test this in node
+            test.done();
+            return;
+        }
+
+        ilib.locale = undefined;
+
+        process.env.LC_ALL = "C.UTF8";
+
+        test.expect(1);
+        test.equal(ilib.getLocale(), "en-US");
+        test.done();
+
+        process.env.LC_ALL = "";
+        ilib.locale = undefined;
+    },
+
+    testGetLocaleSimulateRhino: function(test) {
+        if (ilib._getPlatform() !== "nodejs") {
+            // only test this in node
+            test.done();
+            return;
+        }
+
+        ilib.locale = undefined;
+        ilib._platform = "rhino";
+
+        global.environment = {
+            user: {
+                language: "de",
+                country: "AT"
+            }
+        };
+
+        test.expect(1);
+        test.equal(ilib.getLocale(), "de-AT");
+
+        // clean up
+        ilib._platform = undefined;
+        ilib.locale = undefined;
+        global.environment = undefined;
+
+        test.done();
+    },
+
+    testGetLocaleSimulateTrireme1: function(test) {
+        if (ilib._getPlatform() !== "nodejs") {
+            // only test this in node
+            test.done();
+            return;
+        }
+
+        ilib.locale = undefined;
+        ilib._platform = "trireme";
+
+        process.env.LANG = "de-AT";
+
+        test.expect(1);
+        test.equal(ilib.getLocale(), "de-AT");
+
+        // clean up
+        ilib._platform = undefined;
+        ilib.locale = undefined;
+        process.env.LANG = "";
+
+        test.done();
+    },
+
+    testGetLocaleSimulateTrireme2: function(test) {
+        if (ilib._getPlatform() !== "nodejs") {
+            // only test this in node
+            test.done();
+            return;
+        }
+
+        ilib.locale = undefined;
+        ilib._platform = "trireme";
+
+        process.env.LANGUAGE = "de-AT";
+
+        test.expect(1);
+        test.equal(ilib.getLocale(), "de-AT");
+
+        // clean up
+        ilib._platform = undefined;
+        ilib.locale = undefined;
+        process.env.LANGUAGE = "";
+
+        test.done();
+    },
+
+    testGetLocaleSimulateTrireme3: function(test) {
+        if (ilib._getPlatform() !== "nodejs") {
+            // only test this in node
+            test.done();
+            return;
+        }
+
+        ilib.locale = undefined;
+        ilib._platform = "trireme";
+
+        process.env.LC_ALL = "de-AT";
+
+        test.expect(1);
+        test.equal(ilib.getLocale(), "de-AT");
+
+        // clean up
+        ilib._platform = undefined;
+        ilib.locale = undefined;
+        process.env.LC_ALL = "";
+
+        test.done();
+    },
+
+    testGetLocaleSimulateTriremeFullSpecifier: function(test) {
+        if (ilib._getPlatform() !== "nodejs") {
+            // only test this in node
+            test.done();
+            return;
+        }
+
+        ilib.locale = undefined;
+        ilib._platform = "trireme";
+
+        process.env.LC_ALL = "de_DE.UTF8";
+
+        test.expect(1);
+        test.equal(ilib.getLocale(), "de-DE");
+
+        // clean up
+        ilib._platform = undefined;
+        ilib.locale = undefined;
+        process.env.LC_ALL = "";
+
+        test.done();
+    },
+
+    testGetLocaleSimulateTriremeFullLocale: function(test) {
+        if (ilib._getPlatform() !== "nodejs") {
+            // only test this in node
+            test.done();
+            return;
+        }
+
+        ilib.locale = undefined;
+        ilib._platform = "trireme";
+
+        process.env.LC_ALL = "zh-Hans-CN";
+
+        test.expect(1);
+        test.equal(ilib.getLocale(), "zh-Hans-CN");
+
+        // clean up
+        ilib._platform = undefined;
+        ilib.locale = undefined;
+        process.env.LC_ALL = "";
+
+        test.done();
+    },
+
+    testGetLocaleSimulateWebOS: function(test) {
+        if (ilib._getPlatform() !== "nodejs") {
+            // only test this in node
+            test.done();
+            return;
+        }
+
+        ilib.locale = undefined;
+        ilib._platform = "webos";
+
+        global.PalmSystem = {
+            locale: "ru-RU"
+        };
+
+        test.expect(1);
+        test.equal(ilib.getLocale(), "ru-RU");
+
+        // clean up
+        ilib._platform = undefined;
+        ilib.locale = undefined;
+        global.PalmSystem = undefined;
+
+        test.done();
+    },
+
+    testGetLocaleSimulateWebOSWebapp: function(test) {
+        if (ilib._getPlatform() !== "nodejs") {
+            // only test this in node
+            test.done();
+            return;
+        }
+
+        ilib.locale = undefined;
+        ilib._platform = "webos-webapp";
+
+        global.PalmSystem = {
+            locale: "ru-RU"
+        };
+
+        test.expect(1);
+        test.equal(ilib.getLocale(), "ru-RU");
+
+        // clean up
+        ilib._platform = undefined;
+        ilib.locale = undefined;
+        global.PalmSystem = undefined;
+
+        test.done();
+    },
+
+    testGetLocaleSimulateRegularBrowser: function(test) {
+        if (ilib._getPlatform() !== "nodejs") {
+            // only test this in nodejs
+            test.done();
+            return;
+        }
+
+        ilib._platform = "browser";
+        ilib.locale = undefined;
+
+        var loc = "";
+
+        global.navigator = {
+            language: "ja-JP"
+        };
+
+        test.expect(1);
+        test.equal(ilib.getLocale(), "ja-JP");
+
+        // clean up
+        ilib._platform = undefined;
+        ilib.locale = undefined;
+        global.navigator = undefined;
+
+        test.done();
+    },
+
+    testGetLocaleSimulateRegularBrowserLangOnly: function(test) {
+        if (ilib._getPlatform() !== "nodejs") {
+            // only test this in nodejs
+            test.done();
+            return;
+        }
+
+        ilib._platform = "browser";
+        ilib.locale = undefined;
+
+        var loc = "";
+
+        global.navigator = {
+            language: "ja"
+        };
+
+        test.expect(1);
+        test.equal(ilib.getLocale(), "ja");
+
+        // clean up
+        ilib._platform = undefined;
+        ilib.locale = undefined;
+        global.navigator = undefined;
+
+        test.done();
+    },
+
+    testGetLocaleSimulateRegularBrowserFullLocale: function(test) {
+        if (ilib._getPlatform() !== "nodejs") {
+            // only test this in nodejs
+            test.done();
+            return;
+        }
+
+        ilib._platform = "browser";
+        ilib.locale = undefined;
+
+        var loc = "";
+
+        global.navigator = {
+            language: "zh-Hans-CN"
+        };
+
+        test.expect(1);
+        test.equal(ilib.getLocale(), "zh-Hans-CN");
+
+        // clean up
+        ilib._platform = undefined;
+        ilib.locale = undefined;
+        global.navigator = undefined;
+
+        test.done();
+    },
+
+    testGetLocaleSimulateRegularBrowserNonBCP47: function(test) {
+        if (ilib._getPlatform() !== "nodejs") {
+            // only test this in nodejs
+            test.done();
+            return;
+        }
+
+        ilib._platform = "browser";
+        ilib.locale = undefined;
+
+        var loc = "";
+
+        global.navigator = {
+            language: "ja_jp"
+        };
+
+        test.expect(1);
+        test.equal(ilib.getLocale(), "ja-JP");
+
+        // clean up
+        ilib._platform = undefined;
+        ilib.locale = undefined;
+        global.navigator = undefined;
+
+        test.done();
+    },
+
+    testGetLocaleSimulateIEBrowser1: function(test) {
+        if (ilib._getPlatform() !== "nodejs") {
+            // only test this in nodejs
+            test.done();
+            return;
+        }
+
+        ilib._platform = "browser";
+        ilib.locale = undefined;
+
+        var loc = "";
+
+        global.navigator = {
+            browserLanguage: "ja-JP"
+        };
+
+        test.expect(1);
+        test.equal(ilib.getLocale(), "ja-JP");
+
+        // clean up
+        ilib._platform = undefined;
+        ilib.locale = undefined;
+        global.navigator = undefined;
+
+        test.done();
+    },
+
+    testGetLocaleSimulateIEBrowser2: function(test) {
+        if (ilib._getPlatform() !== "nodejs") {
+            // only test this in nodejs
+            test.done();
+            return;
+        }
+
+        ilib._platform = "browser";
+        ilib.locale = undefined;
+
+        var loc = "";
+
+        global.navigator = {
+            userLanguage: "ko-KR"
+        };
+
+        test.expect(1);
+        test.equal(ilib.getLocale(), "ko-KR");
+
+        // clean up
+        ilib._platform = undefined;
+        ilib.locale = undefined;
+        global.navigator = undefined;
+
+        test.done();
+    },
+
+    testGetLocaleSimulateIEBrowser3: function(test) {
+        if (ilib._getPlatform() !== "nodejs") {
+            // only test this in nodejs
+            test.done();
+            return;
+        }
+
+        ilib._platform = "browser";
+        ilib.locale = undefined;
+
+        var loc = "";
+
+        global.navigator = {
+            systemLanguage: "zh-CN"
+        };
+
+        test.expect(1);
+        test.equal(ilib.getLocale(), "zh-CN");
+
+        // clean up
+        ilib._platform = undefined;
+        ilib.locale = undefined;
+        global.navigator = undefined;
+
+        test.done();
+    },
+
+    testGetLocaleSimulateIEBrowserNonBCP: function(test) {
+        if (ilib._getPlatform() !== "nodejs") {
+            // only test this in nodejs
+            test.done();
+            return;
+        }
+
+        ilib._platform = "browser";
+        ilib.locale = undefined;
+
+        var loc = "";
+
+        global.navigator = {
+            systemLanguage: "zh_cn"
+        };
+
+        test.expect(1);
+        test.equal(ilib.getLocale(), "zh-CN");
+
+        // clean up
+        ilib._platform = undefined;
+        ilib.locale = undefined;
+        global.navigator = undefined;
+
+        test.done();
+    },
+
+    testGetLocaleSimulateIEBrowserFull: function(test) {
+        if (ilib._getPlatform() !== "nodejs") {
+            // only test this in nodejs
+            test.done();
+            return;
+        }
+
+        ilib._platform = "browser";
+        ilib.locale = undefined;
+
+        var loc = "";
+
+        global.navigator = {
+            systemLanguage: "zh-Hans-CN"
+        };
+
+        test.expect(1);
+        test.equal(ilib.getLocale(), "zh-Hans-CN");
+
+        // clean up
+        ilib._platform = undefined;
+        ilib.locale = undefined;
+        global.navigator = undefined;
+
+        test.done();
+    },
+
+    testGetLocaleSimulateQt: function(test) {
+        if (ilib._getPlatform() !== "nodejs") {
+            // only test this in nodejs
+            test.done();
+            return;
+        }
+
+        ilib._platform = "qt";
+        ilib.locale = undefined;
+
+        var loc = "";
+
+        global.Qt = {
+            locale: function() {
+                return {
+                    name: "fr-FR"
+                };
+            }
+        };
+
+        test.expect(1);
+        test.equal(ilib.getLocale(), "fr-FR");
+
+        // clean up
+        ilib._platform = undefined;
+        ilib.locale = undefined;
+        global.Qt = undefined;
+
+        test.done();
+    },
+
     testGetLocaleRhino: function(test) {
         if (ilib._getPlatform() !== "rhino") {
             // only test this in node
@@ -297,8 +802,7 @@ module.exports.testglobal = {
         
         test.expect(1);
         test.equal(ilib.getLocale(), "de-AT");
-        test.done();
-        
+
         if (typeof(process) === 'undefined') {
             // under plain rhino
             environment.user.language = undefined;
@@ -306,8 +810,9 @@ module.exports.testglobal = {
         } else {
             process.env.LANG = "en_US.UTF8";
         }
+        test.done();
     },
-    
+
     testGetLocaleWebOS: function(test) {
         if (ilib._getPlatform() !== "webos") {
             // only test this in node
@@ -321,9 +826,9 @@ module.exports.testglobal = {
         
         test.expect(1);
         test.equal(ilib.getLocale(), "ru-RU");
-        test.done();
-        
+
         PalmSystem.locale = undefined;
+        test.done();
     },
     
     testGetLocaleNotString: function(test) {

--- a/js/test/root/testglobal.js
+++ b/js/test/root/testglobal.js
@@ -252,10 +252,10 @@ module.exports.testglobal = {
         
         test.expect(1);
         test.equal(ilib.getLocale(), "th-TH");
-        test.done();
 
         process.env.LANG = "";
         ilib.locale = undefined;
+        test.done();
     },
 
     testGetLocaleNodejs2: function(test) {
@@ -271,10 +271,67 @@ module.exports.testglobal = {
 
         test.expect(1);
         test.equal(ilib.getLocale(), "th-TH");
-        test.done();
 
         process.env.LC_ALL = "";
         ilib.locale = undefined;
+        test.done();
+    },
+
+    testGetLocaleNodejsFullLocale: function(test) {
+        if (ilib._getPlatform() !== "nodejs") {
+            // only test this in node
+            test.done();
+            return;
+        }
+
+        ilib.locale = undefined;
+
+        process.env.LC_ALL = "zh-Hans-CN";
+
+        test.expect(1);
+        test.equal(ilib.getLocale(), "zh-Hans-CN");
+
+        process.env.LC_ALL = "";
+        ilib.locale = undefined;
+        test.done();
+    },
+
+    testGetLocaleNodejsLangScript: function(test) {
+        if (ilib._getPlatform() !== "nodejs") {
+            // only test this in node
+            test.done();
+            return;
+        }
+
+        ilib.locale = undefined;
+
+        process.env.LC_ALL = "zh-Hans";
+
+        test.expect(1);
+        test.equal(ilib.getLocale(), "zh-Hans");
+
+        process.env.LC_ALL = "";
+        ilib.locale = undefined;
+        test.done();
+    },
+
+    testGetLocaleNodejsLangOnly: function(test) {
+        if (ilib._getPlatform() !== "nodejs") {
+            // only test this in node
+            test.done();
+            return;
+        }
+
+        ilib.locale = undefined;
+
+        process.env.LC_ALL = "zh";
+
+        test.expect(1);
+        test.equal(ilib.getLocale(), "zh");
+
+        process.env.LC_ALL = "";
+        ilib.locale = undefined;
+        test.done();
     },
 
     testGetLocaleNodejsPosixLocale: function(test) {


### PR DESCRIPTION
* Fixed various bugs parsing the platform locales in ilib.getLocale()
    * Locales with a script code such as "zh-Hans-CN"
    * The posix "C" default locale
    * Platforms where the region code is not upper-case
    * Platforms that don't use a dash to separate the components
    * Platforms that include a dot and a charset name after the specifier
* Now includes many tests for getLocale that simulates the environment of various platforms while running under node, so we can test everything under node as well as on the real platform.

### Checklist

* [x] At least one test case is included for this feature or bug fix.
* [x] `ReleaseNotes` has added or is not needed.
* [x] This PR has passed all of the test cases on `Nodejs` and `Chrome Browser`.
* [ ] This PR has passed all of the test cases on `QT/QML`.
* [ ] This is an API breaking change.
* [ ] Requires a major version change.


### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

### Links
[//]: # (Related issues, references)
