### PR TITLE
update copyright year in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ section about webpack for links.
 Copyright and License
 -------
 
-Copyright (c) 2011-2021, JEDLSoft
+Copyright (c) 2011-2022, JEDLSoft
 
 Ilib is licensed under the Apache License, Version 2.0 (the "License");
 you may not use this library except in compliance with the License.


### PR DESCRIPTION
Let's keep legal happy.

### Checklist

* [ ] At least one test case is included for this feature or bug fix.
* [ ] `ReleaseNotes` has added or is not needed.
* [ ] This PR has passed all of the test cases on `Nodejs` and `Chrome Browser`.
* [ ] This PR has passed all of the test cases on `QT/QML`.
* [ ] This is an API breaking change.
* [ ] Requires a major version change.


### Issue Resolved / Feature Added
oh.. I restore the copyright/2022 branch that I deleted.. I think at least the copyright year in the **README.md** file should be updated every year as long as  ilib is publishing continuously..

### Resolution

### Links
[//]: # (Related issues, references)
