### PR TITLE
Fixed ilib demo bulid failures issue that is related ilib-scanner

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -12,6 +12,7 @@ New Features:
 Bug Fixes:
 * Fixed the long name of the pounds per square inch (psi) of pressure measure to match the long name used
   in CLDR so that measures of psi can be formatted with the format templates from CLDR
+* Fixed the ilib demo build failure issue that is related ilib-scanner.
 
 
 Build 021

--- a/js/build.xml
+++ b/js/build.xml
@@ -498,12 +498,12 @@ limitations under the License.
             <exec osfamily="unix" executable="bash" dir="${build.demo}" failifexecutionfails="@{failquit}" failonerror="@{failquit}" searchpath="true">
                 <env key="PATH" path="${env.PATH}:${nm.bin}"/>
                 <arg value="-c"/>
-                <arg value="ilib-scanner scripts/ilib-include.js --assembly=assembled --compilation=compiled --locales=${locales.demo} --ilibRoot=${build.base} --mode=production"/>
+                <arg value="ilib-scanner scripts/ilib-include.js --assembly=assembled --compilation=compiled --locales=${locales.demo} --ilibRoot=${build.base} --mode=production --classPath=./lib/ilib-unpack.js"/>
             </exec>
             <exec osfamily="windows" executable="cmd.exe" dir="${build.demo}" failifexecutionfails="@{failquit}"  failonerror="@{failquit}" searchpath="true">
                 <env key="Path" path="${env.PATH}:${nm.bin}"/>
                 <arg value="/c"/>
-                <arg value="ilib-scanner.bat scripts/ilib-include.js --assembly=assembled --compilation=compiled --locales=${locales.demo} --ilibRoot=${build.base} --mode=production"/>
+                <arg value="ilib-scanner.bat scripts/ilib-include.js --assembly=assembled --compilation=compiled --locales=${locales.demo} --ilibRoot=${build.base} --mode=production --classPath=./lib/ilib-unpack.js"/>
             </exec>
         </sequential>
     </target>
@@ -513,12 +513,12 @@ limitations under the License.
             <exec osfamily="unix" executable="bash" dir="${build.demo}" failifexecutionfails="@{failquit}" failonerror="@{failquit}" searchpath="true">
                 <env key="PATH" path="${env.PATH}:${nm.bin}"/>
                 <arg value="-c"/>
-                <arg value="ilib-scanner scripts/ilib-include.js --assembly=dynamicdata --compilation=compiled --locales=${locales.demo} --ilibRoot=${build.base} --mode=production"/>
+                <arg value="ilib-scanner scripts/ilib-include.js --assembly=dynamicdata --compilation=compiled --locales=${locales.demo} --ilibRoot=${build.base} --mode=production --classPath=./lib/ilib-unpack.js"/>
             </exec>
             <exec osfamily="windows" executable="cmd.exe" dir="${build.demo}" failifexecutionfails="@{failquit}"  failonerror="@{failquit}" searchpath="true">
                 <env key="Path" path="${env.PATH}:${nm.bin}"/>
                 <arg value="/c"/>
-                <arg value="ilib-scanner.bat scripts/ilib-include.js --assembly=dynamicdata --compilation=compiled --locales=${locales.demo} --ilibRoot=${build.base} --mode=production"/>
+                <arg value="ilib-scanner.bat scripts/ilib-include.js --assembly=dynamicdata --compilation=compiled --locales=${locales.demo} --ilibRoot=${build.base} --mode=production --classPath=./lib/ilib-unpack.js"/>
             </exec>
         </sequential>
     </target>


### PR DESCRIPTION
### Checklist

* [x] At least one test case is included for this feature or bug fix.
* [x] `ReleaseNotes` has added or is not needed.
* [x] This PR has passed all of the test cases on `Nodejs` and `Chrome Browser`.
* [x] This PR has passed all of the test cases on `QT/QML`.
* [ ] This is an API breaking change.
* [ ] Requires a major version change.


### Issue Resolved / Feature Added

The current version of ilib-scanner occurs circular dependency. 
It's related https://github.com/iLib-js/ilib-scanner/pull/7. when it's mergedm  build.xml is also need to be updated following an ilib-scanner change

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

### Links
[//]: # (Related issues, references)
