### PR TITLE
Fixed a bug where the Currency didn't work asynchronously

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -21,6 +21,8 @@ Bug Fixes:
 * Updated hardcoded locales for LocaleMatcher. (bn-IN, en-KR, hr-HU, ka-IR, ko-US, ku-IQ, ps-PK, pt-MO)
 * Fixed to generate `plurals.json` files even when the rule only has `other`.
 * Updated to load `plurals.json` in ResBundle Constructor, then you could call synchronously all the time because we can be sure if is already loaded.
+* Fixed a bug where the Currency was loaded always synchronously.
+
 
 Build 022
 -------

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -21,7 +21,7 @@ Bug Fixes:
 * Updated hardcoded locales for LocaleMatcher. (bn-IN, en-KR, hr-HU, ka-IR, ko-US, ku-IQ, ps-PK, pt-MO)
 * Fixed to generate `plurals.json` files even when the rule only has `other`.
 * Updated to load `plurals.json` in ResBundle Constructor, then you could call synchronously all the time because we can be sure if is already loaded.
-* Fixed a bug where the Currency was loaded always synchronously.
+* Fixed a bug where the Currency didn't work asynchronously.
 
 
 Build 022

--- a/js/lib/Currency.js
+++ b/js/lib/Currency.js
@@ -1,7 +1,7 @@
 /*
  * Currency.js - Currency definition
  *
- * Copyright © 2012-2015, 2018, JEDLSoft
+ * Copyright © 2012-2015, 2018, 2022 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -105,12 +105,9 @@ var Currency = function (options) {
         if (options.loadParams) {
             this.loadParams = options.loadParams;
         }
+        options.sync = (typeof(options.sync) !== 'undefined') ? options.sync : true;
     } else {
         options = {sync: true};
-    }
-
-    if (typeof(options.sync) === 'undefined') {
-        options.sync = true;
     }
 
     this.locale = this.locale || new Locale();
@@ -119,7 +116,7 @@ var Currency = function (options) {
             name: "currency.json",
             object: "Currency",
             locale: "-",
-            sync: this.sync,
+            sync: options.sync,
             loadParams: this.loadParams,
             callback: ilib.bind(this, function(currency) {
                 ilib.data.currency = currency;


### PR DESCRIPTION
### Checklist

* [ ] At least one test case is included for this feature or bug fix.
* [x] `ReleaseNotes` has added or is not needed.
* [ ] This PR has passed all of the test cases on `Nodejs` and `Chrome Browser`.
* [ ] This PR has passed all of the test cases on `QT/QML`.
* [ ] This is an API breaking change.
* [ ] Requires a major version change.


### Issue Resolved / Feature Added
There is no code to set the sync option value when the value is transferred through parameters
It has been only working synchronously.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

### Links
[//]: # (Related issues, references)
