### PR TITLE
Fixed NodeLoader to check application's resource dir first correctly

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -9,6 +9,7 @@ New Features:
 
 Bug Fixes:
 * Updated to IANA time zone data 2021c
+* Fixed NodeLoader to check application's resource dir first correctly
 
 Build 017
 -------

--- a/js/lib/NodeLoader.js
+++ b/js/lib/NodeLoader.js
@@ -47,7 +47,7 @@ module.exports = function (ilib) {
         //console.log("base is defined as " + this.base);
 
         // this.includePath.push(path.join(this.root, "resources"));     // always check the application's resources dir first
-        this._exists(this.root, "resources"); // always check the application's resources dir first
+        this._exists(path.join(this.root, "resources")); // always check the application's resources dir first
         this._exists(path.join(this.root, "locale"), "localeinfo.json");
 
         // then a standard locale dir of a built version of ilib from npm


### PR DESCRIPTION
### Checklist

* [ ] At least one test case is included for this feature or bug fix.
* [x] `ReleaseNotes` has added or is not needed.
* [x] This PR has passed all of the test cases on `Nodejs` and `Chrome Browser`.
* [ ] This PR has passed all of the test cases on `QT/QML`.
* [ ] This is an API breaking change.
* [ ] Requires a major version change.


### Issue Resolved / Feature Added
Fixed NodeLoader to check application's resource dir first correctly.
Currently, NodeLoader does not add  app's resource directory to include path

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

### Links
[//]: # (Related issues, references)
