### PR TITLE
Fixed to handle a path correctly in ilib-web.js

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -23,6 +23,7 @@ Bug Fixes:
 * Updated to load `plurals.json` in ResBundle Constructor, then you could call synchronously all the time because we can be sure if is already loaded.
 * Fixed a bug where the Currency didn't work asynchronously.
 * Update to time zone data 2022c
+* Fixed to handle both absolute and relative paths correctly in `ilib-web.js`.
 
 Build 022
 -------

--- a/js/lib/ilib-web.js
+++ b/js/lib/ilib-web.js
@@ -59,9 +59,9 @@ var requireClass = function() {
     for (var i = 0; i < scripts.length; i++) {
         var source = scripts[i].src;
         if (source && (pos = source.search(/ilib-web\.js$/)) !== -1) {
-            var colon = source.indexOf('://');
-            this.protocol = source.substring(0,colon+3);
-            this.root = source.substring(colon+3, pos-1);
+            var url = new URL(source);
+            this.protocol = url.protocol + "//";
+            this.root = url.pathname;
             break;
         }
     }

--- a/js/lib/ilib-web.js
+++ b/js/lib/ilib-web.js
@@ -58,11 +58,23 @@ var requireClass = function() {
 
     for (var i = 0; i < scripts.length; i++) {
         var source = scripts[i].src;
-        if (source && (pos = source.search(/ilib-web\.js$/)) !== -1) {
-            var url = new URL(source);
-            this.protocol = url.protocol + "//";
-            this.root = url.pathname;
+
+        if (navigator && navigator.userAgent && (navigator.userAgent.indexOf(" .NET") > -1) ){
+            // IE brower
+            var colon = source.indexOf('://');
+            this.protocol = source.substring(0, colon+3);
+            this.root = source.substring(colon+3, pos-1);
+            if (this.root.indexOf("/") !== 0) {
+                this.root = "/" + this.root;
+            }
             break;
+        } else {
+            if (source && (pos = source.search(/ilib-web\.js$/)) !== -1) {
+                var url = new URL(source);
+                this.protocol = url.protocol + "//";
+                this.root = url.pathname;
+                break;
+            }
         }
     }
 };


### PR DESCRIPTION
### Checklist

* [ ] At least one test case is included for this feature or bug fix.
* [x] `ReleaseNotes` has added or is not needed.
* [ ] This PR has passed all of the test cases on `Nodejs` and `Chrome Browser`.
* [ ] This PR has passed all of the test cases on `QT/QML`.
* [ ] This is an API breaking change.
* [ ] Requires a major version change.


### Issue Resolved / Feature Added
Fixed to handle both absolute and relative paths properly in `ilib-web.js`
(`ilib-web.js` file is still used in webOS Signage.)

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

### Links
[//]: # (Related issues, references)
