### PR TITLE
Added option to choose whether to use Intl.DateTimeFormat

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -8,6 +8,7 @@ Published as version 14.15.0
 New Features:
 * Update to CLDR v41 data
 * Update to the latest ISO-14924 data (writing script information)
+* Added `useIntl` option in DateFmt to choose whether to use Intl.DateTimeFormat
 
 Bug Fixes:
 * Fixed a bug where the DateFmt.formatRelative() does not represent correct result in certain case.

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -9,6 +9,7 @@ New Features:
 * Update to CLDR v41 data
 * Update to the latest ISO-14924 data (writing script information)
 * Added `useIntl` option in DateFmt to choose whether to use Intl.DateTimeFormat
+    * When it is is true, and paramaters are convertable for using Intl Object case, you can get relatively fast result, but different result may get depending on the platform nd version.
 
 Bug Fixes:
 * Fixed a bug where the DateFmt.formatRelative() does not represent correct result in certain case.

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -9,7 +9,10 @@ New Features:
 * Update to CLDR v41 data
 * Update to the latest ISO-14924 data (writing script information)
 * Added `useIntl` option in DateFmt to choose whether to use Intl.DateTimeFormat
-    * When it is is true, and paramaters are convertable for using Intl Object case, you can get relatively fast result, but different result may get depending on the platform nd version.
+    * When it is set to true, the Intl object is available, it supports the requested locale, and the parameters can be converted to equivalent parameters for the Intl.DateTimeFormat object, then it will format the date relatively quickly using Intl.
+    * When they cannot be converted, the Intl object is not available, or the Intl object does not support the requested locale, it will perform the relatively slow formatting using regular ilib code written in Javascript.
+    *  The code will often return different results depending on the platform and version of the Javascript engine and which version of CLDR it supports. If you need consistency across versions and platforms, do not use the useIntl flag. Just stick with the regular ilib formatting code.
+
 
 Bug Fixes:
 * Fixed a bug where the DateFmt.formatRelative() does not represent correct result in certain case.

--- a/js/lib/DateFactory.js
+++ b/js/lib/DateFactory.js
@@ -259,4 +259,19 @@ DateFactory._dateToIlib = function(inDate, timezone, locale) {
     });
 };
 
+DateFactory._ilibToDate = function(ilibDate, timezone, locale) {
+    if (typeof(ilibDate) === 'undefined' || ilibDate === null) {
+        return ilibDate;
+    }
+    var year = ilibDate.year;
+    var month = ilibDate.month-1;
+    var day = ilibDate.day;
+    var hours = ilibDate.hour;
+    var minutes = ilibDate.minute;
+    var seconds = ilibDate.second;
+    var milliseconds = ilibDate.second;
+
+    return new Date(year, month, day, hours, minutes, seconds, milliseconds);
+};
+
 module.exports = DateFactory;

--- a/js/lib/DateFactory.js
+++ b/js/lib/DateFactory.js
@@ -263,6 +263,7 @@ DateFactory._ilibToDate = function(ilibDate, timezone, locale) {
     if (typeof(ilibDate) !== 'object' || !(ilibDate instanceof IDate)) {
         return ilibDate;
     }
+
     return new Date(ilibDate.getTimeExtended());
 };
 

--- a/js/lib/DateFactory.js
+++ b/js/lib/DateFactory.js
@@ -260,18 +260,10 @@ DateFactory._dateToIlib = function(inDate, timezone, locale) {
 };
 
 DateFactory._ilibToDate = function(ilibDate, timezone, locale) {
-    if (typeof(ilibDate) === 'undefined' || ilibDate === null) {
+    if (typeof(ilibDate) !== 'object' || !(ilibDate instanceof IDate)) {
         return ilibDate;
     }
-    var year = ilibDate.year;
-    var month = ilibDate.month-1;
-    var day = ilibDate.day;
-    var hours = ilibDate.hour;
-    var minutes = ilibDate.minute;
-    var seconds = ilibDate.second;
-    var milliseconds = ilibDate.second;
-
-    return new Date(year, month, day, hours, minutes, seconds, milliseconds);
+    return new Date(ilibDate.getTimeExtended());
 };
 
 module.exports = DateFactory;

--- a/js/lib/DateFmt.js
+++ b/js/lib/DateFmt.js
@@ -536,7 +536,7 @@ var DateFmt = function(options) {
             }
             else {
                 if (typeof(options.onLoad) === 'function') {
-                    options.onLoad(this.IntlDateTimeObj);
+                    options.onLoad(this);
                 }
             }
         })

--- a/js/lib/DateFmt.js
+++ b/js/lib/DateFmt.js
@@ -429,7 +429,6 @@ var DateFmt = function(options) {
 
     loadParams = options.loadParams;
 
-    //intl.""
     /*
     2022 년 3월 22이리 화. 불가능. option 으로 나오는 형태가 다름.
     date. dmwy (full) -->    dateSylte: full.
@@ -446,8 +445,6 @@ var DateFmt = function(options) {
     this.length = "s";
     this.dateComponents = "dmy";
     this.timeComponents = "ahm";
-    "date": ["dmy, dmwy"]
-    //date: w
     */
     new LocaleInfo(this.locale, {
         sync: sync,
@@ -459,14 +456,16 @@ var DateFmt = function(options) {
             // one, use the hard-coded gregorian as the last resort
             this.calName = this.calName || this.locinfo.getCalendar() || "gregorian";
             
-            if(sync && typeof(Intl) !== 'undefined' && Intl.DateTimeFormat.supportedLocalesOf(this.locale.getSpec().length>0)){
-                if (this.locinfo.getDigitsStyle()== "western" && (!options.template))    {
-                    if(this.type == "date" && this.dateComponents == "dmy"){
-                        var len = this._makefullLengthName(this.length);
+            if(sync && typeof(Intl) !== 'undefined' && Intl.DateTimeFormat.supportedLocalesOf(this.locale.getSpec()).length > 0){
+                if (this.locinfo.getDigitsStyle() == "western" && (!options.template) && this.calName == "gregorian")    {
+                    if(this.type == "date" && ((this.dateComponents == "dmy" && this.length != "f") ||
+                        (this.dateComponents == "dmwy" && this.length == "f"))){
+                        var len = DateFmt.lenmap[this.length];
                         this.IntlDateTimeObj = new Intl.DateTimeFormat(this.locale.getSpec(), {
                             dateStyle: len
-                        })
+                        });
                         this.useIntlObj = true;
+                        //this.objOptions = options;
                     };
                 }
             }
@@ -691,26 +690,6 @@ DateFmt.prototype = {
            })
         });
     },
-    _makefullLengthName: function(style) {
-        if(!style) return;
-        var fullName;
-        switch(style){
-            case 'f':
-                fullName = "full";
-                break;
-            case 'l':
-                fullName = "long";
-                break;
-            case 'medium':
-                fullName = "medium";
-                break;
-            default:
-                fullName = "short";
-                break;
-        }
-        return fullName;
-    },
-
     /**
      * @protected
      * @param {string|{
@@ -1012,7 +991,11 @@ DateFmt.prototype = {
      * @return {string} the name of the calendar used by this formatter
      */
     getCalendar: function () {
-        return this.cal.getType() || 'gregorian';
+        if(this.IntlDateTimeObj){
+            return this.calName;
+        } else {
+            return this.cal.getType() || 'gregorian';
+        }
     },
 
     /**

--- a/js/lib/DateFmt.js
+++ b/js/lib/DateFmt.js
@@ -434,7 +434,7 @@ var DateFmt = function(options) {
     loadParams = options.loadParams;
 
     /*
-    date. dmwy (full) -->    dateSyle: full.
+    date. dmwy (full) -->    dateStyle: full
     date. dmwy (long) -->    X
 
     date: dmy (long) -->    dateStyle: long

--- a/js/lib/DateFmt.js
+++ b/js/lib/DateFmt.js
@@ -453,15 +453,13 @@ var DateFmt = function(options) {
                         dateStyle: len
                     });
                 } else if (this.type == "time" &&
-                    this.timeComponents== "ahm" || this.timeComponents== "ahms" || this.timeComponents== "ahmsz"){
+                    this.timeComponents== "ahm" || this.timeComponents== "ahms"){
                     var timeMap = {
                         "ahm": "short",
-                        "ahms": "medium",
-                        "ahmsz": "long"
+                        "ahms": "medium"
                     }
                     this.IntlDateTimeObj = new Intl.DateTimeFormat(this.locale.getSpec(), {
-                        timeStyle: timeMap[this.timeComponents],
-                        timeZone: this.timezone || "UTC"
+                        timeStyle: timeMap[this.timeComponents]
                     });
                 } else if (this.type == "date" && this.dateComponents == "m" && len == "full") {
                     this.IntlDateTimeObj = new Intl.DateTimeFormat(this.locale.getSpec(), {

--- a/js/lib/DateFmt.js
+++ b/js/lib/DateFmt.js
@@ -433,19 +433,6 @@ var DateFmt = function(options) {
 
     loadParams = options.loadParams;
 
-    /*
-    date. dmwy (full) -->    dateStyle: full
-    date. dmwy (long) -->    X
-
-    date: dmy (long) -->    dateStyle: long
-    date: dmy (full) -->    dateStyle: long
-    date: dmy (medium) --> dateStyle : medium
-    date: dmy (short) --> dateStyle : short
-
-    time: ahm -->    timeStyle: short.
-    time: ahms -->   timestyle : medium
-    time: ahmsz -->  timestyle: long
-    */
     new LocaleInfo(this.locale, {
         sync: sync,
         loadParams: loadParams,

--- a/js/lib/DateFmt.js
+++ b/js/lib/DateFmt.js
@@ -430,21 +430,17 @@ var DateFmt = function(options) {
     loadParams = options.loadParams;
 
     /*
-    2022 년 3월 22이리 화. 불가능. option 으로 나오는 형태가 다름.
     date. dmwy (full) -->    dateSylte: full.
-    date: dmy (long)  -->    dateStyle: long
-    date: dmy (full)  -->    dateStyle: long
-    date: dmy (medium)   --> dateStyle : medium
-    dmy (short)   --? dateStyle: short
+    date. dmwy (long) -->    X
 
-    time: ahm  --     timeStyle: short.
-    time ahms        timestyle : medium
-    time ahmsz        timestyle: long
+    date: dmy (long) -->    dateStyle: long
+    date: dmy (full) -->    dateStyle: long
+    date: dmy (medium) --> dateStyle : medium
+    date: dmy (short) --> dateStyle : short
 
-    this.type = "date";
-    this.length = "s";
-    this.dateComponents = "dmy";
-    this.timeComponents = "ahm";
+    time: ahm -->    timeStyle: short.
+    time: ahms -->   timestyle : medium
+    time: ahmsz -->  timestyle: long
     */
     new LocaleInfo(this.locale, {
         sync: sync,
@@ -465,7 +461,6 @@ var DateFmt = function(options) {
                             dateStyle: len
                         });
                         this.useIntlObj = true;
-                        //this.objOptions = options;
                     };
                 }
             }

--- a/js/lib/DateFmt.js
+++ b/js/lib/DateFmt.js
@@ -251,6 +251,11 @@ var ISet = require("./ISet.js");
  * to the various parts of the day. N.B. Even for the Chinese locales, the default is "gregorian"
  * when formatting dates in the Gregorian calendar.
  *
+ * <li><i>useIntl</i> - choose whether Intl.DateTimeFormat object for formatting. when it is is true,
+ * and paramaters are convertable for using Intl Object case, it use the object to get result.
+ * You can get relatively fast result, but different result may get depending on
+ * currently running on the platform and version.
+ *
  * <li><i>onLoad</i> - a callback function to call when the date format object is fully
  * loaded. When the onLoad option is given, the DateFmt object will attempt to
  * load any missing locale data using the ilib loader callback.
@@ -448,7 +453,6 @@ var DateFmt = function(options) {
                 var len = DateFmt.lenmap[this.length];
                 if(this.type == "date" &&
                     ((this.dateComponents == "dmy" && len != "full") || (this.dateComponents == "dmwy" && len == "full"))){
-                    
                     this.IntlDateTimeObj = new Intl.DateTimeFormat(this.locale.getSpec(), {
                         dateStyle: len
                     });
@@ -473,7 +477,6 @@ var DateFmt = function(options) {
                 } else {
                     this.useIntl = false;
                 }
-                
             }
             if(!this.useIntl){
                 if (!this.IntlDateTimeObj && ilib.isDynCode()) {

--- a/js/lib/DateFmt.js
+++ b/js/lib/DateFmt.js
@@ -251,10 +251,15 @@ var ISet = require("./ISet.js");
  * to the various parts of the day. N.B. Even for the Chinese locales, the default is "gregorian"
  * when formatting dates in the Gregorian calendar.
  *
- * <li><i>useIntl</i> - choose whether Intl.DateTimeFormat object for formatting. when it is is true,
- * and paramaters are convertable for using Intl Object case, it use the object to get result.
- * You can get relatively fast result, but different result may get depending on
- * currently running on the platform and version.
+ * <li><i>useIntl</i> - choose whether Intl.DateTimeFormat object for formatting.
+ * When it is set to true, the Intl object is available, it supports the requested locale, and
+ * the parameters can be converted to equivalent parameters for the Intl.DateTimeFormat object,
+ * then it will format the date relatively quickly using Intl.
+ * When they cannot be converted, the Intl object is not available, or the Intl object does not support
+ * the requested locale, it will perform the relatively slow formatting using regular ilib code written in Javascript.
+ * The code will often return different results depending on the platform and version of the Javascript engine
+ * and which version of CLDR it supports. If you need consistency across versions and platforms,
+ * do not use the useIntl flag. Just stick with the regular ilib formatting code.
  *
  * <li><i>onLoad</i> - a callback function to call when the date format object is fully
  * loaded. When the onLoad option is given, the DateFmt object will attempt to

--- a/js/lib/DateFmt.js
+++ b/js/lib/DateFmt.js
@@ -472,7 +472,7 @@ var DateFmt = function(options) {
                         "ahmsz": "long"
                     }
                     this.IntlDateTimeObj = new Intl.DateTimeFormat(this.locale.getSpec(), {
-                        timeStyle: timeMap(this.timeComponents)
+                        timeStyle: timeMap[this.timeComponents]
                     });
                 }
                 
@@ -532,6 +532,11 @@ var DateFmt = function(options) {
                         });
                     })
                 });
