### PR TITLE
Updated to route the code flow via NodeLoader when a platform is IoTjs

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version=14.11.1
+version=14.11.2

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -1,6 +1,14 @@
 Release Notes for Version 14
 ============================
 
+Build 020
+-------
+Published as version 14.11.2
+
+Bug Fixes:
+* Updated to route the code flow via NodeLoader when a platform is IoTjs
+
+
 Build 019
 -------
 Published as version 14.11.1

--- a/js/lib/ilib.js
+++ b/js/lib/ilib.js
@@ -138,7 +138,7 @@ ilib._getPlatform = function () {
             }
         } catch (e) {}
 
-        if (typeof(global) !== 'undefined' && global.process && global.process.versions && global.process.versions.node && typeof(module) !== 'undefined' || (typeof(process.iotjs) !== "undefined") ) {
+        if (typeof(global) !== 'undefined' && global.process && global.process.versions && global.process.versions.node && typeof(module) !== 'undefined' || (typeof(global.process.iotjs) !== "undefined") ) {
             ilib._platform = "nodejs";
         } else if (typeof(Qt) !== 'undefined') {
             ilib._platform = "qt";

--- a/js/lib/ilib.js
+++ b/js/lib/ilib.js
@@ -138,7 +138,7 @@ ilib._getPlatform = function () {
             }
         } catch (e) {}
 
-        if (typeof(global) !== 'undefined' && global.process && global.process.versions && global.process.versions.node && typeof(module) !== 'undefined') {
+        if (typeof(global) !== 'undefined' && global.process && global.process.versions && global.process.versions.node && typeof(module) !== 'undefined' || (typeof(process.iotjs) !== "undefined") ) {
             ilib._platform = "nodejs";
         } else if (typeof(Qt) !== 'undefined') {
             ilib._platform = "qt";

--- a/js/test/root/testglobal.js
+++ b/js/test/root/testglobal.js
@@ -1,7 +1,7 @@
 /*
  * testglobal.js - test the ilib static routines
  *
- * Copyright © 2012-2015, 2017-2019, JEDLSoft
+ * Copyright © 2012-2015, 2017-2019, 2021 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -237,7 +237,17 @@ module.exports.testglobal = {
         test.equal(ilib.getTimeZone(), "Europe/London");
         test.done();
     },
-    
+    testGetPlatformIoTjs: function(test) {
+        test.expect(1);
+
+        global.process.iotjs = {
+            "board": "None"
+        };
+
+        test.equal(ilib._getPlatform(), "nodejs");
+        global.iotjs = undefined;
+        test.done();
+    },
     testGetLocaleNodejs1: function(test) {
         if (ilib._getPlatform() !== "nodejs") {
             // only test this in node

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib",
-    "version": "14.11.1",
+    "version": "14.11.2",
     "main": "js/index.js",
     "description": "iLib is a cross-engine library of internationalization (i18n) classes written in pure JS",
     "keywords": [


### PR DESCRIPTION
### Checklist

* [ ] At least one test case is included for this feature or bug fix.
* [x] `ReleaseNotes` has added or is not needed.
* [x] This PR has passed all of the test cases on `Nodejs` and `Chrome Browser`.
* [ ] This PR has passed all of the test cases on `QT/QML`.
* [ ] This is an API breaking change.
* [ ] Requires a major version change.


### Issue Resolved / Feature Added

It's related to https://github.com/iLib-js/iLib/pull/315 PR.
Updated code to route code flow via NodeLoader when a  platform is IoTjs. which is already applied to webos tv version ilib sources. 
Currently, iLib doesn't work on opensource version IoTjs  platform. but webOS TV is running on IoTjs  which are included many additional internal patches version.
Supporting IotNodeader might take loonng time. so Updated this code for the quick  fixes.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

### Links
https://github.com/jerryscript-project/iotjs
