### PR TITLE
Add ability to test minified version of files on Qt

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -17,6 +17,7 @@ Bug Fixes:
     * Platforms that don't use a dash to separate the components
     * Platforms that include a dot and a charset name after the specifier
 * Fixed a `genplurals.js` tool code bug when default target directory is empty
+* Added ability to test minified version of files on Qt
 
 Build 014
 -------

--- a/js/lib/DateRngFmt.js
+++ b/js/lib/DateRngFmt.js
@@ -304,7 +304,7 @@ DateRngFmt.prototype = {
 
         var start = DateFactory._dateToIlib(startDateLike, thisZoneName, this.locale);
         var end = DateFactory._dateToIlib(endDateLike, thisZoneName, this.locale);
-        var isStandAlone = false;
+        var tmp;
 
         if (typeof(start) !== 'object' || !start.getCalendar || start.getCalendar() !== this.calName || (this.timezone && start.timezone && start.timezone !== this.timezone)) {
             start = DateFactory({
@@ -371,7 +371,7 @@ DateRngFmt.prototype = {
         } else if (endRd - startRd < 3650) {
             fmt = new IString(this.dateFmt._getFormat(this.dateFmt.formats.range, "c20", this.length));
             // need to check for month/year stand-alone formats here
-            var tmp = this.dateFmt._getFormatInternal(formats, "mys", this.length);
+            tmp = this.dateFmt._getFormatInternal(formats, "mys", this.length);
             if (tmp) {
                 if (tmp.indexOf('r') > -1) {
                     var tmp2 = this.dateFmt._getFormatInternal(formats, "r", this.length);
@@ -389,7 +389,7 @@ DateRngFmt.prototype = {
         } else {
             fmt = new IString(this.dateFmt._getFormat(this.dateFmt.formats.range, "c30", this.length));
             // need to check for stand-alone year formats here
-            var tmp = this.dateFmt._getFormatInternal(formats, "r", this.length);
+            tmp = this.dateFmt._getFormatInternal(formats, "r", this.length);
             if (tmp) {
                 yearTemplate = this.dateFmt._tokenize(tmp);
             }

--- a/qt/build.xml
+++ b/qt/build.xml
@@ -2,7 +2,7 @@
 <!--
 build.xml - build the Qt/QML parts
 
-Copyright © 2015, 2019 2021 JEDLSoft
+Copyright © 2015, 2019, 2021 JEDLSoft
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -144,7 +144,6 @@ limitations under the License.
             </fileset>
         </copy>
         <move file="${build.js}/lib/index.js" tofile="${build.js}/index.js"/>
-        <!-- <antcall target="js.original"/>-->
     </target>
 
     <target name="js.original" depends="" description="">
@@ -164,6 +163,19 @@ limitations under the License.
             </exec>
         </sequential>
     </target>
+    <target name="test.all.compiled" depends="qt.version, filereader, js.minify" description="Run the unit tests in the qt test framework. Make sure you have Qt 5.4 or later, and it is the first Qt in your path.">
+        <sequential>
+            <exec osfamily="unix" executable="qmlscene" dir="${build.unittest}" failifexecutionfails="true" failonerror="true">
+                <env key="QML2_IMPORT_PATH" value="../FileReader/imports"/>
+                <arg line="NodeunitRunAll.qml"/>
+            </exec>
+            <exec osfamily="windows" executable="qmlscene.exe" dir="${build.unittest}" failifexecutionfails="true"  failonerror="true">
+                <env key="QML2_IMPORT_PATH" value="../FileReader/imports"/>
+                <arg line="NodeunitRunAll.qml"/>
+            </exec>
+        </sequential>
+        <antcall target="js.original"/>
+    </target>
 
     <target name="test.address" depends="qt.version, filereader" description="Run the address unit tests in the qt test framework.">
         <sequential>
@@ -177,7 +189,7 @@ limitations under the License.
             </exec>
         </sequential>
     </target>
-    <target name="test.address.minify" depends="qt.version, filereader, js.minify" description="Run the address unit tests in the qt test framework.">
+    <target name="test.address.compiled" depends="qt.version, filereader, js.minify" description="Run the address unit tests in the qt test framework.">
         <sequential>
             <exec osfamily="unix" executable="qmlscene" dir="${build.unittest}" failifexecutionfails="true" failonerror="true">
                 <env key="QML2_IMPORT_PATH" value="../FileReader/imports"/>
@@ -203,6 +215,19 @@ limitations under the License.
             </exec>
         </sequential>
     </target>
+    <target name="test.calendar.compiled" depends="qt.version, export, js.minify" description="Run the calendar unit tests in the qt test framework.">
+        <sequential>
+            <exec osfamily="unix" executable="qmlscene" dir="${build.base}/NodeunitTest" failifexecutionfails="true" failonerror="true">
+                <env key="QML2_IMPORT_PATH" value="../FileReader/imports"/>
+                <arg line="NodeunitRun_calendar.qml"/>
+            </exec>
+            <exec osfamily="windows" executable="qmlscene.exe" dir="${build.base}/NodeunitTest" failifexecutionfails="true"  failonerror="true">
+                <env key="QML2_IMPORT_PATH" value="../FileReader/imports"/>
+                <arg line="NodeunitRun_calendar.qml"/>
+            </exec>
+        </sequential>
+        <antcall target="js.original"/>
+    </target>
 
     <target name="test.collate" depends="qt.version, export" description="Run the collate unit tests in the qt test framework.">
         <sequential>
@@ -215,6 +240,19 @@ limitations under the License.
                 <arg line="NodeunitRun_collate.qml"/>
             </exec>
         </sequential>
+    </target>
+    <target name="test.collate.compiled" depends="qt.version, export, js.minify" description="Run the collate unit tests in the qt test framework.">
+        <sequential>
+            <exec osfamily="unix" executable="qmlscene" dir="${build.base}/NodeunitTest" failifexecutionfails="true" failonerror="true">
+                <env key="QML2_IMPORT_PATH" value="../FileReader/imports"/>
+                <arg line="NodeunitRun_collate.qml"/>
+            </exec>
+            <exec osfamily="windows" executable="qmlscene.exe" dir="${build.base}/NodeunitTest" failifexecutionfails="true"  failonerror="true">
+                <env key="QML2_IMPORT_PATH" value="../FileReader/imports"/>
+                <arg line="NodeunitRun_collate.qml"/>
+            </exec>
+        </sequential>
+        <antcall target="js.original"/>
     </target>
 
     <target name="test.ctype" depends="qt.version, export" description="Run the ctype unit tests in the qt test framework.">
@@ -229,6 +267,19 @@ limitations under the License.
             </exec>
         </sequential>
     </target>
+    <target name="test.ctype.compiled" depends="qt.version, export, js.minify" description="Run the ctype unit tests in the qt test framework.">
+        <sequential>
+            <exec osfamily="unix" executable="qmlscene" dir="${build.base}/NodeunitTest" failifexecutionfails="true" failonerror="true">
+                <env key="QML2_IMPORT_PATH" value="../FileReader/imports"/>
+                <arg line="NodeunitRun_ctype.qml"/>
+            </exec>
+            <exec osfamily="windows" executable="qmlscene.exe" dir="${build.base}/NodeunitTest" failifexecutionfails="true"  failonerror="true">
+                <env key="QML2_IMPORT_PATH" value="../FileReader/imports"/>
+                <arg line="NodeunitRun_ctype.qml"/>
+            </exec>
+        </sequential>
+        <antcall target="js.original"/>
+    </target>
 
     <target name="test.date" depends="qt.version, export" description="Run the date unit tests in the qt test framework.">
         <sequential>
@@ -241,6 +292,19 @@ limitations under the License.
                 <arg line="NodeunitRun_date.qml"/>
             </exec>
         </sequential>
+    </target>
+    <target name="test.date.compiled" depends="qt.version, export, js.minify" description="Run the date unit tests in the qt test framework.">
+        <sequential>
+            <exec osfamily="unix" executable="qmlscene" dir="${build.base}/NodeunitTest" failifexecutionfails="true" failonerror="true">
+                <env key="QML2_IMPORT_PATH" value="../FileReader/imports"/>
+                <arg line="NodeunitRun_date.qml"/>
+            </exec>
+            <exec osfamily="windows" executable="qmlscene.exe" dir="${build.base}/NodeunitTest" failifexecutionfails="true"  failonerror="true">
+                <env key="QML2_IMPORT_PATH" value="../FileReader/imports"/>
+                <arg line="NodeunitRun_date.qml"/>
+            </exec>
+        </sequential>
+        <antcall target="js.original"/>
     </target>
 
     <target name="test.daterange" depends="qt.version, export" description="Run the daterange unit tests in the qt test framework.">
@@ -255,6 +319,19 @@ limitations under the License.
             </exec>
         </sequential>
     </target>
+    <target name="test.daterange.compiled" depends="qt.version, export, js.minify" description="Run the daterange unit tests in the qt test framework.">
+        <sequential>
+            <exec osfamily="unix" executable="qmlscene" dir="${build.base}/NodeunitTest" failifexecutionfails="true" failonerror="true">
+                <env key="QML2_IMPORT_PATH" value="../FileReader/imports"/>
+                <arg line="NodeunitRun_daterange.qml"/>
+            </exec>
+            <exec osfamily="windows" executable="qmlscene.exe" dir="${build.base}/NodeunitTest" failifexecutionfails="true"  failonerror="true">
+                <env key="QML2_IMPORT_PATH" value="../FileReader/imports"/>
+                <arg line="NodeunitRun_daterange.qml"/>
+            </exec>
+        </sequential>
+        <antcall target="js.original"/>
+    </target>
 
     <target name="test.durfmt" depends="qt.version, export" description="Run the durfmt unit tests in the qt test framework.">
         <sequential>
@@ -267,6 +344,19 @@ limitations under the License.
                 <arg line="NodeunitRun_durfmt.qml"/>
             </exec>
         </sequential>
+    </target>
+    <target name="test.durfmt.compiled" depends="qt.version, export" description="Run the durfmt unit tests in the qt test framework.">
+        <sequential>
+            <exec osfamily="unix" executable="qmlscene" dir="${build.base}/NodeunitTest" failifexecutionfails="true" failonerror="true">
+                <env key="QML2_IMPORT_PATH" value="../FileReader/imports"/>
+                <arg line="NodeunitRun_durfmt.qml"/>
+            </exec>
+            <exec osfamily="windows" executable="qmlscene.exe" dir="${build.base}/NodeunitTest" failifexecutionfails="true"  failonerror="true">
+                <env key="QML2_IMPORT_PATH" value="../FileReader/imports"/>
+                <arg line="NodeunitRun_durfmt.qml"/>
+            </exec>
+        </sequential>
+        <antcall target="js.original"/>
     </target>
 
     <target name="test.maps" depends="qt.version, export" description="Run the maps unit tests in the qt test framework.">
@@ -281,6 +371,19 @@ limitations under the License.
             </exec>
         </sequential>
     </target>
+    <target name="test.maps.compiled" depends="qt.version, export, js.minify" description="Run the maps unit tests in the qt test framework.">
+        <sequential>
+            <exec osfamily="unix" executable="qmlscene" dir="${build.base}/NodeunitTest" failifexecutionfails="true" failonerror="true">
+                <env key="QML2_IMPORT_PATH" value="../FileReader/imports"/>
+                <arg line="NodeunitRun_maps.qml"/>
+            </exec>
+            <exec osfamily="windows" executable="qmlscene.exe" dir="${build.base}/NodeunitTest" failifexecutionfails="true"  failonerror="true">
+                <env key="QML2_IMPORT_PATH" value="../FileReader/imports"/>
+                <arg line="NodeunitRun_maps.qml"/>
+            </exec>
+        </sequential>
+        <antcall target="js.original"/>
+    </target>
 
     <target name="test.name" depends="qt.version, export" description="Run the name unit tests in the qt test framework.">
         <sequential>
@@ -293,6 +396,19 @@ limitations under the License.
                 <arg line="NodeunitRun_name.qml"/>
             </exec>
         </sequential>
+    </target>
+    <target name="test.name.compiled" depends="qt.version, export, js.minify" description="Run the name unit tests in the qt test framework.">
+        <sequential>
+            <exec osfamily="unix" executable="qmlscene" dir="${build.base}/NodeunitTest" failifexecutionfails="true" failonerror="true">
+                <env key="QML2_IMPORT_PATH" value="../FileReader/imports"/>
+                <arg line="NodeunitRun_name.qml"/>
+            </exec>
+            <exec osfamily="windows" executable="qmlscene.exe" dir="${build.base}/NodeunitTest" failifexecutionfails="true"  failonerror="true">
+                <env key="QML2_IMPORT_PATH" value="../FileReader/imports"/>
+                <arg line="NodeunitRun_name.qml"/>
+            </exec>
+        </sequential>
+        <antcall target="js.original"/>
     </target>
 
     <target name="test.number" depends="qt.version, export" description="Run the number unit tests in the qt test framework.">
@@ -307,6 +423,19 @@ limitations under the License.
             </exec>
         </sequential>
     </target>
+    <target name="test.number.compiled" depends="qt.version, export, js.minify" description="Run the number unit tests in the qt test framework.">
+        <sequential>
+            <exec osfamily="unix" executable="qmlscene" dir="${build.base}/NodeunitTest" failifexecutionfails="true" failonerror="true">
+                <env key="QML2_IMPORT_PATH" value="../FileReader/imports"/>
+                <arg line="NodeunitRun_number.qml"/>
+            </exec>
+            <exec osfamily="windows" executable="qmlscene.exe" dir="${build.base}/NodeunitTest" failifexecutionfails="true"  failonerror="true">
+                <env key="QML2_IMPORT_PATH" value="../FileReader/imports"/>
+                <arg line="NodeunitRun_number.qml"/>
+            </exec>
+        </sequential>
+        <antcall target="js.original"/>
+    </target>
 
     <target name="test.phone" depends="qt.version, export" description="Run the phone unit tests in the qt test framework.">
         <sequential>
@@ -319,6 +448,19 @@ limitations under the License.
                 <arg line="NodeunitRun_phone.qml"/>
             </exec>
         </sequential>
+    </target>
+    <target name="test.phone.compiled" depends="qt.version, export, js.minify" description="Run the phone unit tests in the qt test framework.">
+        <sequential>
+            <exec osfamily="unix" executable="qmlscene" dir="${build.base}/NodeunitTest" failifexecutionfails="true" failonerror="true">
+                <env key="QML2_IMPORT_PATH" value="../FileReader/imports"/>
+                <arg line="NodeunitRun_phone.qml"/>
+            </exec>
+            <exec osfamily="windows" executable="qmlscene.exe" dir="${build.base}/NodeunitTest" failifexecutionfails="true"  failonerror="true">
+                <env key="QML2_IMPORT_PATH" value="../FileReader/imports"/>
+                <arg line="NodeunitRun_phone.qml"/>
+            </exec>
+        </sequential>
+        <antcall target="js.original"/>
     </target>
 
     <target name="test.root" depends="qt.version, export" description="Run the root unit tests in the qt test framework.">
@@ -333,6 +475,19 @@ limitations under the License.
             </exec>
         </sequential>
     </target>
+    <target name="test.root.compiled" depends="qt.version, export, js.minify" description="Run the root unit tests in the qt test framework.">
+        <sequential>
+            <exec osfamily="unix" executable="qmlscene" dir="${build.base}/NodeunitTest" failifexecutionfails="true" failonerror="true">
+                <env key="QML2_IMPORT_PATH" value="../FileReader/imports"/>
+                <arg line="NodeunitRun_root.qml"/>
+            </exec>
+            <exec osfamily="windows" executable="qmlscene.exe" dir="${build.base}/NodeunitTest" failifexecutionfails="true"  failonerror="true">
+                <env key="QML2_IMPORT_PATH" value="../FileReader/imports"/>
+                <arg line="NodeunitRun_root.qml"/>
+            </exec>
+        </sequential>
+        <antcall target="js.original"/>
+    </target>
 
     <target name="test.strings_ext" depends="qt.version, export" description="Run the strings_ext unit tests in the qt test framework.">
         <sequential>
@@ -345,6 +500,19 @@ limitations under the License.
                 <arg line="NodeunitRun_strings_ext.qml"/>
             </exec>
         </sequential>
+    </target>
+    <target name="test.strings_ext.compiled" depends="qt.version, export, js.minify" description="Run the strings_ext unit tests in the qt test framework.">
+        <sequential>
+            <exec osfamily="unix" executable="qmlscene" dir="${build.base}/NodeunitTest" failifexecutionfails="true" failonerror="true">
+                <env key="QML2_IMPORT_PATH" value="../FileReader/imports"/>
+                <arg line="NodeunitRun_strings_ext.qml"/>
+            </exec>
+            <exec osfamily="windows" executable="qmlscene.exe" dir="${build.base}/NodeunitTest" failifexecutionfails="true"  failonerror="true">
+                <env key="QML2_IMPORT_PATH" value="../FileReader/imports"/>
+                <arg line="NodeunitRun_strings_ext.qml"/>
+            </exec>
+        </sequential>
+        <antcall target="js.original"/>
     </target>
 
     <target name="test.units" depends="qt.version, export" description="Run the units unit tests in the qt test framework.">
@@ -359,6 +527,19 @@ limitations under the License.
             </exec>
         </sequential>
     </target>
+    <target name="test.units.compiled" depends="qt.version, export, js.minify" description="Run the units unit tests in the qt test framework.">
+        <sequential>
+            <exec osfamily="unix" executable="qmlscene" dir="${build.base}/NodeunitTest" failifexecutionfails="true" failonerror="true">
+                <env key="QML2_IMPORT_PATH" value="../FileReader/imports"/>
+                <arg line="NodeunitRun_units.qml"/>
+            </exec>
+            <exec osfamily="windows" executable="qmlscene.exe" dir="${build.base}/NodeunitTest" failifexecutionfails="true"  failonerror="true">
+                <env key="QML2_IMPORT_PATH" value="../FileReader/imports"/>
+                <arg line="NodeunitRun_units.qml"/>
+            </exec>
+        </sequential>
+        <antcall target="js.original"/>
+    </target>
 
     <target name="test.util" depends="qt.version, export" description="Run the util unit tests in the qt test framework.">
         <sequential>
@@ -372,6 +553,20 @@ limitations under the License.
             </exec>
         </sequential>
     </target>
+    <target name="test.util.compiled" depends="qt.version, export, js.minify" description="Run the util unit tests in the qt test framework.">
+        <sequential>
+            <exec osfamily="unix" executable="qmlscene" dir="${build.base}/NodeunitTest" failifexecutionfails="true" failonerror="true">
+                <env key="QML2_IMPORT_PATH" value="../FileReader/imports"/>
+                <arg line="NodeunitRun_util.qml"/>
+            </exec>
+            <exec osfamily="windows" executable="qmlscene.exe" dir="${build.base}/NodeunitTest" failifexecutionfails="true"  failonerror="true">
+                <env key="QML2_IMPORT_PATH" value="../FileReader/imports"/>
+                <arg line="NodeunitRun_util.qml"/>
+            </exec>
+        </sequential>
+        <antcall target="js.original"/>
+    </target>
+
     <target name="test" description="Run all tests and build all reports" />
     <target name="doc" />
 </project>

--- a/qt/build.xml
+++ b/qt/build.xml
@@ -134,7 +134,7 @@ limitations under the License.
         </copy>
     </target>
 
-    <target name="js.minify" depends="" description="">
+    <target name="js.minify" depends= "export" description="Copy minified files from export/ directory">
         <move file="${build.js}/lib" tofile="${build.js}/lib_org"/>
         <move file="${build.js}/index.js" tofile="${build.js}/index.js_org"/>
         <mkdir dir="${build.js}/lib" />
@@ -146,7 +146,7 @@ limitations under the License.
         <move file="${build.js}/lib/index.js" tofile="${build.js}/index.js"/>
     </target>
 
-    <target name="js.original" depends="" description="">
+    <target name="js.original" description="Restore original files">
         <move file="${build.js}/lib_org" tofile="${build.js}/lib"/>
         <move file="${build.js}/index.js_org" tofile="${build.js}/index.js"/>
     </target>
@@ -189,7 +189,7 @@ limitations under the License.
             </exec>
         </sequential>
     </target>
-    <target name="test.address.compiled" depends="qt.version, filereader, js.minify" description="Run the address unit tests in the qt test framework.">
+    <target name="test.address.compiled" depends="qt.version, filereader, js.minify" description="Run the address unit tests in the qt framework with minified files">
         <sequential>
             <exec osfamily="unix" executable="qmlscene" dir="${build.unittest}" failifexecutionfails="true" failonerror="true">
                 <env key="QML2_IMPORT_PATH" value="../FileReader/imports"/>
@@ -215,7 +215,7 @@ limitations under the License.
             </exec>
         </sequential>
     </target>
-    <target name="test.calendar.compiled" depends="qt.version, export, js.minify" description="Run the calendar unit tests in the qt test framework.">
+    <target name="test.calendar.compiled" depends="qt.version, js.minify" description="Run the address unit tests in the qt framework with minified files">
         <sequential>
             <exec osfamily="unix" executable="qmlscene" dir="${build.base}/NodeunitTest" failifexecutionfails="true" failonerror="true">
                 <env key="QML2_IMPORT_PATH" value="../FileReader/imports"/>
@@ -241,7 +241,7 @@ limitations under the License.
             </exec>
         </sequential>
     </target>
-    <target name="test.collate.compiled" depends="qt.version, export, js.minify" description="Run the collate unit tests in the qt test framework.">
+    <target name="test.collate.compiled" depends="qt.version, js.minify" description="Run the address unit tests in the qt framework with minified files">
         <sequential>
             <exec osfamily="unix" executable="qmlscene" dir="${build.base}/NodeunitTest" failifexecutionfails="true" failonerror="true">
                 <env key="QML2_IMPORT_PATH" value="../FileReader/imports"/>
@@ -267,7 +267,7 @@ limitations under the License.
             </exec>
         </sequential>
     </target>
-    <target name="test.ctype.compiled" depends="qt.version, export, js.minify" description="Run the ctype unit tests in the qt test framework.">
+    <target name="test.ctype.compiled" depends="qt.version, js.minify" description="Run the address unit tests in the qt framework with minified files">
         <sequential>
             <exec osfamily="unix" executable="qmlscene" dir="${build.base}/NodeunitTest" failifexecutionfails="true" failonerror="true">
                 <env key="QML2_IMPORT_PATH" value="../FileReader/imports"/>
@@ -293,7 +293,7 @@ limitations under the License.
             </exec>
         </sequential>
     </target>
-    <target name="test.date.compiled" depends="qt.version, export, js.minify" description="Run the date unit tests in the qt test framework.">
+    <target name="test.date.compiled" depends="qt.version, js.minify" description="Run the address unit tests in the qt framework with minified files">
         <sequential>
             <exec osfamily="unix" executable="qmlscene" dir="${build.base}/NodeunitTest" failifexecutionfails="true" failonerror="true">
                 <env key="QML2_IMPORT_PATH" value="../FileReader/imports"/>
@@ -319,7 +319,7 @@ limitations under the License.
             </exec>
         </sequential>
     </target>
-    <target name="test.daterange.compiled" depends="qt.version, export, js.minify" description="Run the daterange unit tests in the qt test framework.">
+    <target name="test.daterange.compiled" depends="qt.version, js.minify" description="Run the address unit tests in the qt framework with minified files">
         <sequential>
             <exec osfamily="unix" executable="qmlscene" dir="${build.base}/NodeunitTest" failifexecutionfails="true" failonerror="true">
                 <env key="QML2_IMPORT_PATH" value="../FileReader/imports"/>
@@ -345,7 +345,7 @@ limitations under the License.
             </exec>
         </sequential>
     </target>
-    <target name="test.durfmt.compiled" depends="qt.version, export" description="Run the durfmt unit tests in the qt test framework.">
+    <target name="test.durfmt.compiled" depends="qt.version, js.minify" description="Run the address unit tests in the qt framework with minified files">
         <sequential>
             <exec osfamily="unix" executable="qmlscene" dir="${build.base}/NodeunitTest" failifexecutionfails="true" failonerror="true">
                 <env key="QML2_IMPORT_PATH" value="../FileReader/imports"/>
@@ -371,7 +371,7 @@ limitations under the License.
             </exec>
         </sequential>
     </target>
-    <target name="test.maps.compiled" depends="qt.version, export, js.minify" description="Run the maps unit tests in the qt test framework.">
+    <target name="test.maps.compiled" depends="qt.version, js.minify" description="Run the address unit tests in the qt framework with minified files">
         <sequential>
             <exec osfamily="unix" executable="qmlscene" dir="${build.base}/NodeunitTest" failifexecutionfails="true" failonerror="true">
                 <env key="QML2_IMPORT_PATH" value="../FileReader/imports"/>
@@ -397,7 +397,7 @@ limitations under the License.
             </exec>
         </sequential>
     </target>
-    <target name="test.name.compiled" depends="qt.version, export, js.minify" description="Run the name unit tests in the qt test framework.">
+    <target name="test.name.compiled" depends="qt.version, js.minify" description="Run the address unit tests in the qt framework with minified files">
         <sequential>
             <exec osfamily="unix" executable="qmlscene" dir="${build.base}/NodeunitTest" failifexecutionfails="true" failonerror="true">
                 <env key="QML2_IMPORT_PATH" value="../FileReader/imports"/>
@@ -423,7 +423,7 @@ limitations under the License.
             </exec>
         </sequential>
     </target>
-    <target name="test.number.compiled" depends="qt.version, export, js.minify" description="Run the number unit tests in the qt test framework.">
+    <target name="test.number.compiled" depends="qt.version, js.minify" description="Run the address unit tests in the qt framework with minified files">
         <sequential>
             <exec osfamily="unix" executable="qmlscene" dir="${build.base}/NodeunitTest" failifexecutionfails="true" failonerror="true">
                 <env key="QML2_IMPORT_PATH" value="../FileReader/imports"/>
@@ -449,7 +449,7 @@ limitations under the License.
             </exec>
         </sequential>
     </target>
-    <target name="test.phone.compiled" depends="qt.version, export, js.minify" description="Run the phone unit tests in the qt test framework.">
+    <target name="test.phone.compiled" depends="qt.version, js.minify" description="Run the address unit tests in the qt framework with minified files">
         <sequential>
             <exec osfamily="unix" executable="qmlscene" dir="${build.base}/NodeunitTest" failifexecutionfails="true" failonerror="true">
                 <env key="QML2_IMPORT_PATH" value="../FileReader/imports"/>
@@ -475,7 +475,7 @@ limitations under the License.
             </exec>
         </sequential>
     </target>
-    <target name="test.root.compiled" depends="qt.version, export, js.minify" description="Run the root unit tests in the qt test framework.">
+    <target name="test.root.compiled" depends="qt.version, js.minify" description="Run the address unit tests in the qt framework with minified files">
         <sequential>
             <exec osfamily="unix" executable="qmlscene" dir="${build.base}/NodeunitTest" failifexecutionfails="true" failonerror="true">
                 <env key="QML2_IMPORT_PATH" value="../FileReader/imports"/>
@@ -501,7 +501,7 @@ limitations under the License.
             </exec>
         </sequential>
     </target>
-    <target name="test.strings_ext.compiled" depends="qt.version, export, js.minify" description="Run the strings_ext unit tests in the qt test framework.">
+    <target name="test.strings_ext.compiled" depends="qt.version, js.minify" description="Run the address unit tests in the qt framework with minified files">
         <sequential>
             <exec osfamily="unix" executable="qmlscene" dir="${build.base}/NodeunitTest" failifexecutionfails="true" failonerror="true">
                 <env key="QML2_IMPORT_PATH" value="../FileReader/imports"/>
@@ -527,7 +527,7 @@ limitations under the License.
             </exec>
         </sequential>
     </target>
-    <target name="test.units.compiled" depends="qt.version, export, js.minify" description="Run the units unit tests in the qt test framework.">
+    <target name="test.units.compiled" depends="qt.version, js.minify" description="Run the address unit tests in the qt framework with minified files">
         <sequential>
             <exec osfamily="unix" executable="qmlscene" dir="${build.base}/NodeunitTest" failifexecutionfails="true" failonerror="true">
                 <env key="QML2_IMPORT_PATH" value="../FileReader/imports"/>
@@ -553,7 +553,7 @@ limitations under the License.
             </exec>
         </sequential>
     </target>
-    <target name="test.util.compiled" depends="qt.version, export, js.minify" description="Run the util unit tests in the qt test framework.">
+    <target name="test.util.compiled" depends="qt.version, js.minify" description="Run the address unit tests in the qt framework with minified files">
         <sequential>
             <exec osfamily="unix" executable="qmlscene" dir="${build.base}/NodeunitTest" failifexecutionfails="true" failonerror="true">
                 <env key="QML2_IMPORT_PATH" value="../FileReader/imports"/>

--- a/qt/build.xml
+++ b/qt/build.xml
@@ -2,7 +2,7 @@
 <!--
 build.xml - build the Qt/QML parts
 
-Copyright © 2015, 2019 JEDLSoft
+Copyright © 2015, 2019 2021 JEDLSoft
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ limitations under the License.
     <!-- Properties that can be overridden -->
     <!-- directories -->
     <property name="build.base"						value="${basedir}"/>
+    <property name="build.js"					value="${build.base}/../js"/>
     <property name="build.export"					value="${build.base}/../export"/>
     <property name="build.output"					value="${build.base}/output"/>
     <property name="build.output.qt"				value="${build.base}/output/qt"/>
@@ -133,6 +134,24 @@ limitations under the License.
         </copy>
     </target>
 
+    <target name="js.minify" depends="" description="">
+        <move file="${build.js}/lib" tofile="${build.js}/lib_org"/>
+        <move file="${build.js}/index.js" tofile="${build.js}/index.js_org"/>
+        <mkdir dir="${build.js}/lib" />
+        <copy todir="${build.js}/lib">
+            <fileset dir="${build.export}/js/dyncode">
+                <include name ="**/*.js"/>
+            </fileset>
+        </copy>
+        <move file="${build.js}/lib/index.js" tofile="${build.js}/index.js"/>
+        <!-- <antcall target="js.original"/>-->
+    </target>
+
+    <target name="js.original" depends="" description="">
+        <move file="${build.js}/lib_org" tofile="${build.js}/lib"/>
+        <move file="${build.js}/index.js_org" tofile="${build.js}/index.js"/>
+    </target>
+
     <target name="test.all" depends="qt.version, filereader" description="Run the unit tests in the qt test framework. Make sure you have Qt 5.4 or later, and it is the first Qt in your path.">
         <sequential>
             <exec osfamily="unix" executable="qmlscene" dir="${build.unittest}" failifexecutionfails="true" failonerror="true">
@@ -157,6 +176,19 @@ limitations under the License.
                 <arg line="NodeunitRun_address.qml"/>
             </exec>
         </sequential>
+    </target>
+    <target name="test.address.minify" depends="qt.version, filereader, js.minify" description="Run the address unit tests in the qt test framework.">
+        <sequential>
+            <exec osfamily="unix" executable="qmlscene" dir="${build.unittest}" failifexecutionfails="true" failonerror="true">
+                <env key="QML2_IMPORT_PATH" value="../FileReader/imports"/>
+                <arg line="NodeunitRun_address.qml"/>
+            </exec>
+            <exec osfamily="windows" executable="qmlscene.exe" dir="${build.unittest}" failifexecutionfails="true"  failonerror="true">
+                <env key="QML2_IMPORT_PATH" value="../FileReader/imports"/>
+                <arg line="NodeunitRun_address.qml"/>
+            </exec>
+        </sequential>
+        <antcall target="js.original"/>
     </target>
 
     <target name="test.calendar" depends="qt.version, export" description="Run the calendar unit tests in the qt test framework.">


### PR DESCRIPTION
### Checklist

* [ ] At least one test case is included for this feature or bug fix.
* [x] `ReleaseNotes` has added or is not needed.
* [x] This PR has passed all of the test cases on `Nodejs` and `Chrome Browser`.
* [x] This PR has passed all of the test cases on `QT/QML`.
* [ ] This is an API breaking change.
* [ ] Requires a major version change.


### Issue Resolved / Feature Added
* Add ability to test minified version of files on Qt
  * used tricky way to copy minified files on js/lib directory.
* Fix warning while occurring on qt with minified files

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

### Links
[//]: # (Related issues, references)
