### PR TITLE
Add ko-US locale to localematch.json

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -18,6 +18,7 @@ Bug Fixes:
 * Fixed a bug where the DateFmt.formatRelative() does not represent correct result in certain case.
 * Updated locale data to have a consistently sorted order by rerunning cldr tool code.
 * Fixed a bug which a default script for `uz` should be `Latin` instead of `Arabic`
+* Updated hardcoded locales for localematch (bn-IN, en-KR, hr-HU, ka-IR, ko-US, ku-IQ, ps-PK, pt-MO)
 
 
 Build 022

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -18,7 +18,7 @@ Bug Fixes:
 * Fixed a bug where the DateFmt.formatRelative() does not represent correct result in certain case.
 * Updated locale data to have a consistently sorted order by rerunning cldr tool code.
 * Fixed a bug which a default script for `uz` should be `Latin` instead of `Arabic`
-* Updated hardcoded locales for localematch (bn-IN, en-KR, hr-HU, ka-IR, ko-US, ku-IQ, ps-PK, pt-MO)
+* Updated hardcoded locales for LocaleMatcher (bn-IN, en-KR, hr-HU, ka-IR, ko-US, ku-IQ, ps-PK, pt-MO)
 
 
 Build 022

--- a/js/data/locale/localematch.json
+++ b/js/data/locale/localematch.json
@@ -2831,6 +2831,7 @@
         "ko-KP": "ko-Kore-KP",
         "ko-KR": "ko-Kore-KR",
         "ko-Kore": "ko-Kore-KR",
+        "ko-US": "ko-Kore-US",
         "koi": "koi-Cyrl-RU",
         "koi-Cyrl": "koi-Cyrl-RU",
         "koi-RU": "koi-Cyrl-RU",

--- a/js/test/root/testlocalematch.js
+++ b/js/test/root/testlocalematch.js
@@ -1611,6 +1611,17 @@ module.exports.testlocalematch = {
         test.equal(locale.getSpec(), "yo-Latn-BJ");
         test.done();
     },
+    testLocaleMatcherGetLikelyLocaleByLocaleCode_ko_US: function(test) {
+        test.expect(3);
+        var lm = new LocaleMatcher({
+            locale: "ko-US"
+        });
+        test.ok(typeof(lm) !== "undefined");
+        var locale = lm.getLikelyLocale();
+        test.ok(typeof(locale) !== "undefined");
+        test.equal(locale.getSpec(), "ko-Kore-US");
+        test.done();
+    },
     testLocaleMatcherMatchExactFullLocale: function(test) {
         test.expect(2);
         var lm = new LocaleMatcher({

--- a/tools/cldr/genlikelyloc.js
+++ b/tools/cldr/genlikelyloc.js
@@ -67,14 +67,15 @@ var localematch = {};
 
 // cldr is missing these
 var hardCodedSubtags = {
-    "yo-BJ": "yo-Latn-BJ",
     "bn-IN": "bn-Beng-IN",
     "en-KR": "en-Latn-KR",
     "hr-HU": "hr-Latn-HU",
     "ka-IR": "ka-Geor-IR",
+    "ko-US": "ko-Kore-US",
     "ku-IQ": "ku-Arab-IQ",
     "ps-PK": "ps-Arab-PK",
-    "pt-MO": "pt-Latn-MO"
+    "pt-MO": "pt-Latn-MO",
+    "yo-BJ": "yo-Latn-BJ"
 };
 
 // Likely Locales


### PR DESCRIPTION
### Checklist

* [ ] At least one test case is included for this feature or bug fix.
* [x] `ReleaseNotes` has added or is not needed.
* [x] This PR has passed all of the test cases on `Nodejs` and `Chrome Browser`.
* [ ] This PR has passed all of the test cases on `QT/QML`.
* [ ] This is an API breaking change.
* [ ] Requires a major version change.


### Issue Resolved / Feature Added
Add `ko-US` locale to localematch.json that is currently returning `ko-Kore-KR` instead of `ko-Kore-US`
It is related https://github.com/iLib-js/ilib-loctool-samples/pull/19 case

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

### Links
[//]: # (Related issues, references)
