### PR TITLE
Locale specs can not contain underscores

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -4,8 +4,12 @@ Release Notes for Version 14
 Build 017
 -------
 Published as version 14.10.0
+
 New Features:
 * Changed a default UnitSystem in GB from `imperial` to `metric`
+* Added the ability to parse locale specs with underscores instead of dashes. Some
+  locale specs for Java properties file names or in some gnu gettext libraries are
+  specified with underscores. (ie. "zh_Hans_CN" === "zh-Hans-CN" now)
 
 Bug Fixes:
 * Fixed a bug which a default script for `az` should be `Latin` instead of `Arabic`

--- a/js/lib/Locale.js
+++ b/js/lib/Locale.js
@@ -70,7 +70,7 @@ var Locale = function(language, region, variant, script) {
     if (typeof(region) === 'undefined' && typeof(variant) === 'undefined' && typeof(script) === 'undefined') {
         var spec = language || ilib.getLocale();
         if (typeof(spec) === 'string') {
-            var parts = spec.split('-');
+            var parts = spec.split(/[-_]/g);
             for ( var i = 0; i < parts.length; i++ ) {
                 if (Locale._isLanguageCode(parts[i])) {
                     /**

--- a/js/test/root/testlocale.js
+++ b/js/test/root/testlocale.js
@@ -426,7 +426,7 @@ module.exports.testlocale = {
         test.done();
     },
 
-    testLocaleConstructorSpecPartial: function(test) {
+    testLocaleConstructorSpecWithUnderscores2: function(test) {
         test.expect(4);
         // some locales like those in java properties file names
         // or in gnu gettext libraries are specified with underscores

--- a/js/test/root/testlocale.js
+++ b/js/test/root/testlocale.js
@@ -411,6 +411,35 @@ module.exports.testlocale = {
         test.done();
     },
 
+    testLocaleConstructorSpecWithUnderscores1: function(test) {
+        test.expect(5);
+        // some locales like those in java properties file names
+        // or in gnu gettext libraries are specified with underscores
+        var loc = new Locale("zh_Hans_CN");
+
+        test.ok(loc !== null);
+
+        test.equal(loc.getLanguage(), "zh");
+        test.equal(loc.getRegion(), "CN");
+        test.equal(loc.getScript(), "Hans");
+        test.ok(typeof(loc.getVariant()) === "undefined");
+        test.done();
+    },
+
+    testLocaleConstructorSpecPartial: function(test) {
+        test.expect(4);
+        // some locales like those in java properties file names
+        // or in gnu gettext libraries are specified with underscores
+        var loc = new Locale("en_US");
+
+        test.ok(loc !== null);
+
+        test.equal(loc.getLanguage(), "en");
+        test.equal(loc.getRegion(), "US");
+        test.ok(typeof(loc.getVariant()) === "undefined");
+        test.done();
+    },
+
     testLocaleConstructorShort: function(test) {
         test.expect(4);
         var loc = new Locale("en");


### PR DESCRIPTION
* Added the ability to parse locale specs with underscores instead of dashes. Some
  locale specs for Java properties file names or in some gnu gettext libraries are
  specified with underscores. (ie. "zh_Hans_CN" === "zh-Hans-CN" now)

### Checklist

* [x] At least one test case is included for this feature or bug fix.
* [x] `ReleaseNotes` has added or is not needed.
* [x] This PR has passed all of the test cases on `Nodejs` and `Chrome Browser`.
* [ ] This PR has passed all of the test cases on `QT/QML`.
* [ ] This is an API breaking change.
* [ ] Requires a major version change.


### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

### Links
[//]: # (Related issues, references)