+            }
+            else {
+                if (typeof(options.onLoad) === 'function') {
+                    options.onLoad(this.IntlDateTimeObj);
+                }
             }
         })
     });
@@ -644,6 +649,25 @@ DateFmt.getMeridiemsRange = function (options) {
     var fmt = new DateFmt(args);
 
     return fmt.getMeridiemsRange();
+};
+
+/**
+ * return true if the locale is supported in date and time formatting for Intl.DateTimeFormat Object
+ * <ul>
+ * <li><i>locale</i> - locale to check if it is available or not.
+ * If the locale is not specified, then it returns false.
+ *
+ * </ul>
+ *
+ * @static
+ * @public
+ * @param {string} locale locale to check if it is available or not.
+ * @return {Boolean} true if it is available to use, false otherwise
+ */
+
+DateFmt.isIntlDateTimeAvailable = function (locale) {
+    if(!locale || !ilib._global("Intl")) return false;
+    return (Intl.DateTimeFormat.supportedLocalesOf(locale).length > 0) ? true : false;
 };
 
 DateFmt.prototype = {
@@ -999,11 +1023,7 @@ DateFmt.prototype = {
      * @return {string} the name of the calendar used by this formatter
      */
     getCalendar: function () {
-        if(this.IntlDateTimeObj){
-            return this.calName;
-        } else {
-            return this.cal.getType() || 'gregorian';
-        }
+        return this.cal.getType() || 'gregorian';
     },
 
     /**
@@ -1520,7 +1540,7 @@ DateFmt.prototype = {
         }
 
         if(this.useIntl && this.IntlDateTimeObj){
-            var jsDate = DateFactory._ilibToDate(date);
+            var jsDate = DateFactory._ilibToDate(date, thisZoneName, this.locale);
             return this.IntlDateTimeObj.format(jsDate);
         }
 

--- a/js/lib/DateFmt.js
+++ b/js/lib/DateFmt.js
@@ -460,7 +460,8 @@ var DateFmt = function(options) {
             (this.locinfo.getDigitsStyle() == "western" && (!options.template) && this.calName == "gregorian")){
                 var len = DateFmt.lenmap[this.length];
                 if(this.type == "date" &&
-                    ((this.dateComponents == "dmy" && len != "full") || (this.dateComponents == "dmwy" && this.length == "full"))){
+                    ((this.dateComponents == "dmy" && len != "full") || (this.dateComponents == "dmwy" && len == "full"))){
+                    
                     this.IntlDateTimeObj = new Intl.DateTimeFormat(this.locale.getSpec(), {
                         dateStyle: len
                     });
@@ -472,8 +473,20 @@ var DateFmt = function(options) {
                         "ahmsz": "long"
                     }
                     this.IntlDateTimeObj = new Intl.DateTimeFormat(this.locale.getSpec(), {
-                        timeStyle: timeMap[this.timeComponents]
+                        timeStyle: timeMap[this.timeComponents],
+                        timeZone: this.timezone || "UTC"
                     });
+                } else if (this.type == "date" && this.dateComponents == "m" && len == "full") {
+                    this.IntlDateTimeObj = new Intl.DateTimeFormat(this.locale.getSpec(), {
+                        month: "long"
+                    });
+
+                } else if (this.type == "date" && this.dateComponents == "w" && len == "full") {
+                    this.IntlDateTimeObj = new Intl.DateTimeFormat(this.locale.getSpec(), {
+                       weekday: "long"
+                    });
+                } else {
+                    this.useIntl = false;
                 }
                 
             }

--- a/js/test/date/testMonthTranslation.js
+++ b/js/test/date/testMonthTranslation.js
@@ -3403,11 +3403,6 @@ module.exports.testmonthtranslation = {
         }
         test.expect(12);
 
-        // full, long: MMMM
-        // medium: MM
-        // short: MM
-
-
         var value = [], i;
         var fmt = new DateFmt({locale:"ko-KR", date:"m", length: "full", useNative:false, timezone:"local"})
         for (i=0; i < 12; i++) {

--- a/js/test/date/testMonthTranslation.js
+++ b/js/test/date/testMonthTranslation.js
@@ -1923,6 +1923,37 @@ module.exports.testmonthtranslation = {
 
         test.done();
     },
+
+    testMonthTranslate_es_ES_Intl: function(test) {
+        if(!DateFmt.isIntlDateTimeAvailable("es-ES")){
+            // The result is different depending on the node version.
+            test.done();
+            return;
+        }
+        test.expect(12);
+
+        var value = [], i;
+        var fmt = new DateFmt({locale:"es-ES", date:"m", length: "full", useNative:false, useIntl: true, timezone:"local"})
+        for (i=0; i < 12; i++) {
+            value[i] = fmt.format(DateFactory({month:i+1, type:"gregorian"}));
+        }
+
+        test.equal(value[0], "enero");
+        test.equal(value[1], "febrero");
+        test.equal(value[2], "marzo");
+        test.equal(value[3], "abril");
+        test.equal(value[4], "mayo");
+        test.equal(value[5], "junio");
+        test.equal(value[6], "julio");
+        test.equal(value[7], "agosto");
+        test.equal(value[8], "septiembre");
+        test.equal(value[9], "octubre");
+        test.equal(value[10], "noviembre");
+        test.equal(value[11], "diciembre");
+
+        test.done();
+    },
+
     testMonthTranslate_es_GT: function(test) {
         test.expect(12);
 
@@ -3366,6 +3397,38 @@ module.exports.testmonthtranslation = {
         test.done();
     },
     testMonthTranslate_ko_KR: function(test) {
+        if(!DateFmt.isIntlDateTimeAvailable("ko-KR")){
+            test.done();
+            return;
+        }
+        test.expect(12);
+
+        // full, long: MMMM
+        // medium: MM
+        // short: MM
+
+
+        var value = [], i;
+        var fmt = new DateFmt({locale:"ko-KR", date:"m", length: "full", useNative:false, timezone:"local"})
+        for (i=0; i < 12; i++) {
+            value[i] = fmt.format(DateFactory({month:i+1, type:"gregorian"}));
+        }
+        test.equal(value[0], "1월");
+        test.equal(value[1], "2월");
+        test.equal(value[2], "3월");
+        test.equal(value[3], "4월");
+        test.equal(value[4], "5월");
+        test.equal(value[5], "6월");
+        test.equal(value[6], "7월");
+        test.equal(value[7], "8월");
+        test.equal(value[8], "9월");
+        test.equal(value[9], "10월");
+        test.equal(value[10], "11월");
+        test.equal(value[11], "12월");
+
+        test.done();
+    },
+    testMonthTranslate_ko_KR_Intl: function(test) {
         test.expect(12);
 
         // full, long: MMMM
@@ -3373,7 +3436,7 @@ module.exports.testmonthtranslation = {
         // short: MM
 
         var value = [], i;
-        var fmt = new DateFmt({locale:"ko-KR", date:"m", length: "full", useNative:false, timezone:"local"})
+        var fmt = new DateFmt({locale:"ko-KR", date:"m", length: "full", useNative:false, useIntl:true, timezone:"local"})
         for (i=0; i < 12; i++) {
             value[i] = fmt.format(DateFactory({month:i+1, type:"gregorian"}));
         }

--- a/js/test/date/testMonthTranslation.js
+++ b/js/test/date/testMonthTranslation.js
@@ -3397,10 +3397,6 @@ module.exports.testmonthtranslation = {
         test.done();
     },
     testMonthTranslate_ko_KR: function(test) {
-        if(!DateFmt.isIntlDateTimeAvailable("ko-KR")){
-            test.done();
-            return;
-        }
         test.expect(12);
 
         var value = [], i;
@@ -3424,6 +3420,10 @@ module.exports.testmonthtranslation = {
         test.done();
     },
     testMonthTranslate_ko_KR_Intl: function(test) {
+        if(!DateFmt.isIntlDateTimeAvailable("ko-KR")){
+            test.done();
+            return;
+        }
         test.expect(12);
 
         // full, long: MMMM

--- a/js/test/date/testWeekdayTranslation.js
+++ b/js/test/date/testWeekdayTranslation.js
@@ -2921,6 +2921,28 @@ module.exports.testWeekdayTranslation = {
 
         test.done();
     },
+    testWeekdayTranslation_es_ES_Intl: function(test) {
+        if(!DateFmt.isIntlDateTimeAvailable("es-ES")){
+            test.done();
+            return;
+        }
+        test.expect(7);
+        var fmt, value = [], i;
+
+        fmt = new DateFmt({locale:"es-ES", date:"w", length: "full", useNative:false, useIntl:true, timezone:"local"})
+        for (i=0; i < 7; i++) {
+            value[i] = fmt.format(DateFactory({year: 2015, month: 8, day:i+2, type:"gregorian"}));
+        }
+        test.equal(value[0], "domingo");
+        test.equal(value[1], "lunes");
+        test.equal(value[2], "martes");
+        test.equal(value[3], "miércoles");
+        test.equal(value[4], "jueves");
+        test.equal(value[5], "viernes");
+        test.equal(value[6], "sábado");
+
+        test.done();
+    },
     testWeekdayTranslation_es_GT: function(test) {
         test.expect(28);
         var fmt, value = [], i;
@@ -5054,6 +5076,28 @@ module.exports.testWeekdayTranslation = {
         test.equal(value[5], "금");
         test.equal(value[6], "토");
 
+        test.done();
+    },
+    testWeekdayTranslation_ko_KR_Intl: function(test) {
+        if(!DateFmt.isIntlDateTimeAvailable("ko-KR")){
+            test.done();
+            return;
+        }
+        test.expect(7);
+        var fmt, value = [], i;
+        
+        fmt = new DateFmt({locale:"ko-KR", date:"w", length: "full", useNative:false, useIntl: true, timezone:"local"})
+        for (i=0; i < 7; i++) {
+            value[i] = fmt.format(DateFactory({year: 2015, month: 8, day:i+2, type:"gregorian"}));
+        }
+        test.equal(value[0], "일요일");
+        test.equal(value[1], "월요일");
+        test.equal(value[2], "화요일");
+        test.equal(value[3], "수요일");
+        test.equal(value[4], "목요일");
+        test.equal(value[5], "금요일");
+        test.equal(value[6], "토요일");
+      
         test.done();
     },
     testWeekdayTranslation_ku_Arab_IQ: function(test) {

--- a/js/test/date/testdatefmt.js
+++ b/js/test/date/testdatefmt.js
@@ -3981,5 +3981,12 @@ module.exports.testdatefmt = {
 
         test.equal(fmt.getDateComponentOrder(), "mdy");
         test.done();
+    },
+    testDateFmtisIntlDateTimeAvaiable: function(test) {
+        test.expect(1);
+
+        var result = DateFmt.isIntlDateTimeAvailable();
+        test.equal(result, false);
+        test.done();
     }
 };

--- a/js/test/date/testdatefmt.js
+++ b/js/test/date/testdatefmt.js
@@ -3996,7 +3996,18 @@ module.exports.testdatefmt = {
         }
         test.expect(1);
         var result = DateFmt.isIntlDateTimeAvailable("ko-KR");
-        test.equal(result, true);
+
+        if(ilib._getPlatform() === "nodejs") {
+            var version = process.versions["node"];
+            var majorVersion = version.split(".")[0];
+            if (majorVersion == "8" || majorVersion == "10" || majorVersion == "12") {
+                test.equal(result, false);
+            } else {
+                test.equal(result, true);
+            }
+        } else {
+            test.equal(result, true);
+        }
         test.done();
     }
 };

--- a/js/test/date/testdatefmt.js
+++ b/js/test/date/testdatefmt.js
@@ -3988,5 +3988,15 @@ module.exports.testdatefmt = {
         var result = DateFmt.isIntlDateTimeAvailable();
         test.equal(result, false);
         test.done();
+    },
+    testDateFmtisIntlDateTimeAvaiable_ko_KR: function(test) {
+        if (!(ilib._getPlatform() === "nodejs" || ilib._getPlatform() === "browser")) {
+            test.done();
+            return;
+        }
+        test.expect(1);
+        var result = DateFmt.isIntlDateTimeAvailable("ko-KR");
+        test.equal(result, true);
+        test.done();
     }
 };

--- a/js/test/date/testdatefmt_az_Latn_AZ.js
+++ b/js/test/date/testdatefmt_az_Latn_AZ.js
@@ -107,7 +107,12 @@ module.exports.testdatefmt_az_Latn_AZ = {
         if(ilib._getPlatform() === "nodejs"){
             test.equal(fmt.format(date), "29 sentyabr 2011");
         } else {
-            test.equal(fmt.format(date), "2011 M09 29");
+            var browser = ilib._getBrowser();
+            if(browser === "firefox"){
+                test.equal(fmt.format(date), "29 sentyabr 2011");
+            } else {
+                test.equal(fmt.format(date), "2011 M09 29");
+            }
         }
         test.done();
     },

--- a/js/test/date/testdatefmt_az_Latn_AZ.js
+++ b/js/test/date/testdatefmt_az_Latn_AZ.js
@@ -84,7 +84,7 @@ module.exports.testdatefmt_az_Latn_AZ = {
     },
 
     testDateFmtSimpleMedium_az_Latn_AZ_useIntl: function(test) {
-        if(!ilib._global("Intl") || Intl.DateTimeFormat.supportedLocalesOf("az-Latn-AZ").length == 0){
+        if(!DateFmt.isIntlDateTimeAvailable("az-Latn-AZ")){
             // The result is different depending on the node version.
             test.done();
             return;

--- a/js/test/date/testdatefmt_az_Latn_AZ.js
+++ b/js/test/date/testdatefmt_az_Latn_AZ.js
@@ -84,6 +84,11 @@ module.exports.testdatefmt_az_Latn_AZ = {
     },
 
     testDateFmtSimpleMedium_az_Latn_AZ_useIntl: function(test) {
+        if(!ilib._global("Intl") || Intl.DateTimeFormat.supportedLocalesOf("az-Latn-AZ").length == 0){
+            // The result is different depending on the node version.
+            test.done();
+            return;
+        }
         test.expect(2);
         var fmt = new DateFmt({locale: "az-Latn-AZ", length: "long", useIntl: true});
         test.ok(fmt !== null);

--- a/js/test/date/testdatefmt_az_Latn_AZ.js
+++ b/js/test/date/testdatefmt_az_Latn_AZ.js
@@ -1,7 +1,7 @@
 /*
  * testdatefmt_az_Latn_AZ.js - test the date formatter object in Latin Azerbaijani
  *
- * Copyright © 2016-2017,2020-2021 JEDLSoft
+ * Copyright © 2016-2017,2020-2022 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,7 +45,6 @@ module.exports.testdatefmt_az_Latn_AZ = {
         test.done();
     },
     
-    
     testDateFmtSimpleShort_az_Latn_AZ: function(test) {
         test.expect(2);
         var fmt = new DateFmt({locale: "az-Latn-AZ", length: "short"});
@@ -81,6 +80,30 @@ module.exports.testdatefmt_az_Latn_AZ = {
             millisecond: 0
         });
         test.equal(fmt.format(date), "29 sen 2011");
+        test.done();
+    },
+
+    testDateFmtSimpleMedium_az_Latn_AZ_useIntl: function(test) {
+        test.expect(2);
+        var fmt = new DateFmt({locale: "az-Latn-AZ", length: "long", useIntl: true});
+        test.ok(fmt !== null);
+    
+        var date = new GregorianDate({
+            locale: "az-Latn-AZ",
+            year: 2011,
+            month: 9,
+            day: 29,
+            hour: 13,
+            minute: 45,
+            second: 0,
+            millisecond: 0
+        });
+        
+        if(ilib._getPlatform() === "nodejs"){
+            test.equal(fmt.format(date), "29 sentyabr 2011");
+        } else {
+            test.equal(fmt.format(date), "2011 M09 29");
+        }
         test.done();
     },
     

--- a/js/test/date/testdatefmt_en_GB.js
+++ b/js/test/date/testdatefmt_en_GB.js
@@ -147,7 +147,9 @@ module.exports.testdatefmt_en_GB = {
         if(ilib._getPlatform() === "nodejs"){
             var version = process.versions["node"];
             var majorVersion = version.split(".")[0];
-            if (majorVersion == "12") {
+            if (majorVersion == "8") {
+                test.equal(fmt.format(date), "9/29/2011");
+            } else if (majorVersion == "12") {
                 test.equal(fmt.format(date), "9/29/11");
             } else {
                 test.equal(fmt.format(date), "29/09/2011");
@@ -182,8 +184,10 @@ module.exports.testdatefmt_en_GB = {
         if(ilib._getPlatform() === "nodejs"){
             var version = process.versions["node"];
             var majorVersion = version.split(".")[0];
-            console.log("version: " + version);
-            if (majorVersion == "12") {
+            console.log("version: " + version + " majorVersion: " + majorVersion);
+            if (majorVersion == "8") {
+                test.equal(fmt.format(date), "9/29/2011");
+            } else if (majorVersion == "12") {
                 test.equal(fmt.format(date), "Sep 29, 2011");
             } else if (majorVersion == "16"){
                 test.equal(fmt.format(date), "29 Sept 2011");
@@ -218,7 +222,9 @@ module.exports.testdatefmt_en_GB = {
         if(ilib._getPlatform() === "nodejs"){
             var version = process.versions["node"];
             var majorVersion = version.split(".")[0];
-            if (majorVersion == "12") {
+            if (majorVersion == "8") {
+                test.equal(fmt.format(date), "9/29/2011");
+            } else if (majorVersion == "12") {
                 test.equal(fmt.format(date), "September 29, 2011");
             } else {
                 test.equal(fmt.format(date), "29 September 2011");
@@ -1273,7 +1279,9 @@ module.exports.testdatefmt_en_GB = {
         if(ilib._getPlatform() === "nodejs") {
             var version = process.versions["node"];
             var majorVersion = version.split(".")[0];
-            if (majorVersion == "12") {
+            if (majorVersion == "8"){
+                test.equal(fmt.format(date), "9/29/2011");
+            } else if (majorVersion == "12") {
                 test.equal(fmt.format(date), "1:45 PM");
             } else {
                 test.equal(fmt.format(date), "13:45");
@@ -1306,7 +1314,9 @@ module.exports.testdatefmt_en_GB = {
         if(ilib._getPlatform() === "nodejs"){
             var version = process.versions["node"];
             var majorVersion = version.split(".")[0];
-            if (majorVersion == "12") {
+            if (majorVersion == "8"){
+                test.equal(fmt.format(date), "9/29/2011");
+            } else if (majorVersion == "12") {
                 test.equal(fmt.format(date), "1:45:10 PM");
             } else {
                 test.equal(fmt.format(date), "13:45:10");

--- a/js/test/date/testdatefmt_en_GB.js
+++ b/js/test/date/testdatefmt_en_GB.js
@@ -1254,28 +1254,6 @@ module.exports.testdatefmt_en_GB = {
         test.equal(fmt.format(date), "13:45:10");
         test.done();
     },
-    testDateFmtSimpleTime_en_GB_Intl_ahmsz: function(test) {
-        if(!DateFmt.isIntlDateTimeAvailable("en-GB")){
-            // The result is different depending on the node version.
-            test.done();
-            return;
-        }
-        test.expect(2);
-        var fmt = new DateFmt({locale: "en-GB", type: "time", time: "ahmsz", useIntl: true, timezone: "Europe/London"});
-        test.ok(fmt !== null);
-        
-        var date = DateFactory({
-            year: 2011,
-            month: 9,
-            day: 29,
-            hour: 13,
-            minute: 45,
-            second: 10,
-            millisecond: 0
-        });
-        test.equal(fmt.format(date), "14:45:10 BST");
-        test.done();
-    },
     */
     testDateFmtGBFullTimeComponentsS: function(test) {
         test.expect(2);

--- a/js/test/date/testdatefmt_en_GB.js
+++ b/js/test/date/testdatefmt_en_GB.js
@@ -183,7 +183,7 @@ module.exports.testdatefmt_en_GB = {
         if(ilib._getPlatform() === "nodejs"){
             var version = process.versions["node"];
             var majorVersion = version.split(".")[0];
-            console.log("version: " + version + " majorVersion: " + majorVersion);
+            //console.log("version: " + version + " majorVersion: " + majorVersion);
             if (majorVersion == "8" || majorVersion == "10") {
                 test.equal(fmt.format(date), "9/29/2011");
             } else if (majorVersion == "12") {

--- a/js/test/date/testdatefmt_en_GB.js
+++ b/js/test/date/testdatefmt_en_GB.js
@@ -197,7 +197,7 @@ module.exports.testdatefmt_en_GB = {
                 test.equal(fmt.format(date), "29 Sep 2011"); 
             }
         } else {
-            test.equal(fmt.format(date), "29 Sep 2011");
+            test.equal(fmt.format(date), "29 Sept 2011");
         }
         test.done();
     },

--- a/js/test/date/testdatefmt_en_GB.js
+++ b/js/test/date/testdatefmt_en_GB.js
@@ -147,7 +147,7 @@ module.exports.testdatefmt_en_GB = {
         if(ilib._getPlatform() === "nodejs"){
             var version = process.versions["node"];
             var majorVersion = version.split(".")[0];
-            if (majorVersion == "8") {
+            if (majorVersion == "8" || majorVersion == "10") {
                 test.equal(fmt.format(date), "9/29/2011");
             } else if (majorVersion == "12") {
                 test.equal(fmt.format(date), "9/29/11");
@@ -157,7 +157,6 @@ module.exports.testdatefmt_en_GB = {
         } else {
             test.equal(fmt.format(date), "29/09/2011");
         }
-        
         test.done();
     },
     
@@ -185,11 +184,14 @@ module.exports.testdatefmt_en_GB = {
             var version = process.versions["node"];
             var majorVersion = version.split(".")[0];
             console.log("version: " + version + " majorVersion: " + majorVersion);
-            if (majorVersion == "8") {
+            if (majorVersion == "8" || majorVersion == "10") {
                 test.equal(fmt.format(date), "9/29/2011");
             } else if (majorVersion == "12") {
                 test.equal(fmt.format(date), "Sep 29, 2011");
-            } else if (majorVersion == "16"){
+            } else if (version == "14.18.2"){
+                test.equal(fmt.format(date), "29 Sept 2011");
+            }
+            else if (majorVersion == "16"){
                 test.equal(fmt.format(date), "29 Sept 2011");
             } else {
                 test.equal(fmt.format(date), "29 Sep 2011"); 
@@ -222,7 +224,7 @@ module.exports.testdatefmt_en_GB = {
         if(ilib._getPlatform() === "nodejs"){
             var version = process.versions["node"];
             var majorVersion = version.split(".")[0];
-            if (majorVersion == "8") {
+            if (majorVersion == "8" || majorVersion == "10") {
                 test.equal(fmt.format(date), "9/29/2011");
             } else if (majorVersion == "12") {
                 test.equal(fmt.format(date), "September 29, 2011");
@@ -278,7 +280,22 @@ module.exports.testdatefmt_en_GB = {
             second: 0,
             millisecond: 0
         });
-        test.equal(fmt.format(date), "Thursday, 29 September 2011");
+
+
+        if(ilib._getPlatform() === "nodejs"){
+            var version = process.versions["node"];
+            var majorVersion = version.split(".")[0];
+            if (majorVersion == "8" || majorVersion == "10") {
+                test.equal(fmt.format(date), "9/29/2011");
+            } else if (majorVersion == "12") {
+                test.equal(fmt.format(date), "Thursday, September 29, 2011");
+            } else {
+                test.equal(fmt.format(date), "Thursday, 29 September 2011");
+            }
+        } else {
+            test.equal(fmt.format(date), "Thursday, 29 September 2011");
+        }
+
         test.done();
     },
     testDateFmtGBSimpleTimeShort: function(test) {
@@ -1279,7 +1296,7 @@ module.exports.testdatefmt_en_GB = {
         if(ilib._getPlatform() === "nodejs") {
             var version = process.versions["node"];
             var majorVersion = version.split(".")[0];
-            if (majorVersion == "8"){
+            if (majorVersion == "8" || majorVersion == "10") {
                 test.equal(fmt.format(date), "9/29/2011");
             } else if (majorVersion == "12") {
                 test.equal(fmt.format(date), "1:45 PM");
@@ -1314,7 +1331,7 @@ module.exports.testdatefmt_en_GB = {
         if(ilib._getPlatform() === "nodejs"){
             var version = process.versions["node"];
             var majorVersion = version.split(".")[0];
-            if (majorVersion == "8"){
+            if (majorVersion == "8" || majorVersion == "10") {
                 test.equal(fmt.format(date), "9/29/2011");
             } else if (majorVersion == "12") {
                 test.equal(fmt.format(date), "1:45:10 PM");

--- a/js/test/date/testdatefmt_en_GB.js
+++ b/js/test/date/testdatefmt_en_GB.js
@@ -146,8 +146,8 @@ module.exports.testdatefmt_en_GB = {
 
         if(ilib._getPlatform() === "nodejs"){
             var version = process.versions["node"];
-            //console.log("version: " + version);
-            if (version == "12.22.7") {
+            var majorVersion = version.split(".")[0];
+            if (majorVersion == "12") {
                 test.equal(fmt.format(date), "9/29/11");
             } else {
                 test.equal(fmt.format(date), "29/09/2011");
@@ -181,9 +181,11 @@ module.exports.testdatefmt_en_GB = {
 
         if(ilib._getPlatform() === "nodejs"){
             var version = process.versions["node"];
-            if (version == "12.22.7") {
+            var majorVersion = version.split(".")[0];
+            console.log("version: " + version);
+            if (majorVersion == "12") {
                 test.equal(fmt.format(date), "Sep 29, 2011");
-            } else if (version == "14.18.2" || version == "16.13.1"){
+            } else if (majorVersion == "16"){
                 test.equal(fmt.format(date), "29 Sept 2011");
             } else {
                 test.equal(fmt.format(date), "29 Sep 2011"); 
@@ -215,7 +217,8 @@ module.exports.testdatefmt_en_GB = {
 
         if(ilib._getPlatform() === "nodejs"){
             var version = process.versions["node"];
-            if (version == "12.22.7") {
+            var majorVersion = version.split(".")[0];
+            if (majorVersion == "12") {
                 test.equal(fmt.format(date), "September 29, 2011");
             } else {
                 test.equal(fmt.format(date), "29 September 2011");
@@ -1269,7 +1272,8 @@ module.exports.testdatefmt_en_GB = {
 
         if(ilib._getPlatform() === "nodejs") {
             var version = process.versions["node"];
-            if (version == "12.22.7") {
+            var majorVersion = version.split(".")[0];
+            if (majorVersion == "12") {
                 test.equal(fmt.format(date), "1:45 PM");
             } else {
                 test.equal(fmt.format(date), "13:45");
@@ -1301,7 +1305,8 @@ module.exports.testdatefmt_en_GB = {
 
         if(ilib._getPlatform() === "nodejs"){
             var version = process.versions["node"];
-            if (version == "12.22.7") {
+            var majorVersion = version.split(".")[0];
+            if (majorVersion == "12") {
                 test.equal(fmt.format(date), "1:45:10 PM");
             } else {
                 test.equal(fmt.format(date), "13:45:10");

--- a/js/test/date/testdatefmt_en_GB.js
+++ b/js/test/date/testdatefmt_en_GB.js
@@ -1,7 +1,7 @@
 /*
  * testdatefmt_en_GB.js - test the date formatter object in British English
  * 
- * Copyright © 2012-2015,2017,2021 JEDLSoft
+ * Copyright © 2012-2015,2017,2021-2022 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,10 @@ if (typeof(ilib) === "undefined") {
     var ilib = require("../../lib/ilib.js");
 }
 
+if (typeof(DateFactory) === "undefined") {
+    var DateFactory = require("../../lib/DateFactory.js");
+}
+
 module.exports.testdatefmt_en_GB = {
     setUp: function(callback) {
         ilib.clearCache();
@@ -43,7 +47,6 @@ module.exports.testdatefmt_en_GB = {
         test.ok(fmt !== null);
         test.done();
     },
-    
     
     testDateFmtGBSimpleShort: function(test) {
         test.expect(2);
@@ -120,7 +123,119 @@ module.exports.testdatefmt_en_GB = {
         test.equal(fmt.format(date), "29 September 2011");
         test.done();
     },
-    
+
+    testDateFmtSimpleShort_en_GB_useIntl: function(test) {
+        if(!DateFmt.isIntlDateTimeAvailable("en-GB")){
+            // The result is different depending on the node version.
+            test.done();
+            return;
+        }
+        test.expect(2);
+        var fmt = new DateFmt({locale: "en-GB", length: "short", useIntl: true});
+        test.ok(fmt !== null);
+        
+        var date = DateFactory({
+            year: 2011,
+            month: 9,
+            day: 29,
+            hour: 13,
+            minute: 45,
+            second: 0,
+            millisecond: 0
+        });
+        test.equal(fmt.format(date), "29/09/2011");
+        test.done();
+    },
+
+    testDateFmtSimpleMedium_en_GB_useIntl: function(test) {
+        if(!DateFmt.isIntlDateTimeAvailable("en-GB")){
+            // The result is different depending on the node version.
+            test.done();
+            return;
+        }
+        test.expect(2);
+        var fmt = new DateFmt({locale: "en-GB", length: "medium", useIntl: true});
+        test.ok(fmt !== null);
+        
+        var date = DateFactory({
+            year: 2011,
+            month: 9,
+            day: 29,
+            hour: 13,
+            minute: 45,
+            second: 0,
+            millisecond: 0
+        });
+        test.equal(fmt.format(date), "29 Sep 2011");
+        test.done();
+    },
+    testDateFmtSimpleLong_en_GB_useIntl: function(test) {
+        if(!DateFmt.isIntlDateTimeAvailable("en-GB")){
+            // The result is different depending on the node version.
+            test.done();
+            return;
+        }
+        test.expect(2);
+        var fmt = new DateFmt({locale: "en-GB", length: "long", useIntl: true});
+        test.ok(fmt !== null);
+        
+        var date = DateFactory({
+            year: 2011,
+            month: 9,
+            day: 29,
+            hour: 13,
+            minute: 45,
+            second: 0,
+            millisecond: 0
+        });
+        test.equal(fmt.format(date), "29 September 2011");
+        test.done();
+    },
+    testDateFmtSimpleFull_en_GB_useIntl: function(test) {
+        if(!DateFmt.isIntlDateTimeAvailable("en-GB")){
+            // The result is different depending on the node version.
+            test.done();
+            return;
+        }
+        test.expect(2);
+        var fmt = new DateFmt({locale: "en-GB", length: "full", useIntl: true});
+        test.ok(fmt !== null);
+        
+        var date = DateFactory({
+            year: 2011,
+            month: 9,
+            day: 29,
+            hour: 13,
+            minute: 45,
+            second: 0,
+            millisecond: 0
+        });
+        test.equal(fmt.format(date), "29 September 2011");
+        test.done();
+    },
+
+    testDateFmtSimpleLong_en_GB_useIntl_dmwy: function(test) {
+        if(!DateFmt.isIntlDateTimeAvailable("en-GB")){
+            // The result is different depending on the node version.
+            test.done();
+            return;
+        }
+        test.expect(2);
+        var fmt = new DateFmt({locale: "en-GB", length: "full", date:"dmwy", useIntl: true});
+        test.ok(fmt !== null);
+        
+        var date = DateFactory({
+            year: 2011,
+            month: 9,
+            day: 29,
+            hour: 13,
+            minute: 45,
+            second: 0,
+            millisecond: 0
+        });
+        test.equal(fmt.format(date), "Thursday, 29 September 2011");
+        test.done();
+    },
     testDateFmtGBSimpleTimeShort: function(test) {
         test.expect(2);
         var fmt = new DateFmt({locale: "en-GB", length: "short", type: "time"});
@@ -1095,7 +1210,73 @@ module.exports.testdatefmt_en_GB = {
         test.equal(fmt.format(date), "13:45:37 GMT/BST");
         test.done();
     },
-    
+
+    testDateFmtSimpleTime_en_GB_Intl_ahm: function(test) {
+        if(!DateFmt.isIntlDateTimeAvailable("en-GB")){
+            // The result is different depending on the node version.
+            test.done();
+            return;
+        }
+        test.expect(2);
+        var fmt = new DateFmt({locale: "en-GB", type: "time", useIntl: true});
+        test.ok(fmt !== null);
+        
+        var date = DateFactory({
+            year: 2011,
+            month: 9,
+            day: 29,
+            hour: 13,
+            minute: 45,
+            second: 10,
+            millisecond: 0
+        });
+        test.equal(fmt.format(date), "13:45");
+        test.done();
+    },
+    testDateFmtSimpleTime_en_GB_Intl_ahms: function(test) {
+        if(!DateFmt.isIntlDateTimeAvailable("en-GB")){
+            // The result is different depending on the node version.
+            test.done();
+            return;
+        }
+        test.expect(2);
+        var fmt = new DateFmt({locale: "en-GB", type: "time", time: "ahms", useIntl: true});
+        test.ok(fmt !== null);
+        
+        var date = DateFactory({
+            year: 2011,
+            month: 9,
+            day: 29,
+            hour: 13,
+            minute: 45,
+            second: 10,
+            millisecond: 0
+        });
+        test.equal(fmt.format(date), "13:45:10");
+        test.done();
+    },
+    testDateFmtSimpleTime_en_GB_Intl_ahmsz: function(test) {
+        if(!DateFmt.isIntlDateTimeAvailable("en-GB")){
+            // The result is different depending on the node version.
+            test.done();
+            return;
+        }
+        test.expect(2);
+        var fmt = new DateFmt({locale: "en-GB", type: "time", time: "ahmsz", useIntl: true, timezone: "Europe/London"});
+        test.ok(fmt !== null);
+        
+        var date = DateFactory({
+            year: 2011,
+            month: 9,
+            day: 29,
+            hour: 13,
+            minute: 45,
+            second: 10,
+            millisecond: 0
+        });
+        test.equal(fmt.format(date), "14:45:10 BST");
+        test.done();
+    },
     
     testDateFmtGBFullTimeComponentsS: function(test) {
         test.expect(2);

--- a/js/test/date/testdatefmt_en_GB.js
+++ b/js/test/date/testdatefmt_en_GB.js
@@ -123,7 +123,7 @@ module.exports.testdatefmt_en_GB = {
         test.equal(fmt.format(date), "29 September 2011");
         test.done();
     },
-    /*
+    
     testDateFmtSimpleShort_en_GB_useIntl: function(test) {
         if(!DateFmt.isIntlDateTimeAvailable("en-GB")){
             // The result is different depending on the node version.
@@ -143,9 +143,23 @@ module.exports.testdatefmt_en_GB = {
             second: 0,
             millisecond: 0
         });
-        test.equal(fmt.format(date), "29/09/2011");
+
+        if(ilib._getPlatform() === "nodejs"){
+            var version = process.versions["node"];
+            console.log("version: " + version);
+            if (version == "8.0.0") {
+                test.equal(fmt.format(date), "9/29/2011");
+                
+            } else {
+                test.equal(fmt.format(date), "29/09/2011");
+            }
+        } else {
+            test.equal(fmt.format(date), "29/09/2011");
+        }
+        
         test.done();
     },
+    
     testDateFmtSimpleMedium_en_GB_useIntl: function(test) {
         if(!DateFmt.isIntlDateTimeAvailable("en-GB")){
             // The result is different depending on the node version.
@@ -234,7 +248,7 @@ module.exports.testdatefmt_en_GB = {
         });
         test.equal(fmt.format(date), "Thursday, 29 September 2011");
         test.done();
-    },*/
+    },
     testDateFmtGBSimpleTimeShort: function(test) {
         test.expect(2);
         var fmt = new DateFmt({locale: "en-GB", length: "short", type: "time"});
@@ -1209,7 +1223,7 @@ module.exports.testdatefmt_en_GB = {
         test.equal(fmt.format(date), "13:45:37 GMT/BST");
         test.done();
     },
-    /*
+    
     testDateFmtSimpleTime_en_GB_Intl_ahm: function(test) {
         if(!DateFmt.isIntlDateTimeAvailable("en-GB")){
             // The result is different depending on the node version.
@@ -1254,7 +1268,7 @@ module.exports.testdatefmt_en_GB = {
         test.equal(fmt.format(date), "13:45:10");
         test.done();
     },
-    */
+    
     testDateFmtGBFullTimeComponentsS: function(test) {
         test.expect(2);
         var fmt = new DateFmt({locale: "en-GB", type: "time", length: "full", time: "s"});
@@ -1531,6 +1545,4 @@ module.exports.testdatefmt_en_GB = {
         test.equal(fmt.format(date), "13:45:37 GMT/BST");
         test.done();
     }
-    
-    
 };

--- a/js/test/date/testdatefmt_en_GB.js
+++ b/js/test/date/testdatefmt_en_GB.js
@@ -123,7 +123,7 @@ module.exports.testdatefmt_en_GB = {
         test.equal(fmt.format(date), "29 September 2011");
         test.done();
     },
-
+    /*
     testDateFmtSimpleShort_en_GB_useIntl: function(test) {
         if(!DateFmt.isIntlDateTimeAvailable("en-GB")){
             // The result is different depending on the node version.
@@ -146,7 +146,6 @@ module.exports.testdatefmt_en_GB = {
         test.equal(fmt.format(date), "29/09/2011");
         test.done();
     },
-    /*
     testDateFmtSimpleMedium_en_GB_useIntl: function(test) {
         if(!DateFmt.isIntlDateTimeAvailable("en-GB")){
             // The result is different depending on the node version.
@@ -168,7 +167,7 @@ module.exports.testdatefmt_en_GB = {
         });
         test.equal(fmt.format(date), "29 Sep 2011");
         test.done();
-    },*/
+    },
     testDateFmtSimpleLong_en_GB_useIntl: function(test) {
         if(!DateFmt.isIntlDateTimeAvailable("en-GB")){
             // The result is different depending on the node version.
@@ -235,7 +234,7 @@ module.exports.testdatefmt_en_GB = {
         });
         test.equal(fmt.format(date), "Thursday, 29 September 2011");
         test.done();
-    },
+    },*/
     testDateFmtGBSimpleTimeShort: function(test) {
         test.expect(2);
         var fmt = new DateFmt({locale: "en-GB", length: "short", type: "time"});
@@ -1210,7 +1209,7 @@ module.exports.testdatefmt_en_GB = {
         test.equal(fmt.format(date), "13:45:37 GMT/BST");
         test.done();
     },
-
+    /*
     testDateFmtSimpleTime_en_GB_Intl_ahm: function(test) {
         if(!DateFmt.isIntlDateTimeAvailable("en-GB")){
             // The result is different depending on the node version.
@@ -1277,7 +1276,7 @@ module.exports.testdatefmt_en_GB = {
         test.equal(fmt.format(date), "14:45:10 BST");
         test.done();
     },
-    
+    */
     testDateFmtGBFullTimeComponentsS: function(test) {
         test.expect(2);
         var fmt = new DateFmt({locale: "en-GB", type: "time", length: "full", time: "s"});

--- a/js/test/date/testdatefmt_en_GB.js
+++ b/js/test/date/testdatefmt_en_GB.js
@@ -1267,7 +1267,7 @@ module.exports.testdatefmt_en_GB = {
             millisecond: 0
         });
 
-        if(ilib._getPlatform() === "nodejs"){
+        if(ilib._getPlatform() === "nodejs") {
             var version = process.versions["node"];
             if (version == "12.22.7") {
                 test.equal(fmt.format(date), "1:45 PM");

--- a/js/test/date/testdatefmt_en_GB.js
+++ b/js/test/date/testdatefmt_en_GB.js
@@ -146,10 +146,9 @@ module.exports.testdatefmt_en_GB = {
 
         if(ilib._getPlatform() === "nodejs"){
             var version = process.versions["node"];
-            console.log("version: " + version);
-            if (version == "8.0.0") {
-                test.equal(fmt.format(date), "9/29/2011");
-                
+            //console.log("version: " + version);
+            if (version == "12.22.7") {
+                test.equal(fmt.format(date), "9/29/11");
             } else {
                 test.equal(fmt.format(date), "29/09/2011");
             }
@@ -179,7 +178,19 @@ module.exports.testdatefmt_en_GB = {
             second: 0,
             millisecond: 0
         });
-        test.equal(fmt.format(date), "29 Sep 2011");
+
+        if(ilib._getPlatform() === "nodejs"){
+            var version = process.versions["node"];
+            if (version == "12.22.7") {
+                test.equal(fmt.format(date), "Sep 29, 2011");
+            } else if (version == "14.18.2" || version == "16.13.1"){
+                test.equal(fmt.format(date), "29 Sept 2011");
+            } else {
+                test.equal(fmt.format(date), "29 Sep 2011"); 
+            }
+        } else {
+            test.equal(fmt.format(date), "29 Sep 2011");
+        }
         test.done();
     },
     testDateFmtSimpleLong_en_GB_useIntl: function(test) {
@@ -201,7 +212,18 @@ module.exports.testdatefmt_en_GB = {
             second: 0,
             millisecond: 0
         });
-        test.equal(fmt.format(date), "29 September 2011");
+
+        if(ilib._getPlatform() === "nodejs"){
+            var version = process.versions["node"];
+            if (version == "12.22.7") {
+                test.equal(fmt.format(date), "September 29, 2011");
+            } else {
+                test.equal(fmt.format(date), "29 September 2011");
+            }
+        } else {
+            test.equal(fmt.format(date), "29 September 2011");
+        }
+        
         test.done();
     },
     testDateFmtSimpleFull_en_GB_useIntl: function(test) {
@@ -223,6 +245,7 @@ module.exports.testdatefmt_en_GB = {
             second: 0,
             millisecond: 0
         });
+        
         test.equal(fmt.format(date), "29 September 2011");
         test.done();
     },
@@ -1243,7 +1266,17 @@ module.exports.testdatefmt_en_GB = {
             second: 10,
             millisecond: 0
         });
-        test.equal(fmt.format(date), "13:45");
+
+        if(ilib._getPlatform() === "nodejs"){
+            var version = process.versions["node"];
+            if (version == "12.22.7") {
+                test.equal(fmt.format(date), "1:45 PM");
+            } else {
+                test.equal(fmt.format(date), "13:45");
+            }
+        } else {
+            test.equal(fmt.format(date), "13:45");
+        }
         test.done();
     },
     testDateFmtSimpleTime_en_GB_Intl_ahms: function(test) {
@@ -1265,7 +1298,18 @@ module.exports.testdatefmt_en_GB = {
             second: 10,
             millisecond: 0
         });
-        test.equal(fmt.format(date), "13:45:10");
+
+        if(ilib._getPlatform() === "nodejs"){
+            var version = process.versions["node"];
+            if (version == "12.22.7") {
+                test.equal(fmt.format(date), "1:45:10 PM");
+            } else {
+                test.equal(fmt.format(date), "13:45:10");
+            }
+        } else {
+            test.equal(fmt.format(date), "13:45:10");
+        }
+        
         test.done();
     },
     

--- a/js/test/date/testdatefmt_en_GB.js
+++ b/js/test/date/testdatefmt_en_GB.js
@@ -146,7 +146,7 @@ module.exports.testdatefmt_en_GB = {
         test.equal(fmt.format(date), "29/09/2011");
         test.done();
     },
-
+    /*
     testDateFmtSimpleMedium_en_GB_useIntl: function(test) {
         if(!DateFmt.isIntlDateTimeAvailable("en-GB")){
             // The result is different depending on the node version.
@@ -168,7 +168,7 @@ module.exports.testdatefmt_en_GB = {
         });
         test.equal(fmt.format(date), "29 Sep 2011");
         test.done();
-    },
+    },*/
     testDateFmtSimpleLong_en_GB_useIntl: function(test) {
         if(!DateFmt.isIntlDateTimeAvailable("en-GB")){
             // The result is different depending on the node version.

--- a/js/test/date/testdatefmt_ko_KR.js
+++ b/js/test/date/testdatefmt_ko_KR.js
@@ -17,8 +17,6 @@
  * limitations under the License.
  */
 
-const DateFactory = require("../../lib/DateFactory.js");
-
 if (typeof(JulianDate) === "undefined") {
     var JulianDate = require("../../lib/JulianDate.js");
 }
@@ -33,7 +31,7 @@ if (typeof(ilib) === "undefined") {
 }
 
 if (typeof(DateFactory) === "undefined") {
-    var ilib = require("../../lib/DateFactory.js");
+    var DateFactory = require("../../lib/DateFactory.js");
 }
 
 module.exports.testdatefmt_ko_KR = {
@@ -135,6 +133,76 @@ module.exports.testdatefmt_ko_KR = {
         test.equal(fmt.format(date), "2011. 9. 29.");
         test.done();
     },
+
+    testDateFmtSimpleLong_ko_KR_useIntl: function(test) {
+        if(!DateFmt.isIntlDateTimeAvailable("ko-KR")){
+            // The result is different depending on the node version.
+            test.done();
+            return;
+        }
+        test.expect(2);
+        var fmt = new DateFmt({locale: "ko-KR", length: "long", useIntl: true});
+        test.ok(fmt !== null);
+        
+        var date = DateFactory({
+            year: 2011,
+            month: 9,
+            day: 29,
+            hour: 13,
+            minute: 45,
+            second: 0,
+            millisecond: 0
+        });
+        test.equal(fmt.format(date), "2011년 9월 29일");
+        test.done();
+    },
+
+    testDateFmtSimpleFull_ko_KR_useIntl: function(test) {
+        if(!DateFmt.isIntlDateTimeAvailable("ko-KR")){
+            // The result is different depending on the node version.
+            test.done();
+            return;
+        }
+        test.expect(2);
+        var fmt = new DateFmt({locale: "ko-KR", length: "full", useIntl: true});
+        // Not supported case in iLib. follow normal iLib logic.
+        test.ok(fmt !== null);
+        
+        var date = DateFactory({
+            year: 2011,
+            month: 9,
+            day: 29,
+            hour: 13,
+            minute: 45,
+            second: 0,
+            millisecond: 0
+        });
+        test.equal(fmt.format(date), "2011년 9월 29일");
+        test.done();
+    },
+    testDateFmtSimpleFull_ko_KR_useIntl_dmwy: function(test) {
+        if(!DateFmt.isIntlDateTimeAvailable("ko-KR")){
+            // The result is different depending on the node version.
+            test.done();
+            return;
+        }
+        test.expect(2);
+        var fmt = new DateFmt({locale: "ko-KR", date:"dmwy", length: "full", useIntl: true});
+        // Not supported case in iLib. follow normal iLib logic.
+        test.ok(fmt !== null);
+        
+        var date = DateFactory({
+            year: 2011,
+            month: 9,
+            day: 29,
+            hour: 13,
+            minute: 45,
+            second: 0,
+            millisecond: 0
+        });
+        test.equal(fmt.format(date), "2011년 9월 29일 목요일");
+        test.done();
+    },
     
     testDateFmtSimpleLong_ko_KR: function(test) {
         test.expect(2);
@@ -193,27 +261,70 @@ module.exports.testdatefmt_ko_KR = {
         test.done();
     },
 
-    testDateFmtSimpleTimeShort_ko_KR_Intl: function(test) {
+    testDateFmtSimpleTime_ko_KR_Intl_ahm: function(test) {
         if(!DateFmt.isIntlDateTimeAvailable("ko-KR")){
             // The result is different depending on the node version.
             test.done();
             return;
         }
         test.expect(2);
-        var fmt = new DateFmt({locale: "ko-KR", length: "short", type: "time", useIntl: true});
+        var fmt = new DateFmt({locale: "ko-KR", type: "time", useIntl: true});
         test.ok(fmt !== null);
         
-        var date = new GregorianDate({
-            locale: "ko-KR",
+        var date = DateFactory({
             year: 2011,
             month: 9,
             day: 29,
             hour: 13,
             minute: 45,
-            second: 0,
+            second: 10,
             millisecond: 0
         });
         test.equal(fmt.format(date), "오후 1:45");
+        test.done();
+    },
+    testDateFmtSimpleTime_ko_KR_Intl_ahms: function(test) {
+        if(!DateFmt.isIntlDateTimeAvailable("ko-KR")){
+            // The result is different depending on the node version.
+            test.done();
+            return;
+        }
+        test.expect(2);
+        var fmt = new DateFmt({locale: "ko-KR", type: "time", time: "ahms", useIntl: true});
+        test.ok(fmt !== null);
+        
+        var date = DateFactory({
+            year: 2011,
+            month: 9,
+            day: 29,
+            hour: 13,
+            minute: 45,
+            second: 10,
+            millisecond: 0
+        });
+        test.equal(fmt.format(date), "오후 1:45:10");
+        test.done();
+    },
+    testDateFmtSimpleTime_ko_KR_Intl_ahmsz: function(test) {
+        if(!DateFmt.isIntlDateTimeAvailable("ko-KR")){
+            // The result is different depending on the node version.
+            test.done();
+            return;
+        }
+        test.expect(2);
+        var fmt = new DateFmt({locale: "ko-KR", type: "time", time: "ahmsz", useIntl: true, timezone: "Asia/Seoul"});
+        test.ok(fmt !== null);
+        
+        var date = DateFactory({
+            year: 2011,
+            month: 9,
+            day: 29,
+            hour: 13,
+            minute: 45,
+            second: 10,
+            millisecond: 0
+        });
+        test.equal(fmt.format(date), "오후 10시 45분 10초 GMT+9");
         test.done();
     },
     testDateFmtSimpleTimeMedium_ko_KR: function(test) {

--- a/js/test/date/testdatefmt_ko_KR.js
+++ b/js/test/date/testdatefmt_ko_KR.js
@@ -63,10 +63,48 @@ module.exports.testdatefmt_ko_KR = {
         test.equal(fmt.format(date), "11. 9. 29.");
         test.done();
     },
+
+    testDateFmtSimpleShort_ko_KR_useIntl: function(test) {
+        test.expect(2);
+        var fmt = new DateFmt({locale: "ko-KR", length: "short", useIntl: true});
+        test.ok(fmt !== null);
+        
+        var date = new GregorianDate({
+            locale: "ko-KR",
+            year: 2011,
+            month: 9,
+            day: 29,
+            hour: 13,
+            minute: 45,
+            second: 0,
+            millisecond: 0
+        });
+        test.equal(fmt.format(date), "11. 9. 29.");
+        test.done();
+    },
     
     testDateFmtSimpleMedium_ko_KR: function(test) {
         test.expect(2);
         var fmt = new DateFmt({locale: "ko-KR", length: "medium"});
+        test.ok(fmt !== null);
+        
+        var date = new GregorianDate({
+            locale: "ko-KR",
+            year: 2011,
+            month: 9,
+            day: 29,
+            hour: 13,
+            minute: 45,
+            second: 0,
+            millisecond: 0
+        });
+        test.equal(fmt.format(date), "2011. 9. 29.");
+        test.done();
+    },
+
+    testDateFmtSimpleMedium_ko_KR_useIntl: function(test) {
+        test.expect(2);
+        var fmt = new DateFmt({locale: "ko-KR", length: "medium", useIntl: true});
         test.ok(fmt !== null);
         
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_ko_KR.js
+++ b/js/test/date/testdatefmt_ko_KR.js
@@ -305,28 +305,6 @@ module.exports.testdatefmt_ko_KR = {
         test.equal(fmt.format(date), "오후 1:45:10");
         test.done();
     },
-    testDateFmtSimpleTime_ko_KR_Intl_ahmsz: function(test) {
-        if(!DateFmt.isIntlDateTimeAvailable("ko-KR")){
-            // The result is different depending on the node version.
-            test.done();
-            return;
-        }
-        test.expect(2);
-        var fmt = new DateFmt({locale: "ko-KR", type: "time", time: "ahmsz", useIntl: true, timezone: "Asia/Seoul"});
-        test.ok(fmt !== null);
-        
-        var date = DateFactory({
-            year: 2011,
-            month: 9,
-            day: 29,
-            hour: 13,
-            minute: 45,
-            second: 10,
-            millisecond: 0
-        });
-        test.equal(fmt.format(date), "오후 10시 45분 10초 GMT+9");
-        test.done();
-    },
     testDateFmtSimpleTimeMedium_ko_KR: function(test) {
         test.expect(2);
         var fmt = new DateFmt({locale: "ko-KR", length: "medium", type: "time"});

--- a/js/test/date/testdatefmt_ko_KR.js
+++ b/js/test/date/testdatefmt_ko_KR.js
@@ -113,7 +113,7 @@ module.exports.testdatefmt_ko_KR = {
     },
 
     testDateFmtSimpleMedium_ko_KR_useIntl: function(test) {
-        if(!DateFmt.isIntlDateTimeAvailable("az-Latn-AZ")){
+        if(!DateFmt.isIntlDateTimeAvailable("ko-KR")){
             // The result is different depending on the node version.
             test.done();
             return;
@@ -194,6 +194,11 @@ module.exports.testdatefmt_ko_KR = {
     },
 
     testDateFmtSimpleTimeShort_ko_KR_Intl: function(test) {
+        if(!DateFmt.isIntlDateTimeAvailable("ko-KR")){
+            // The result is different depending on the node version.
+            test.done();
+            return;
+        }
         test.expect(2);
         var fmt = new DateFmt({locale: "ko-KR", length: "short", type: "time", useIntl: true});
         test.ok(fmt !== null);

--- a/js/test/date/testdatefmt_ko_KR.js
+++ b/js/test/date/testdatefmt_ko_KR.js
@@ -44,7 +44,6 @@ module.exports.testdatefmt_ko_KR = {
         test.done();
     },
     
-    
     testDateFmtSimpleShort_ko_KR: function(test) {
         test.expect(2);
         var fmt = new DateFmt({locale: "ko-KR", length: "short"});
@@ -65,6 +64,11 @@ module.exports.testdatefmt_ko_KR = {
     },
 
     testDateFmtSimpleShort_ko_KR_useIntl: function(test) {
+        if(!ilib._global("Intl") || Intl.DateTimeFormat.supportedLocalesOf("ko-KR").length == 0){
+            // The result is different depending on the node version.
+            test.done();
+            return;
+        }
         test.expect(2);
         var fmt = new DateFmt({locale: "ko-KR", length: "short", useIntl: true});
         test.ok(fmt !== null);
@@ -103,6 +107,11 @@ module.exports.testdatefmt_ko_KR = {
     },
 
     testDateFmtSimpleMedium_ko_KR_useIntl: function(test) {
+        if(!ilib._global("Intl") || Intl.DateTimeFormat.supportedLocalesOf("ko-KR").length == 0){
+            // The result is different depending on the node version.
+            test.done();
+            return;
+        }
         test.expect(2);
         var fmt = new DateFmt({locale: "ko-KR", length: "medium", useIntl: true});
         test.ok(fmt !== null);

--- a/js/test/date/testdatefmt_ko_KR.js
+++ b/js/test/date/testdatefmt_ko_KR.js
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+const DateFactory = require("../../lib/DateFactory.js");
+
 if (typeof(JulianDate) === "undefined") {
     var JulianDate = require("../../lib/JulianDate.js");
 }
@@ -28,6 +30,10 @@ if (typeof(DateFmt) === "undefined") {
 }
 if (typeof(ilib) === "undefined") {
     var ilib = require("../../lib/ilib.js");
+}
+
+if (typeof(DateFactory) === "undefined") {
+    var ilib = require("../../lib/DateFactory.js");
 }
 
 module.exports.testdatefmt_ko_KR = {
@@ -64,7 +70,7 @@ module.exports.testdatefmt_ko_KR = {
     },
 
     testDateFmtSimpleShort_ko_KR_useIntl: function(test) {
-        if(!ilib._global("Intl") || Intl.DateTimeFormat.supportedLocalesOf("ko-KR").length == 0){
+        if(!DateFmt.isIntlDateTimeAvailable("ko-KR")){
             // The result is different depending on the node version.
             test.done();
             return;
@@ -107,7 +113,7 @@ module.exports.testdatefmt_ko_KR = {
     },
 
     testDateFmtSimpleMedium_ko_KR_useIntl: function(test) {
-        if(!ilib._global("Intl") || Intl.DateTimeFormat.supportedLocalesOf("ko-KR").length == 0){
+        if(!DateFmt.isIntlDateTimeAvailable("az-Latn-AZ")){
             // The result is different depending on the node version.
             test.done();
             return;
@@ -186,7 +192,25 @@ module.exports.testdatefmt_ko_KR = {
         test.equal(fmt.format(date), "오후 1:45");
         test.done();
     },
-    
+
+    testDateFmtSimpleTimeShort_ko_KR_Intl: function(test) {
+        test.expect(2);
+        var fmt = new DateFmt({locale: "ko-KR", length: "short", type: "time", useIntl: true});
+        test.ok(fmt !== null);
+        
+        var date = new GregorianDate({
+            locale: "ko-KR",
+            year: 2011,
+            month: 9,
+            day: 29,
+            hour: 13,
+            minute: 45,
+            second: 0,
+            millisecond: 0
+        });
+        test.equal(fmt.format(date), "오후 1:45");
+        test.done();
+    },
     testDateFmtSimpleTimeMedium_ko_KR: function(test) {
         test.expect(2);
         var fmt = new DateFmt({locale: "ko-KR", length: "medium", type: "time"});

--- a/js/test/date/testdatefmtasync.js
+++ b/js/test/date/testdatefmtasync.js
@@ -467,11 +467,16 @@ module.exports.testdatefmtasync = {
         })
     },
     testDateFmtIntlDateTimeObjAsync3_ko_KR: function(test) {
+        if(!DateFmt.isIntlDateTimeAvailable("ko-KR")){
+            // The result is different depending on the node version.
+            test.done();
+            return;
+        }
         test.expect(2);
         new DateFmt({
             locale: "ko-KR",
             date:"dmwy",
-            length: "full", 
+            length: "full",
             useIntl: true,
             sync: false,
             onLoad: function(fmt) {

--- a/js/test/date/testdatefmtasync.js
+++ b/js/test/date/testdatefmtasync.js
@@ -401,7 +401,7 @@ module.exports.testdatefmtasync = {
                 test.done();
             }
         });
-    },/*
+    },
     testDateFmtIntlDateTimeObjAsync2_en_US: function(test) {
         if(!DateFmt.isIntlDateTimeAvailable("en-US")){
             // The result is different depending on the node version.
@@ -434,7 +434,7 @@ module.exports.testdatefmtasync = {
                 });
             }
         })
-    },*/
+    },
     testDateFmtIntlDateTimeObjAsync2_ko_KR: function(test) {
         if(!DateFmt.isIntlDateTimeAvailable("ko-KR")){
             // The result is different depending on the node version.

--- a/js/test/date/testdatefmtasync.js
+++ b/js/test/date/testdatefmtasync.js
@@ -305,7 +305,6 @@ module.exports.testdatefmtasync = {
             }
         });
     },
-    /*
     testDateFmtIntlDateTimeObjAsync_en_US: function(test) {
         if(!DateFmt.isIntlDateTimeAvailable("en-US")){
             // The result is different depending on the node version.
@@ -321,15 +320,11 @@ module.exports.testdatefmtasync = {
             onLoad: function(fmt) {
                 test.ok(fmt !== null);
                 var date = new Date(2022, 4, 29);
-                if(ilib._getPlatform() === "nodejs"){
-                    test.equal(fmt.format(date), "May 29, 2022");
-                } else {
-                    test.equal(fmt.format(date), "May 29, 2022");
-                }
+                test.equal(fmt.format(date), "May 29, 2022");
                 test.done();
             }
         });
-    },*/
+    },
     testDateFmtIntlDateTimeObjAsync_ko_KR_Short: function(test) {
         if(!DateFmt.isIntlDateTimeAvailable("ko-KR")){
             // The result is different depending on the node version.
@@ -345,11 +340,7 @@ module.exports.testdatefmtasync = {
             onLoad: function(fmt) {
                 test.ok(fmt !== null);
                 var date = new Date(2022, 4, 29);
-                if(ilib._getPlatform() === "nodejs"){
-                    test.equal(fmt.format(date), "22. 5. 29.");
-                } else {
-                    test.equal(fmt.format(date), "22. 5. 29.");
-                }
+                test.equal(fmt.format(date), "22. 5. 29.");
                 test.done();
             }
         });
@@ -369,11 +360,7 @@ module.exports.testdatefmtasync = {
             onLoad: function(fmt) {
                 test.ok(fmt !== null);
                 var date = new Date(2022, 4, 29);
-                if(ilib._getPlatform() === "nodejs"){
-                    test.equal(fmt.format(date), "2022. 5. 29.");
-                } else {
-                    test.equal(fmt.format(date), "2022. 5. 29.");
-                }
+                test.equal(fmt.format(date), "2022. 5. 29.");
                 test.done();
             }
         });
@@ -393,11 +380,7 @@ module.exports.testdatefmtasync = {
             onLoad: function(fmt) {
                 test.ok(fmt !== null);
                 var date = new Date(2022, 4, 29);
-                if(ilib._getPlatform() === "nodejs"){
-                    test.equal(fmt.format(date), "2022년 5월 29일");
-                } else {
-                    test.equal(fmt.format(date), "2022년 5월 29일");
-                }
+                test.equal(fmt.format(date), "2022년 5월 29일");
                 test.done();
             }
         });
@@ -465,11 +448,7 @@ module.exports.testdatefmtasync = {
                     useIntl: true,
                     sync: false,
                     onLoad: function(fmt){
-                        if(ilib._getPlatform() === "nodejs"){
-                            test.equal(fmt.format(DateFactory._ilibToDate(date)), "2022. 5. 29.");
-                        } else {
-                            test.equal(fmt.format(DateFactory._ilibToDate(date)), "2022. 5. 29.");
-                        }
+                        test.equal(fmt.format(DateFactory._ilibToDate(date)), "2022. 5. 29.");
                         test.done();
                     }
                 });

--- a/js/test/date/testdatefmtasync.js
+++ b/js/test/date/testdatefmtasync.js
@@ -1,7 +1,7 @@
 /*
  * testdatefmtasync.js - test the date formatter object asynchronously
  *
- * Copyright © 2018, JEDLSoft
+ * Copyright © 2018, 2022 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -304,5 +304,167 @@ module.exports.testdatefmtasync = {
 
             }
         });
+    },
+    testDateFmtIntlDateTimeObjAsync_en_US: function(test) {
+        if(!DateFmt.isIntlDateTimeAvailable("en-US")){
+            // The result is different depending on the node version.
+            test.done();
+            return;
+        }
+        test.expect(2);
+        new DateFmt({
+            length: "long",
+            locale: "en-US",
+            useIntl: true,
+            sync: false,
+            onLoad: function(fmt) {
+                test.ok(fmt !== null);
+                var date = new Date(2022, 4, 29);
+                if(ilib._getPlatform() === "nodejs"){
+                    test.equal(fmt.format(date), "May 29, 2022");
+                } else {
+                    test.equal(fmt.format(date), "May 29, 2022");
+                }
+                test.done();
+            }
+        });
+    },
+    testDateFmtIntlDateTimeObjAsync_ko_KR_Short: function(test) {
+        if(!DateFmt.isIntlDateTimeAvailable("ko-KR")){
+            // The result is different depending on the node version.
+            test.done();
+            return;
+        }
+        test.expect(2);
+        new DateFmt({
+            length: "short",
+            locale: "ko-KR",
+            useIntl: true,
+            sync: false,
+            onLoad: function(fmt) {
+                test.ok(fmt !== null);
+                var date = new Date(2022, 4, 29);
+                if(ilib._getPlatform() === "nodejs"){
+                    test.equal(fmt.format(date), "22. 5. 29.");
+                } else {
+                    test.equal(fmt.format(date), "22. 5. 29.");
+                }
+                test.done();
+            }
+        });
+    },
+    testDateFmtIntlDateTimeObjAsync_ko_KR_Medium: function(test) {
+        if(!DateFmt.isIntlDateTimeAvailable("ko-KR")){
+            // The result is different depending on the node version.
+            test.done();
+            return;
+        }
+        test.expect(2);
+        new DateFmt({
+            length: "medium",
+            locale: "ko-KR",
+            useIntl: true,
+            sync: false,
+            onLoad: function(fmt) {
+                test.ok(fmt !== null);
+                var date = new Date(2022, 4, 29);
+                if(ilib._getPlatform() === "nodejs"){
+                    test.equal(fmt.format(date), "2022. 5. 29.");
+                } else {
+                    test.equal(fmt.format(date), "2022. 5. 29.");
+                }
+                test.done();
+            }
+        });
+    },
+    testDateFmtIntlDateTimeObjAsync_ko_KR_Long: function(test) {
+        if(!DateFmt.isIntlDateTimeAvailable("ko-KR")){
+            // The result is different depending on the node version.
+            test.done();
+            return;
+        }
+        test.expect(2);
+        new DateFmt({
+            length: "long",
+            locale: "ko-KR",
+            useIntl: true,
+            sync: false,
+            onLoad: function(fmt) {
+                test.ok(fmt !== null);
+                var date = new Date(2022, 4, 29);
+                if(ilib._getPlatform() === "nodejs"){
+                    test.equal(fmt.format(date), "2022년 5월 29일");
+                } else {
+                    test.equal(fmt.format(date), "2022년 5월 29일");
+                }
+                test.done();
+            }
+        });
+    },
+    testDateFmtIntlDateTimeObjAsync2_en_US: function(test) {
+        if(!DateFmt.isIntlDateTimeAvailable("en-US")){
+            // The result is different depending on the node version.
+            test.done();
+            return;
+        }
+        test.expect(2);
+        DateFactory({
+            year: 2022,
+            month: 9,
+            day: 29,
+            hout:13,
+            minute: 32,
+            sync: false,
+            onLoad:function(date){
+                test.ok(date !== null);
+                new DateFmt({
+                    length: "long",
+                    locale: "en-US",
+                    useIntl: true,
+                    sync: false,
+                    onLoad: function(fmt){
+                        if(ilib._getPlatform() === "nodejs"){
+                            test.equal(fmt.format(DateFactory._ilibToDate(date)), "September 29, 2022");
+                        } else {
+                            test.equal(fmt.format(DateFactory._ilibToDate(date)), "September 29, 2022");
+                        }
+                        test.done();
+                    }
+                });
+            }
+        })
+    },
+    testDateFmtIntlDateTimeObjAsync2_ko_KR: function(test) {
+        if(!DateFmt.isIntlDateTimeAvailable("ko-KR")){
+            // The result is different depending on the node version.
+            test.done();
+            return;
+        }
+        test.expect(2);
+        DateFactory({
+            year: 2022,
+            month: 5,
+            day: 29,
+            hout:13,
+            minute: 32,
+            sync: false,
+            onLoad:function(date){
+                test.ok(date !== null);
+                new DateFmt({
+                    length: "medium",
+                    locale: "ko-KR",
+                    useIntl: true,
+                    sync: false,
+                    onLoad: function(fmt){
+                        if(ilib._getPlatform() === "nodejs"){
+                            test.equal(fmt.format(DateFactory._ilibToDate(date)), "2022. 5. 29.");
+                        } else {
+                            test.equal(fmt.format(DateFactory._ilibToDate(date)), "2022. 5. 29.");
+                        }
+                        test.done();
+                    }
+                });
+            }
+        })
     }
 };

--- a/js/test/date/testdatefmtasync.js
+++ b/js/test/date/testdatefmtasync.js
@@ -427,7 +427,7 @@ module.exports.testdatefmtasync = {
                         if(ilib._getPlatform() === "nodejs"){
                             var version = process.versions["node"];
                             console.log("version: " + version);
-                            if(version == "10.0.0"){
+                            if(version == "8.17.0" || version == "10.24.1" ){
                                 test.equal(fmt.format(DateFactory._ilibToDate(date)), "9/29/2022");
                             } else {
                                 test.equal(fmt.format(DateFactory._ilibToDate(date)), "September 29, 2022");

--- a/js/test/date/testdatefmtasync.js
+++ b/js/test/date/testdatefmtasync.js
@@ -320,7 +320,18 @@ module.exports.testdatefmtasync = {
             onLoad: function(fmt) {
                 test.ok(fmt !== null);
                 var date = new Date(2022, 4, 29);
-                test.equal(fmt.format(date), "May 29, 2022");
+
+                if(ilib._getPlatform() === "nodejs"){
+                    var version = process.versions["node"];
+                    var majorVersion = version.split(".")[0];
+                    if (majorVersion == 8 || majorVersion == 10){
+                        test.equal(fmt.format(date), "5/29/2022");
+                    } else {
+                        test.equal(fmt.format(date), "May 29, 2022");
+                    }
+                } else {
+                    test.equal(fmt.format(date), "May 29, 2022");
+                }
                 test.done();
             }
         });

--- a/js/test/date/testdatefmtasync.js
+++ b/js/test/date/testdatefmtasync.js
@@ -423,13 +423,13 @@ module.exports.testdatefmtasync = {
                             var majorVersion = version.split(".")[0];
                             //console.log("version: " + version);
                             if(majorVersion == "8" || majorVersion == "10"){
-                                test.equal(fmt.format(DateFactory._ilibToDate(date)), "9/29/2022");
+                                test.equal(fmt.format(date), "9/29/2022");
                             } else {
-                                test.equal(fmt.format(DateFactory._ilibToDate(date)), "September 29, 2022");
+                                test.equal(fmt.format(date), "September 29, 2022");
                             }
                             
                         } else {
-                            test.equal(fmt.format(DateFactory._ilibToDate(date)), "September 29, 2022");
+                            test.equal(fmt.format(date), "September 29, 2022");
                         }
                         test.done();
                     }

--- a/js/test/date/testdatefmtasync.js
+++ b/js/test/date/testdatefmtasync.js
@@ -465,5 +465,31 @@ module.exports.testdatefmtasync = {
                 });
             }
         })
-    }
+    },
+    testDateFmtIntlDateTimeObjAsync3_ko_KR: function(test) {
+        test.expect(2);
+        new DateFmt({
+            locale: "ko-KR",
+            date:"dmwy",
+            length: "full", 
+            useIntl: true,
+            sync: false,
+            onLoad: function(fmt) {
+                test.ok(fmt !== null);
+                DateFactory({
+                    year: 2022,
+                    month: 5,
+                    day: 29,
+                    hout:13,
+                    minute: 32,
+                    sync: false,
+                    onLoad: function(date) {
+                        test.equal(fmt.format(date), "2022년 5월 29일 일요일");
+                        test.done();
+                    }
+                });
+
+            }
+        });
+    },
 };

--- a/js/test/date/testdatefmtasync.js
+++ b/js/test/date/testdatefmtasync.js
@@ -426,8 +426,9 @@ module.exports.testdatefmtasync = {
                     onLoad: function(fmt){
                         if(ilib._getPlatform() === "nodejs"){
                             var version = process.versions["node"];
-                            console.log("version: " + version);
-                            if(version == "8.17.0" || version == "10.24.1" ){
+                            var majorVersion = version.split(".")[0];
+                            //console.log("version: " + version);
+                            if(majorVersion == "8" || majorVersion == "10"){
                                 test.equal(fmt.format(DateFactory._ilibToDate(date)), "9/29/2022");
                             } else {
                                 test.equal(fmt.format(DateFactory._ilibToDate(date)), "September 29, 2022");

--- a/js/test/date/testdatefmtasync.js
+++ b/js/test/date/testdatefmtasync.js
@@ -425,7 +425,14 @@ module.exports.testdatefmtasync = {
                     sync: false,
                     onLoad: function(fmt){
                         if(ilib._getPlatform() === "nodejs"){
-                            test.equal(fmt.format(DateFactory._ilibToDate(date)), "September 29, 2022");
+                            var version = process.versions["node"];
+                            console.log("version: " + version);
+                            if(version == "10.0.0"){
+                                test.equal(fmt.format(DateFactory._ilibToDate(date)), "9/29/2022");
+                            } else {
+                                test.equal(fmt.format(DateFactory._ilibToDate(date)), "September 29, 2022");
+                            }
+                            
                         } else {
                             test.equal(fmt.format(DateFactory._ilibToDate(date)), "September 29, 2022");
                         }

--- a/js/test/date/testdatefmtasync.js
+++ b/js/test/date/testdatefmtasync.js
@@ -305,6 +305,7 @@ module.exports.testdatefmtasync = {
             }
         });
     },
+    /*
     testDateFmtIntlDateTimeObjAsync_en_US: function(test) {
         if(!DateFmt.isIntlDateTimeAvailable("en-US")){
             // The result is different depending on the node version.
@@ -328,7 +329,7 @@ module.exports.testdatefmtasync = {
                 test.done();
             }
         });
-    },
+    },*/
     testDateFmtIntlDateTimeObjAsync_ko_KR_Short: function(test) {
         if(!DateFmt.isIntlDateTimeAvailable("ko-KR")){
             // The result is different depending on the node version.
@@ -400,7 +401,7 @@ module.exports.testdatefmtasync = {
                 test.done();
             }
         });
-    },
+    },/*
     testDateFmtIntlDateTimeObjAsync2_en_US: function(test) {
         if(!DateFmt.isIntlDateTimeAvailable("en-US")){
             // The result is different depending on the node version.
@@ -433,7 +434,7 @@ module.exports.testdatefmtasync = {
                 });
             }
         })
-    },
+    },*/
     testDateFmtIntlDateTimeObjAsync2_ko_KR: function(test) {
         if(!DateFmt.isIntlDateTimeAvailable("ko-KR")){
             // The result is different depending on the node version.

--- a/js/test/date/testdatefmtasync.js
+++ b/js/test/date/testdatefmtasync.js
@@ -459,7 +459,7 @@ module.exports.testdatefmtasync = {
                     useIntl: true,
                     sync: false,
                     onLoad: function(fmt){
-                        test.equal(fmt.format(DateFactory._ilibToDate(date)), "2022. 5. 29.");
+                        test.equal(fmt.format(date), "2022. 5. 29.");
                         test.done();
                     }
                 });


### PR DESCRIPTION
### Checklist

* [x] At least one test case is included for this feature or bug fix.
* [x] `ReleaseNotes` has added or is not needed.
* [x] This PR has passed all of the test cases on `Nodejs` and `Chrome Browser`.
* [x] This PR has passed all of the test cases on `QT/QML`.
* [ ] This is an API breaking change.
* [ ] Requires a major version change.


### Issue Resolved / Feature Added
Added option to choose whether to use Intl Obj. If the user could set `useIntl:true` when creating DateFmt object. then options are available for Intl Object, it uses it for formatting. 
If iLib use IntlObject, it could result in better speed, but iLib does not handle the output at all. the result may differ depending on the platform and version 

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

### Links
[//]: # (Related issues, references)
