### PR TITLE
Fix typo in DateFmt.formatRelative()

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version=14.14.0
+version=14.14.1

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -1,6 +1,16 @@
 Release Notes for Version 14
 ============================
 
+Build 023
+-------
+Published as version 14.14.1
+
+New Features:
+
+Bug Fixes:
+* Fixed a bug where the DateFmt.formatRelative() does not represent correct result in certain case.
+
+
 Build 022
 -------
 Published as version 14.14.0

--- a/js/lib/DateFmt.js
+++ b/js/lib/DateFmt.js
@@ -1590,7 +1590,7 @@ DateFmt.prototype = {
                     fmt = diff > 0 ? this.sysres.getString("#{num}d ago") : this.sysres.getString("#in {num}d");
                     break;
                 case 'm':
-                    fmt = diff > 0 ? this.sysres.getString("1#1 dy ago|#{nudurationm} dys ago") : this.sysres.getString("1#in 1 dy|#in {num} dys");
+                    fmt = diff > 0 ? this.sysres.getString("1#1 dy ago|#{num} dys ago") : this.sysres.getString("1#in 1 dy|#in {num} dys");
                     break;
                 default:
                 case 'f':

--- a/js/test/date/testdatefmt.js
+++ b/js/test/date/testdatefmt.js
@@ -1,7 +1,7 @@
 /*
  * testdatefmt.js - test the date formatter object
  *
- * Copyright © 2012-2015, 2017, 2020-2021 JEDLSoft
+ * Copyright © 2012-2015, 2017, 2020-2022 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -2503,6 +2503,34 @@ module.exports.testdatefmt = {
         test.equal(fmt.formatRelative(reference, date), "4 days ago");
         test.done();
     },
+
+    testDateFmtFormatRelativeWithinFortnightBeforeMedium: function(test) {
+        test.expect(2);
+        var fmt = new DateFmt({length: "medium"});
+        test.ok(fmt !== null);
+
+        var reference = new GregorianDate({
+            year: 2011,
+            month: 11,
+            day: 20,
+            hour: 13,
+            minute: 45,
+            second: 0,
+            millisecond: 0
+        });
+        var date = new GregorianDate({
+            year: 2011,
+            month: 11,
+            day: 16,
+            hour: 9,
+            minute: 35,
+            second: 0,
+            millisecond: 0
+        });
+        test.equal(fmt.formatRelative(reference, date), "4 days ago");
+        test.done();
+    },
+    
 
     testDateFmtFormatRelativeWithinQuarterAfter: function(test) {
         test.expect(2);

--- a/js/test/date/testdatefmt_ko_KR.js
+++ b/js/test/date/testdatefmt_ko_KR.js
@@ -1,7 +1,7 @@
 /*
  * testdatefmt_ko_KR.js - test the date formatter object in Korean
  * 
- * Copyright © 2012-2015,2017, JEDLSoft
+ * Copyright © 2012-2015,2017,2022 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1594,6 +1594,35 @@ module.exports.testdatefmt_ko_KR = {
     testDateFmtFormatRelativeWithinFortnightBefore_ko_KR: function(test) {
         test.expect(2);
         var fmt = new DateFmt({locale: "ko-KR", length: "full"});
+        test.ok(fmt !== null);
+        
+        var reference = new GregorianDate({
+            locale: "ko-KR",
+            year: 2011,
+            month: 11,
+            day: 20,
+            hour: 13,
+            minute: 45,
+            second: 0,
+            millisecond: 0
+        });
+        var date = new GregorianDate({
+            locale: "ko-KR",
+            year: 2011,
+            month: 11,
+            day: 16,
+            hour: 9,
+            minute: 35,
+            second: 0,
+            millisecond: 0
+        });
+        test.equal(fmt.formatRelative(reference, date), "4일 전");
+        test.done();
+    },
+
+    testDateFmtFormatRelativeWithinFortnightBeforeMedium_ko_KR: function(test) {
+        test.expect(2);
+        var fmt = new DateFmt({locale: "ko-KR", length: "medium"});
         test.ok(fmt !== null);
         
         var reference = new GregorianDate({

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib",
-    "version": "14.14.0",
+    "version": "14.14.1",
     "main": "js/index.js",
     "description": "iLib is a cross-engine library of internationalization (i18n) classes written in pure JS",
     "keywords": [


### PR DESCRIPTION
### Checklist

* [ ] At least one test case is included for this feature or bug fix.
* [x] `ReleaseNotes` has added or is not needed.
* [x] This PR has passed all of the test cases on `Nodejs` and `Chrome Browser`.
* [x] This PR has passed all of the test cases on `QT/QML`.
* [ ] This is an API breaking change.
* [ ] Requires a major version change.

### Issue Resolved / Feature Added
* Fixed a bug where the `DateFmt.formatRelative()` does not represent the correct result in certain case.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

### Links
[//]: # (Related issues, references)
