### PR TITLE
Fixed some currency symbol (AMD,AZN,GHS)

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -15,7 +15,7 @@ Bug Fixes:
   in CLDR so that measures of psi can be formatted with the format templates from CLDR
 * Fixed the ilib demo build failure issue that is related ilib-scanner.
 * Update to time zone data 2022a
-* * Fixed correct currency symbol (AMD, AZN, GHS)
+* Fixed correct currency symbol (AMD, AZN, GHS)
 
 
 Build 021

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -15,6 +15,7 @@ Bug Fixes:
   in CLDR so that measures of psi can be formatted with the format templates from CLDR
 * Fixed the ilib demo build failure issue that is related ilib-scanner.
 * Update to time zone data 2022a
+* * Fixed correct currency symbol (AMD, AZN, GHS)
 
 
 Build 021

--- a/js/data/locale/currency.json
+++ b/js/data/locale/currency.json
@@ -62,7 +62,7 @@
     "AMD": {
         "name": "Armenian Dram",
         "decimals": 2,
-        "sign": "դր."
+        "sign": "֏"
     },
     "ANG": {
         "name": "Netherlands Antillean Guilder",
@@ -92,7 +92,7 @@
     "AZN": {
         "name": "Azerbaijani Manat",
         "decimals": 2,
-        "sign": "AZN"
+        "sign": "₼"
     },
     "BAM": {
         "name": "Bosnia-Herzegovina Convertible Mark",
@@ -277,7 +277,7 @@
     "GHS": {
         "name": "Ghanaian Cedi",
         "decimals": 2,
-        "sign": "₵"
+        "sign": "GH₵"
     },
     "GIP": {
         "name": "Gibraltar Pound",

--- a/js/test/number/testnumfmt.js
+++ b/js/test/number/testnumfmt.js
@@ -6396,7 +6396,7 @@ module.exports.testnumfmt = {
     
         test.ok(fmt);
     
-        test.equal(fmt.format(100110.57), "100.110,57 AZN");
+        test.equal(fmt.format(100110.57), '100.110,57 ₼');
         test.done();
     },
     testNumFmtPercentageFormatRegular_az_Latn_AZ: function(test) {
@@ -6422,7 +6422,7 @@ module.exports.testnumfmt = {
     
         test.ok(fmt);
     
-        test.equal(fmt.format(-100110.57), "-100.110,57 AZN");
+        test.equal(fmt.format(-100110.57), '-100.110,57 ₼');
         test.done();
     },
     

--- a/js/test/number/testnumfmt2.js
+++ b/js/test/number/testnumfmt2.js
@@ -355,7 +355,7 @@ module.exports.testnumfmt2 = {
         var curfmt = new NumFmt({locale: "en-AM", type: "currency", useNative:false, currency:li.getCurrency()});
         test.equal(li.getCurrencyFormats().common, "{s}{n}");
         test.equal(li.getCurrencyFormats().commonNegative, "-{s}{n}");
-        test.equal(curfmt.format(57.05), "դր.57.05"); //AMD (decimals:0)
+        test.equal(curfmt.format(57.05), '֏57.05'); //AMD (decimals:0)
         test.done();
     },
     testNumFmt_en_AU: function(test) {
@@ -393,7 +393,7 @@ module.exports.testnumfmt2 = {
         var curfmt = new NumFmt({locale: "en-AZ", type: "currency", useNative:false, currency:li.getCurrency()});
         test.equal(li.getCurrencyFormats().common, "{s}{n}");
         test.equal(li.getCurrencyFormats().commonNegative, "-{s}{n}");
-        test.equal(curfmt.format(57.05), "AZN57.05"); //AZN
+        test.equal(curfmt.format(57.05), '₼57.05'); //AZN
         test.done();
     },
     testNumFmt_en_CA: function(test) {
@@ -450,7 +450,7 @@ module.exports.testnumfmt2 = {
         var curfmt = new NumFmt({locale: "en-GH", type: "currency", useNative:false, currency:li.getCurrency()});
         test.equal(li.getCurrencyFormats().common, "{s}{n}");
         test.equal(li.getCurrencyFormats().commonNegative, "-{s}{n}");
-        test.equal(curfmt.format(57.05), "₵57.05"); //GHS
+        test.equal(curfmt.format(57.05), 'GH₵57.05'); //GHS
         test.done();
     },
     testNumFmt_en_HK: function(test) {
@@ -2327,7 +2327,7 @@ module.exports.testnumfmt2 = {
         var curfmt = new NumFmt({locale: "tr-AM", type: "currency", useNative:false, currency:li.getCurrency()});
         test.equal(li.getCurrencyFormats().common, "{s}{n}");
         test.equal(li.getCurrencyFormats().commonNegative, "-{s}{n}");
-        test.equal(curfmt.format(57.05), "դր.57,05"); //AMD
+        test.equal(curfmt.format(57.05), '֏57,05' ); //AMD
         test.done();
     },
     testNumFmt_tr_AZ: function(test) {
@@ -2346,7 +2346,7 @@ module.exports.testnumfmt2 = {
         var curfmt = new NumFmt({locale: "tr-AZ", type: "currency", useNative:false, currency:li.getCurrency()});
         test.equal(li.getCurrencyFormats().common, "{s}{n}");
         test.equal(li.getCurrencyFormats().commonNegative, "-{s}{n}");
-        test.equal(curfmt.format(57.05), "AZN57,05"); //AZN
+        test.equal(curfmt.format(57.05), '₼57,05'); //AZN
         test.done();
     },
     testNumFmt_tr_CY: function(test) {
@@ -2726,7 +2726,7 @@ module.exports.testnumfmt2 = {
         var curfmt = new NumFmt({locale: "az-Latn-AZ", type: "currency", useNative:false, currency:li.getCurrency()});
         test.equal(li.getCurrencyFormats().common, "{n} {s}"); //// CLDR 34 change
         test.equal(li.getCurrencyFormats().commonNegative, "-{n} {s}"); //// CLDR 34 change
-        test.equal(curfmt.format(57.05), "57,05 AZN"); //AZN 
+        test.equal(curfmt.format(57.05), '57,05 ₼'); //AZN
         test.done();
     },
     testNumFmt_km_KH: function(test) {
@@ -3882,7 +3882,7 @@ module.exports.testnumfmt2 = {
         var curfmt = new NumFmt({locale: "hy-AM", type: "currency", useNative:false, currency:li.getCurrency()});
         test.equal(li.getCurrencyFormats().common, "{n} {s}");
         test.equal(li.getCurrencyFormats().commonNegative, "-{n} {s}");
-        test.equal(curfmt.format(57.05), "57,05 դր.");
+        test.equal(curfmt.format(57.05), '57,05 ֏');
         test.done();
     },
     testNumFmt_gl_ES: function(test) {


### PR DESCRIPTION
### Checklist

* [ ] At least one test case is included for this feature or bug fix.
* [x] `ReleaseNotes` has added or is not needed.
* [x] This PR has passed all of the test cases on `Nodejs` and `Chrome Browser`.
* [ ] This PR has passed all of the test cases on `QT/QML`.
* [ ] This is an API breaking change.
* [ ] Requires a major version change.


### Issue Resolved / Feature Added
I ran the `gencurencies.js` tool code again. and seems that it's currently missed some data.
When running `gencurencies.js`, the ilib locale data path should be put as a parameter mandatory. because if the cldr doesn't have proper data, we've decided to maintain current ilib data.
   `Usage: gencurrency  [iLib locale Dir] [toDir] `
double-checked the symbol related to the data change below:
* AMD: https://en.wikipedia.org/wiki/Armenian_dram_sign
* AZN: https://en.wikipedia.org/wiki/Azerbaijani_manat
* GHS: https://en.wikipedia.org/wiki/Ghanaian_cedi

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

### Links
[//]: # (Related issues, references)
