### PR TITLE
Add test cases to check gender formatchoice feature

### DIFF
--- a/js/test/root/teststrings.js
+++ b/js/test/root/teststrings.js
@@ -4399,3 +4399,4 @@ module.exports.teststrings = {
         test.equal(str.formatChoice([params.gender, params.num], params), "(many) Él es mi amigo.");
         test.done();
     }
+}

--- a/js/test/root/teststrings.js
+++ b/js/test/root/teststrings.js
@@ -4343,9 +4343,17 @@ module.exports.teststrings = {
     testStringFormatChoiceGender: function(test) {
         test.expect(2);
         
-        var str = new IString("feminine#She is my friend|masculine#He is my friend|Default#They are my friends");
+        var str = new IString("feminine#She is my friend|masculine#He is my friend|#They are my friends");
         test.ok(str !== null);
         test.equal(str.formatChoice("feminine"), "She is my friend");
+        test.done();
+    },
+    testStringFormatChoiceGenderUnknown: function(test) {
+        test.expect(2);
+        
+        var str = new IString("feminine#She is my friend|masculine#He is my friend|#They are my friends");
+        test.ok(str !== null);
+        test.equal(str.formatChoice("unknown"), "They are my friends");
         test.done();
     },
     testStringFormatChoiceGender_es_ES: function(test) {
@@ -4357,10 +4365,10 @@ module.exports.teststrings = {
             name: "Alice"
         }
         
-        var str = new IString("feminine,one#{name}, Ella es mi amiga.|masculine,one#{name}, Él es mi amigo.|feminine,many#,(many) Ella es mi amiga.|masculine,many#(many) Él es mi amigo.|feminine,#(default)Ellas son mis amigas.|masculine,#(default)Ellos son mis amigos.");
+        var str = new IString("feminine,one#{name}, ella es mi amiga.|masculine,one#{name}, él es mi amigo.|feminine,many#,(many) ella es mi amiga.|masculine,many#(many) él es mi amigo.|feminine,#(feminine, default) Ellas son mis amigas.|masculine,#(masculine, default) Ellos son mis amigos.|#(default, default) Ellos son mis amigos.");
         str.setLocale("es-ES");
         test.ok(str !== null);
-        test.equal(str.formatChoice([params.gender, params.num], params), "Alice, Ella es mi amiga.");
+        test.equal(str.formatChoice([params.gender, params.num], params), "Alice, ella es mi amiga.");
         test.done();
     },
     testStringFormatChoiceGender_es_ES2: function(test) {
@@ -4391,4 +4399,3 @@ module.exports.teststrings = {
         test.equal(str.formatChoice([params.gender, params.num], params), "(many) Él es mi amigo.");
         test.done();
     }
-};

--- a/js/test/root/teststrings.js
+++ b/js/test/root/teststrings.js
@@ -1,7 +1,7 @@
 /*
  * teststrings.js - test the String object
  *
- * Copyright © 2012-2019-2021, JEDLSoft
+ * Copyright © 2012-2019-2022, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -4338,6 +4338,57 @@ module.exports.teststrings = {
         test.ok(str !== null);
 
         test.equal(str.formatChoice(4.1e2), "Default items");
+        test.done();
+    },
+    testStringFormatChoiceGender: function(test) {
+        test.expect(2);
+        
+        var str = new IString("feminine#She is my friend|masculine#He is my friend|Default#They are my friends");
+        test.ok(str !== null);
+        test.equal(str.formatChoice("feminine"), "She is my friend");
+        test.done();
+    },
+    testStringFormatChoiceGender_es_ES: function(test) {
+        test.expect(2);
+
+        var params = {
+            num: 1,
+            gender: "feminine",
+            name: "Alice"
+        }
+        
+        var str = new IString("feminine,one#{name}, Ella es mi amiga.|masculine,one#{name}, Él es mi amigo.|feminine,many#,(many) Ella es mi amiga.|masculine,many#(many) Él es mi amigo.|feminine,#(default)Ellas son mis amigas.|masculine,#(default)Ellos son mis amigos.");
+        str.setLocale("es-ES");
+        test.ok(str !== null);
+        test.equal(str.formatChoice([params.gender, params.num], params), "Alice, Ella es mi amiga.");
+        test.done();
+    },
+    testStringFormatChoiceGender_es_ES2: function(test) {
+        test.expect(2);
+
+        var params = {
+            num: 5,
+            gender: "feminine"
+        }
+        
+        var str = new IString("feminine,one#{name}, Ella es mi amiga.|masculine,one#{name}, Él es mi amigo.|feminine,many#,(many) Ella es mi amiga.|masculine,many#(many) Él es mi amigo.|feminine,#(default)Ellas son mis amigas.|masculine,#(default)Ellos son mis amigos.");
+        str.setLocale("es-ES");
+        test.ok(str !== null);
+        test.equal(str.formatChoice([params.gender, params.num], params), "(default)Ellas son mis amigas.");
+        test.done();
+    },
+    testStringFormatChoiceGender_es_ES3: function(test) {
+        test.expect(2);
+
+        var params = {
+            num: 1000000,
+            gender: "masculine"
+        }
+        
+        var str = new IString("feminine,one#{name}, Ella es mi amiga.|masculine,one#{name}, Él es mi amigo.|feminine,many#,(many) Ella es mi amiga.|masculine,many#(many) Él es mi amigo.|feminine,#(default)Ellas son mis amigas.|masculine,#(default)Ellos son mis amigos.");
+        str.setLocale("es-ES");
+        test.ok(str !== null);
+        test.equal(str.formatChoice([params.gender, params.num], params), "(many) Él es mi amigo.");
         test.done();
     }
 };


### PR DESCRIPTION
### Checklist

* [x] At least one test case is included for this feature or bug fix.
* [ ] `ReleaseNotes` has added or is not needed.
* [x] This PR has passed all of the test cases on `Nodejs` and `Chrome Browser`.
* [x] This PR has passed all of the test cases on `QT/QML`.
* [ ] This is an API breaking change.
* [ ] Requires a major version change.


### Issue Resolved / Feature Added
Add additional test case to check gender formatChice feature

**Issue**
If plural categories are defined as `male` and `female`, 
it couldn't choose category correctly in line https://github.com/iLib-js/iLib/blob/development/js/lib/IString.js#L680
male alphabet is subset is female.


### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

### Links
[//]: # (Related issues, references)
