### PR TITLE
Fix to have Latin as default script for uz

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -13,10 +13,10 @@ New Features:
     * When they cannot be converted, the Intl object is not available, or the Intl object does not support the requested locale, it will perform the relatively slow formatting using regular ilib code written in Javascript.
     *  The code will often return different results depending on the platform and version of the Javascript engine and which version of CLDR it supports. If you need consistency across versions and platforms, do not use the useIntl flag. Just stick with the regular ilib formatting code.
 
-
 Bug Fixes:
 * Fixed a bug where the DateFmt.formatRelative() does not represent correct result in certain case.
 * Updated locale data to have a consistently sorted order by rerunning cldr tool code.
+* Fixed a bug which a default script for `uz` should be `Latin` instead of `Arabic`
 
 
 Build 022

--- a/js/data/locale/uz/scripts.jf
+++ b/js/data/locale/uz/scripts.jf
@@ -1,8 +1,8 @@
 {
     "generated": true,
     "scripts": [
-        "Arab",
+        "Latn",
         "Cyrl",
-        "Latn"
+        "Arab"
     ]
 }

--- a/js/test/root/testlocaleinfo.js
+++ b/js/test/root/testlocaleinfo.js
@@ -12674,7 +12674,7 @@ module.exports.testlocaleinfo = {
         test.expect(2);
         var li = new LocaleInfo("uz-UZ");
         test.ok(typeof(li) !== "undefined");
-        test.equal(li.getDefaultScript(), "Arab");
+        test.equal(li.getDefaultScript(), "Latn");
         test.done();
     },
     
@@ -12690,7 +12690,7 @@ module.exports.testlocaleinfo = {
         test.expect(2);
         var li = new LocaleInfo("uz-UZ");
         test.ok(typeof(li) !== "undefined");
-        test.equal(li.getScript(), "Arab");
+        test.equal(li.getScript(), "Latn");
         test.done();
     },
     

--- a/tools/cldr/genlangscripts.js
+++ b/tools/cldr/genlangscripts.js
@@ -108,7 +108,7 @@ for (var language in scripts) {
             fs.mkdirSync(filename);
         }
         // special cases where we disagree with CLDR
-        if (language === 'az' || language === 'ms' || language === 'kk' || language === 'pa'|| language === 'tk'|| language === 'ha') {
+        if (language === 'az' || language === 'ms' || language === 'kk' || language === 'pa'|| language === 'tk'|| language === 'ha' || language === 'uz') {
             scripts[language] = scripts[language].reverse();
         } else if (language == 'ky'|| language == 'tg') {
             var lang = scripts[language];


### PR DESCRIPTION
### Checklist

* [x] At least one test case is included for this feature or bug fix.
* [x] `ReleaseNotes` has added or is not needed.
* [x] This PR has passed all of the test cases on `Nodejs` and `Chrome Browser`.
* [ ] This PR has passed all of the test cases on `QT/QML`.
* [ ] This is an API breaking change.
* [ ] Requires a major version change.


### Issue Resolved / Feature Added
Fix to have Latin as default script for `uz`
I've checked `cldr-core/likelySubtags.json` and it is mapped as below.
```
"und-UZ": "uz-Latn-UZ",
"uz": "uz-Latn-UZ",
```
### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

### Links
[//]: # (Related issues, references)
