### PR TITLE
Update test cases to use node's cldr version info

### DIFF
--- a/js/test/date/testdatefmt.js
+++ b/js/test/date/testdatefmt.js
@@ -3999,7 +3999,7 @@ module.exports.testdatefmt = {
 
         if(ilib._getPlatform() === "nodejs") {
             var cldrVersion = Number(process.versions["cldr"]);
-            if (cldrVersion < 36) {
+            if (cldrVersion < 38) {
                 test.equal(result, false);
             } else {
                 test.equal(result, true);

--- a/js/test/date/testdatefmt.js
+++ b/js/test/date/testdatefmt.js
@@ -3998,9 +3998,8 @@ module.exports.testdatefmt = {
         var result = DateFmt.isIntlDateTimeAvailable("ko-KR");
 
         if(ilib._getPlatform() === "nodejs") {
-            var version = process.versions["node"];
-            var majorVersion = version.split(".")[0];
-            if (majorVersion == "8" || majorVersion == "10" || majorVersion == "12") {
+            var cldrVersion = process.versions["cldr"];
+            if (Number(cldrVersion) < 35) {
                 test.equal(result, false);
             } else {
                 test.equal(result, true);

--- a/js/test/date/testdatefmt.js
+++ b/js/test/date/testdatefmt.js
@@ -3999,8 +3999,13 @@ module.exports.testdatefmt = {
 
         if(ilib._getPlatform() === "nodejs") {
             var cldrVersion = Number(process.versions["cldr"]);
+            var nodeMajorVersion = process.versions["node"].split(".")[0];
             if (cldrVersion < 38) {
-                test.equal(result, false);
+                if (nodeMajorVersion === "14") {
+                    test.equal(result, true);
+                } else {
+                    test.equal(result, false);
+                }
             } else {
                 test.equal(result, true);
             }

--- a/js/test/date/testdatefmt.js
+++ b/js/test/date/testdatefmt.js
@@ -3999,7 +3999,7 @@ module.exports.testdatefmt = {
 
         if(ilib._getPlatform() === "nodejs") {
             var cldrVersion = Number(process.versions["cldr"]);
-            if (cldrVersion < 35) {
+            if (cldrVersion < 38) {
                 test.equal(result, false);
             } else {
                 test.equal(result, true);

--- a/js/test/date/testdatefmt.js
+++ b/js/test/date/testdatefmt.js
@@ -3999,7 +3999,7 @@ module.exports.testdatefmt = {
 
         if(ilib._getPlatform() === "nodejs") {
             var cldrVersion = Number(process.versions["cldr"]);
-            if (cldrVersion < 38) {
+            if (cldrVersion < 36) {
                 test.equal(result, false);
             } else {
                 test.equal(result, true);

--- a/js/test/date/testdatefmt.js
+++ b/js/test/date/testdatefmt.js
@@ -3998,8 +3998,8 @@ module.exports.testdatefmt = {
         var result = DateFmt.isIntlDateTimeAvailable("ko-KR");
 
         if(ilib._getPlatform() === "nodejs") {
-            var cldrVersion = process.versions["cldr"];
-            if (Number(cldrVersion) < 35) {
+            var cldrVersion = Number(process.versions["cldr"]);
+            if (cldrVersion < 35) {
                 test.equal(result, false);
             } else {
                 test.equal(result, true);

--- a/js/test/date/testdatefmt_en_GB.js
+++ b/js/test/date/testdatefmt_en_GB.js
@@ -145,11 +145,10 @@ module.exports.testdatefmt_en_GB = {
         });
 
         if(ilib._getPlatform() === "nodejs"){
-            var version = process.versions["node"];
-            var majorVersion = version.split(".")[0];
-            if (majorVersion == "8" || majorVersion == "10") {
+            var cldrVersion = process.versions["cldr"];
+            if (Number(cldrVersion) < 34) {
                 test.equal(fmt.format(date), "9/29/2011");
-            } else if (majorVersion == "12") {
+            } else if (Number(cldrVersion) < 35) {
                 test.equal(fmt.format(date), "9/29/11");
             } else {
                 test.equal(fmt.format(date), "29/09/2011");
@@ -181,19 +180,18 @@ module.exports.testdatefmt_en_GB = {
         });
 
         if(ilib._getPlatform() === "nodejs"){
-            var version = process.versions["node"];
-            var majorVersion = version.split(".")[0];
+            var cldrVersion = Number(process.versions["cldr"]);
             //console.log("version: " + version + " majorVersion: " + majorVersion);
-            if (majorVersion == "8" || majorVersion == "10") {
+            if (cldrVersion < 34) {
                 test.equal(fmt.format(date), "9/29/2011");
-            } else if (majorVersion == "12") {
+            } else if(cldrVersion < 35) {
                 test.equal(fmt.format(date), "Sep 29, 2011");
-            } else if (version == "14.18.2"){
+            } else if(cldrVersion < 38){
                 test.equal(fmt.format(date), "29 Sept 2011");
-            }
-            else if (majorVersion == "16"){
+            } else if(cldrVersion < 41){
                 test.equal(fmt.format(date), "29 Sept 2011");
             } else {
+                console.log(3)
                 test.equal(fmt.format(date), "29 Sep 2011"); 
             }
         } else {
@@ -222,11 +220,10 @@ module.exports.testdatefmt_en_GB = {
         });
 
         if(ilib._getPlatform() === "nodejs"){
-            var version = process.versions["node"];
-            var majorVersion = version.split(".")[0];
-            if (majorVersion == "8" || majorVersion == "10") {
+            var cldrVersion = process.versions["cldr"];
+            if (Number(cldrVersion) < 34) {
                 test.equal(fmt.format(date), "9/29/2011");
-            } else if (majorVersion == "12") {
+            } else if (Number(cldrVersion) < 35) {
                 test.equal(fmt.format(date), "September 29, 2011");
             } else {
                 test.equal(fmt.format(date), "29 September 2011");
@@ -283,11 +280,10 @@ module.exports.testdatefmt_en_GB = {
 
 
         if(ilib._getPlatform() === "nodejs"){
-            var version = process.versions["node"];
-            var majorVersion = version.split(".")[0];
-            if (majorVersion == "8" || majorVersion == "10") {
+            var cldrVersion = process.versions["cldr"];
+            if (Number(cldrVersion) < 34) {
                 test.equal(fmt.format(date), "9/29/2011");
-            } else if (majorVersion == "12") {
+            } else if (Number(cldrVersion) < 35) {
                 test.equal(fmt.format(date), "Thursday, September 29, 2011");
             } else {
                 test.equal(fmt.format(date), "Thursday, 29 September 2011");
@@ -1294,11 +1290,10 @@ module.exports.testdatefmt_en_GB = {
         });
 
         if(ilib._getPlatform() === "nodejs") {
-            var version = process.versions["node"];
-            var majorVersion = version.split(".")[0];
-            if (majorVersion == "8" || majorVersion == "10") {
+            var cldrVersion = process.versions["cldr"];
+            if (cldrVersion < 34) {
                 test.equal(fmt.format(date), "9/29/2011");
-            } else if (majorVersion == "12") {
+            } else if (cldrVersion < 35) {
                 test.equal(fmt.format(date), "1:45 PM");
             } else {
                 test.equal(fmt.format(date), "13:45");
@@ -1329,11 +1324,10 @@ module.exports.testdatefmt_en_GB = {
         });
 
         if(ilib._getPlatform() === "nodejs"){
-            var version = process.versions["node"];
-            var majorVersion = version.split(".")[0];
-            if (majorVersion == "8" || majorVersion == "10") {
+            var cldrVersion = process.versions["cldr"];
+            if (cldrVersion < 34) {
                 test.equal(fmt.format(date), "9/29/2011");
-            } else if (majorVersion == "12") {
+            } else if (cldrVersion < 35) {
                 test.equal(fmt.format(date), "1:45:10 PM");
             } else {
                 test.equal(fmt.format(date), "13:45:10");

--- a/js/test/date/testdatefmt_en_GB.js
+++ b/js/test/date/testdatefmt_en_GB.js
@@ -146,9 +146,9 @@ module.exports.testdatefmt_en_GB = {
 
         if(ilib._getPlatform() === "nodejs"){
             var cldrVersion = Number(process.versions["cldr"]);
-            if (cldrVersion < 36) {
+            if (cldrVersion < 35) {
                 test.equal(fmt.format(date), "9/29/2011");
-            } else if (cldrVersion < 38) {
+            } else if (cldrVersion < 36) {
                 test.equal(fmt.format(date), "9/29/11");
             } else {
                 test.equal(fmt.format(date), "29/09/2011");
@@ -182,10 +182,12 @@ module.exports.testdatefmt_en_GB = {
         if(ilib._getPlatform() === "nodejs"){
             var cldrVersion = Number(process.versions["cldr"]);
             //console.log("version: " + version + " majorVersion: " + majorVersion);
-            if (cldrVersion < 36) {
+            if (cldrVersion < 35) {
                 test.equal(fmt.format(date), "9/29/2011");
-            } else if(cldrVersion < 38) {
+            } else if(cldrVersion < 36) {
                 test.equal(fmt.format(date), "Sep 29, 2011");
+            } else if(cldrVersion < 38) {
+                test.equal(fmt.format(date), "29 Sep 2011");
             } else if(cldrVersion < 39){
                 test.equal(fmt.format(date), "29 Sept 2011");
             } else if(cldrVersion < 41){
@@ -221,9 +223,9 @@ module.exports.testdatefmt_en_GB = {
 
         if(ilib._getPlatform() === "nodejs"){
             var cldrVersion = Number(process.versions["cldr"]);
-            if (cldrVersion < 36) {
+            if (cldrVersion < 35) {
                 test.equal(fmt.format(date), "9/29/2011");
-            } else if (cldrVersion < 38) {
+            } else if (cldrVersion < 36) {
                 test.equal(fmt.format(date), "September 29, 2011");
             } else {
                 test.equal(fmt.format(date), "29 September 2011");
@@ -281,9 +283,9 @@ module.exports.testdatefmt_en_GB = {
 
         if(ilib._getPlatform() === "nodejs"){
             var cldrVersion = Number(process.versions["cldr"]);
-            if (cldrVersion < 36) {
+            if (cldrVersion < 35) {
                 test.equal(fmt.format(date), "9/29/2011");
-            } else if (cldrVersion < 38) {
+            } else if (cldrVersion < 36) {
                 test.equal(fmt.format(date), "Thursday, September 29, 2011");
             } else {
                 test.equal(fmt.format(date), "Thursday, 29 September 2011");
@@ -1291,9 +1293,9 @@ module.exports.testdatefmt_en_GB = {
 
         if(ilib._getPlatform() === "nodejs") {
             var cldrVersion = Number(process.versions["cldr"]);
-            if (cldrVersion < 36) {
+            if (cldrVersion < 35) {
                 test.equal(fmt.format(date), "9/29/2011");
-            } else if (cldrVersion < 38) {
+            } else if (cldrVersion < 36) {
                 test.equal(fmt.format(date), "1:45 PM");
             } else {
                 test.equal(fmt.format(date), "13:45");
@@ -1325,9 +1327,9 @@ module.exports.testdatefmt_en_GB = {
 
         if(ilib._getPlatform() === "nodejs"){
             var cldrVersion = Number(process.versions["cldr"]);
-            if (cldrVersion < 36) {
+            if (cldrVersion < 35) {
                 test.equal(fmt.format(date), "9/29/2011");
-            } else if (cldrVersion < 38) {
+            } else if (cldrVersion < 35) {
                 test.equal(fmt.format(date), "1:45:10 PM");
             } else {
                 test.equal(fmt.format(date), "13:45:10");

--- a/js/test/date/testdatefmt_en_GB.js
+++ b/js/test/date/testdatefmt_en_GB.js
@@ -148,7 +148,7 @@ module.exports.testdatefmt_en_GB = {
             var cldrVersion = Number(process.versions["cldr"]);
             if (cldrVersion < 35) {
                 test.equal(fmt.format(date), "9/29/2011");
-            } else if (cldrVersion < 36) {
+            } else if (cldrVersion < 38) {
                 test.equal(fmt.format(date), "9/29/11");
             } else {
                 test.equal(fmt.format(date), "29/09/2011");
@@ -184,10 +184,8 @@ module.exports.testdatefmt_en_GB = {
             //console.log("version: " + version + " majorVersion: " + majorVersion);
             if (cldrVersion < 35) {
                 test.equal(fmt.format(date), "9/29/2011");
-            } else if(cldrVersion < 36) {
-                test.equal(fmt.format(date), "Sep 29, 2011");
             } else if(cldrVersion < 38) {
-                test.equal(fmt.format(date), "29 Sep 2011");
+                test.equal(fmt.format(date), "Sep 29, 2011");
             } else if(cldrVersion < 39){
                 test.equal(fmt.format(date), "29 Sept 2011");
             } else if(cldrVersion < 41){
@@ -225,7 +223,7 @@ module.exports.testdatefmt_en_GB = {
             var cldrVersion = Number(process.versions["cldr"]);
             if (cldrVersion < 35) {
                 test.equal(fmt.format(date), "9/29/2011");
-            } else if (cldrVersion < 36) {
+            } else if (cldrVersion < 38) {
                 test.equal(fmt.format(date), "September 29, 2011");
             } else {
                 test.equal(fmt.format(date), "29 September 2011");
@@ -285,7 +283,7 @@ module.exports.testdatefmt_en_GB = {
             var cldrVersion = Number(process.versions["cldr"]);
             if (cldrVersion < 35) {
                 test.equal(fmt.format(date), "9/29/2011");
-            } else if (cldrVersion < 36) {
+            } else if (cldrVersion < 38) {
                 test.equal(fmt.format(date), "Thursday, September 29, 2011");
             } else {
                 test.equal(fmt.format(date), "Thursday, 29 September 2011");
@@ -1295,7 +1293,7 @@ module.exports.testdatefmt_en_GB = {
             var cldrVersion = Number(process.versions["cldr"]);
             if (cldrVersion < 35) {
                 test.equal(fmt.format(date), "9/29/2011");
-            } else if (cldrVersion < 36) {
+            } else if (cldrVersion < 38) {
                 test.equal(fmt.format(date), "1:45 PM");
             } else {
                 test.equal(fmt.format(date), "13:45");
@@ -1329,7 +1327,7 @@ module.exports.testdatefmt_en_GB = {
             var cldrVersion = Number(process.versions["cldr"]);
             if (cldrVersion < 35) {
                 test.equal(fmt.format(date), "9/29/2011");
-            } else if (cldrVersion < 35) {
+            } else if (cldrVersion < 38) {
                 test.equal(fmt.format(date), "1:45:10 PM");
             } else {
                 test.equal(fmt.format(date), "13:45:10");

--- a/js/test/date/testdatefmt_en_GB.js
+++ b/js/test/date/testdatefmt_en_GB.js
@@ -146,7 +146,7 @@ module.exports.testdatefmt_en_GB = {
 
         if(ilib._getPlatform() === "nodejs"){
             var cldrVersion = Number(process.versions["cldr"]);
-            if (cldrVersion < 34) {
+            if (cldrVersion < 36) {
                 test.equal(fmt.format(date), "9/29/2011");
             } else if (cldrVersion < 38) {
                 test.equal(fmt.format(date), "9/29/11");
@@ -182,7 +182,7 @@ module.exports.testdatefmt_en_GB = {
         if(ilib._getPlatform() === "nodejs"){
             var cldrVersion = Number(process.versions["cldr"]);
             //console.log("version: " + version + " majorVersion: " + majorVersion);
-            if (cldrVersion < 34) {
+            if (cldrVersion < 36) {
                 test.equal(fmt.format(date), "9/29/2011");
             } else if(cldrVersion < 38) {
                 test.equal(fmt.format(date), "Sep 29, 2011");
@@ -221,7 +221,7 @@ module.exports.testdatefmt_en_GB = {
 
         if(ilib._getPlatform() === "nodejs"){
             var cldrVersion = Number(process.versions["cldr"]);
-            if (cldrVersion < 34) {
+            if (cldrVersion < 36) {
                 test.equal(fmt.format(date), "9/29/2011");
             } else if (cldrVersion < 38) {
                 test.equal(fmt.format(date), "September 29, 2011");
@@ -281,7 +281,7 @@ module.exports.testdatefmt_en_GB = {
 
         if(ilib._getPlatform() === "nodejs"){
             var cldrVersion = Number(process.versions["cldr"]);
-            if (cldrVersion < 34) {
+            if (cldrVersion < 36) {
                 test.equal(fmt.format(date), "9/29/2011");
             } else if (cldrVersion < 38) {
                 test.equal(fmt.format(date), "Thursday, September 29, 2011");
@@ -1291,7 +1291,7 @@ module.exports.testdatefmt_en_GB = {
 
         if(ilib._getPlatform() === "nodejs") {
             var cldrVersion = Number(process.versions["cldr"]);
-            if (cldrVersion < 34) {
+            if (cldrVersion < 36) {
                 test.equal(fmt.format(date), "9/29/2011");
             } else if (cldrVersion < 38) {
                 test.equal(fmt.format(date), "1:45 PM");
@@ -1325,7 +1325,7 @@ module.exports.testdatefmt_en_GB = {
 
         if(ilib._getPlatform() === "nodejs"){
             var cldrVersion = Number(process.versions["cldr"]);
-            if (cldrVersion < 34) {
+            if (cldrVersion < 36) {
                 test.equal(fmt.format(date), "9/29/2011");
             } else if (cldrVersion < 38) {
                 test.equal(fmt.format(date), "1:45:10 PM");

--- a/js/test/date/testdatefmt_en_GB.js
+++ b/js/test/date/testdatefmt_en_GB.js
@@ -146,10 +146,19 @@ module.exports.testdatefmt_en_GB = {
 
         if(ilib._getPlatform() === "nodejs"){
             var cldrVersion = Number(process.versions["cldr"]);
+            var nodeMajorVersion = process.versions["node"].split(".")[0];
             if (cldrVersion < 36) {
                 test.equal(fmt.format(date), "9/29/2011");
             } else if (cldrVersion < 38) {
-                test.equal(fmt.format(date), "9/29/11");
+                /*
+                * Both node v12.16.1 and v14.16.1 says the cldr version is 37.0.
+                * But it returns a different result.
+                */
+                if (nodeMajorVersion === "14") {
+                    test.equal(fmt.format(date), "29/09/2011");
+                } else {
+                    test.equal(fmt.format(date), "9/29/11");
+                }
             } else {
                 test.equal(fmt.format(date), "29/09/2011");
             }
@@ -181,18 +190,22 @@ module.exports.testdatefmt_en_GB = {
 
         if(ilib._getPlatform() === "nodejs"){
             var cldrVersion = Number(process.versions["cldr"]);
+            var nodeMajorVersion = process.versions["node"].split(".")[0];
             //console.log("version: " + version + " majorVersion: " + majorVersion);
             if (cldrVersion < 36) {
                 test.equal(fmt.format(date), "9/29/2011");
             } else if(cldrVersion < 38) {
-                test.equal(fmt.format(date), "Sep 29, 2011");
+                if (nodeMajorVersion === "14") {
+                    test.equal(fmt.format(date), "29 Sep 2011");
+                } else {
+                    test.equal(fmt.format(date), "Sep 29, 2011");
+                }
             } else if(cldrVersion < 39){
                 test.equal(fmt.format(date), "29 Sept 2011");
             } else if(cldrVersion < 41){
                 test.equal(fmt.format(date), "29 Sept 2011");
             } else {
-                console.log(3)
-                test.equal(fmt.format(date), "29 Sep 2011"); 
+                test.equal(fmt.format(date), "29 Sep 2011");
             }
         } else {
             test.equal(fmt.format(date), "29 Sept 2011");
@@ -221,10 +234,16 @@ module.exports.testdatefmt_en_GB = {
 
         if(ilib._getPlatform() === "nodejs"){
             var cldrVersion = Number(process.versions["cldr"]);
+            var nodeMajorVersion = process.versions["node"].split(".")[0];
             if (cldrVersion < 36) {
                 test.equal(fmt.format(date), "9/29/2011");
             } else if (cldrVersion < 38) {
-                test.equal(fmt.format(date), "September 29, 2011");
+                if (nodeMajorVersion === "14") {
+                    test.equal(fmt.format(date), "29 September 2011");
+                } else {
+                    test.equal(fmt.format(date), "September 29, 2011");
+                }
+                
             } else {
                 test.equal(fmt.format(date), "29 September 2011");
             }
@@ -281,10 +300,15 @@ module.exports.testdatefmt_en_GB = {
 
         if(ilib._getPlatform() === "nodejs"){
             var cldrVersion = Number(process.versions["cldr"]);
+            var nodeMajorVersion = process.versions["node"].split(".")[0];
             if (cldrVersion < 36) {
                 test.equal(fmt.format(date), "9/29/2011");
             } else if (cldrVersion < 38) {
-                test.equal(fmt.format(date), "Thursday, September 29, 2011");
+                if (nodeMajorVersion === "14") {
+                    test.equal(fmt.format(date), "Thursday, 29 September 2011");
+                } else {
+                    test.equal(fmt.format(date), "Thursday, September 29, 2011");
+                }
             } else {
                 test.equal(fmt.format(date), "Thursday, 29 September 2011");
             }
@@ -1291,10 +1315,15 @@ module.exports.testdatefmt_en_GB = {
 
         if(ilib._getPlatform() === "nodejs") {
             var cldrVersion = Number(process.versions["cldr"]);
+            var nodeMajorVersion = process.versions["node"].split(".")[0];
             if (cldrVersion < 36) {
                 test.equal(fmt.format(date), "9/29/2011");
             } else if (cldrVersion < 38) {
-                test.equal(fmt.format(date), "1:45 PM");
+                if (nodeMajorVersion === "14") {
+                    test.equal(fmt.format(date), "13:45");
+                } else {
+                    test.equal(fmt.format(date), "1:45 PM");
+                }
             } else {
                 test.equal(fmt.format(date), "13:45");
             }
@@ -1325,17 +1354,21 @@ module.exports.testdatefmt_en_GB = {
 
         if(ilib._getPlatform() === "nodejs"){
             var cldrVersion = Number(process.versions["cldr"]);
+            var nodeMajorVersion = process.versions["node"].split(".")[0];
             if (cldrVersion < 36) {
                 test.equal(fmt.format(date), "9/29/2011");
             } else if (cldrVersion < 38) {
-                test.equal(fmt.format(date), "1:45:10 PM");
+                if (nodeMajorVersion === "14") {
+                    test.equal(fmt.format(date), "13:45:10");
+                } else {
+                    test.equal(fmt.format(date), "1:45:10 PM");
+                }
             } else {
                 test.equal(fmt.format(date), "13:45:10");
             }
         } else {
             test.equal(fmt.format(date), "13:45:10");
         }
-        
         test.done();
     },
     

--- a/js/test/date/testdatefmt_en_GB.js
+++ b/js/test/date/testdatefmt_en_GB.js
@@ -148,7 +148,7 @@ module.exports.testdatefmt_en_GB = {
             var cldrVersion = Number(process.versions["cldr"]);
             if (cldrVersion < 34) {
                 test.equal(fmt.format(date), "9/29/2011");
-            } else if (cldrVersion < 35) {
+            } else if (cldrVersion < 38) {
                 test.equal(fmt.format(date), "9/29/11");
             } else {
                 test.equal(fmt.format(date), "29/09/2011");
@@ -184,9 +184,9 @@ module.exports.testdatefmt_en_GB = {
             //console.log("version: " + version + " majorVersion: " + majorVersion);
             if (cldrVersion < 34) {
                 test.equal(fmt.format(date), "9/29/2011");
-            } else if(cldrVersion < 35) {
+            } else if(cldrVersion < 38) {
                 test.equal(fmt.format(date), "Sep 29, 2011");
-            } else if(cldrVersion < 38){
+            } else if(cldrVersion < 39){
                 test.equal(fmt.format(date), "29 Sept 2011");
             } else if(cldrVersion < 41){
                 test.equal(fmt.format(date), "29 Sept 2011");
@@ -223,7 +223,7 @@ module.exports.testdatefmt_en_GB = {
             var cldrVersion = Number(process.versions["cldr"]);
             if (cldrVersion < 34) {
                 test.equal(fmt.format(date), "9/29/2011");
-            } else if (cldrVersion < 35) {
+            } else if (cldrVersion < 38) {
                 test.equal(fmt.format(date), "September 29, 2011");
             } else {
                 test.equal(fmt.format(date), "29 September 2011");
@@ -283,7 +283,7 @@ module.exports.testdatefmt_en_GB = {
             var cldrVersion = Number(process.versions["cldr"]);
             if (cldrVersion < 34) {
                 test.equal(fmt.format(date), "9/29/2011");
-            } else if (cldrVersion < 35) {
+            } else if (cldrVersion < 38) {
                 test.equal(fmt.format(date), "Thursday, September 29, 2011");
             } else {
                 test.equal(fmt.format(date), "Thursday, 29 September 2011");
@@ -1293,7 +1293,7 @@ module.exports.testdatefmt_en_GB = {
             var cldrVersion = Number(process.versions["cldr"]);
             if (cldrVersion < 34) {
                 test.equal(fmt.format(date), "9/29/2011");
-            } else if (cldrVersion < 35) {
+            } else if (cldrVersion < 38) {
                 test.equal(fmt.format(date), "1:45 PM");
             } else {
                 test.equal(fmt.format(date), "13:45");
@@ -1327,7 +1327,7 @@ module.exports.testdatefmt_en_GB = {
             var cldrVersion = Number(process.versions["cldr"]);
             if (cldrVersion < 34) {
                 test.equal(fmt.format(date), "9/29/2011");
-            } else if (cldrVersion < 35) {
+            } else if (cldrVersion < 38) {
                 test.equal(fmt.format(date), "1:45:10 PM");
             } else {
                 test.equal(fmt.format(date), "13:45:10");

--- a/js/test/date/testdatefmt_en_GB.js
+++ b/js/test/date/testdatefmt_en_GB.js
@@ -145,10 +145,10 @@ module.exports.testdatefmt_en_GB = {
         });
 
         if(ilib._getPlatform() === "nodejs"){
-            var cldrVersion = process.versions["cldr"];
-            if (Number(cldrVersion) < 34) {
+            var cldrVersion = Number(process.versions["cldr"]);
+            if (cldrVersion < 34) {
                 test.equal(fmt.format(date), "9/29/2011");
-            } else if (Number(cldrVersion) < 35) {
+            } else if (cldrVersion < 35) {
                 test.equal(fmt.format(date), "9/29/11");
             } else {
                 test.equal(fmt.format(date), "29/09/2011");
@@ -220,10 +220,10 @@ module.exports.testdatefmt_en_GB = {
         });
 
         if(ilib._getPlatform() === "nodejs"){
-            var cldrVersion = process.versions["cldr"];
-            if (Number(cldrVersion) < 34) {
+            var cldrVersion = Number(process.versions["cldr"]);
+            if (cldrVersion < 34) {
                 test.equal(fmt.format(date), "9/29/2011");
-            } else if (Number(cldrVersion) < 35) {
+            } else if (cldrVersion < 35) {
                 test.equal(fmt.format(date), "September 29, 2011");
             } else {
                 test.equal(fmt.format(date), "29 September 2011");
@@ -280,10 +280,10 @@ module.exports.testdatefmt_en_GB = {
 
 
         if(ilib._getPlatform() === "nodejs"){
-            var cldrVersion = process.versions["cldr"];
-            if (Number(cldrVersion) < 34) {
+            var cldrVersion = Number(process.versions["cldr"]);
+            if (cldrVersion < 34) {
                 test.equal(fmt.format(date), "9/29/2011");
-            } else if (Number(cldrVersion) < 35) {
+            } else if (cldrVersion < 35) {
                 test.equal(fmt.format(date), "Thursday, September 29, 2011");
             } else {
                 test.equal(fmt.format(date), "Thursday, 29 September 2011");
@@ -1290,7 +1290,7 @@ module.exports.testdatefmt_en_GB = {
         });
 
         if(ilib._getPlatform() === "nodejs") {
-            var cldrVersion = process.versions["cldr"];
+            var cldrVersion = Number(process.versions["cldr"]);
             if (cldrVersion < 34) {
                 test.equal(fmt.format(date), "9/29/2011");
             } else if (cldrVersion < 35) {
@@ -1324,7 +1324,7 @@ module.exports.testdatefmt_en_GB = {
         });
 
         if(ilib._getPlatform() === "nodejs"){
-            var cldrVersion = process.versions["cldr"];
+            var cldrVersion = Number(process.versions["cldr"]);
             if (cldrVersion < 34) {
                 test.equal(fmt.format(date), "9/29/2011");
             } else if (cldrVersion < 35) {

--- a/js/test/date/testdatefmt_en_GB.js
+++ b/js/test/date/testdatefmt_en_GB.js
@@ -151,7 +151,7 @@ module.exports.testdatefmt_en_GB = {
                 test.equal(fmt.format(date), "9/29/2011");
             } else if (cldrVersion < 38) {
                 /*
-                * Both node v12.16.1 and v14.16.1 says the cldr version is 37.0.
+                * Both node v12.16.1 and v14.16.1 say the cldr version is 37.0.
                 * But it returns a different result.
                 */
                 if (nodeMajorVersion === "14") {

--- a/js/test/date/testdatefmt_en_GB.js
+++ b/js/test/date/testdatefmt_en_GB.js
@@ -146,7 +146,7 @@ module.exports.testdatefmt_en_GB = {
 
         if(ilib._getPlatform() === "nodejs"){
             var cldrVersion = Number(process.versions["cldr"]);
-            if (cldrVersion < 35) {
+            if (cldrVersion < 36) {
                 test.equal(fmt.format(date), "9/29/2011");
             } else if (cldrVersion < 38) {
                 test.equal(fmt.format(date), "9/29/11");
@@ -182,7 +182,7 @@ module.exports.testdatefmt_en_GB = {
         if(ilib._getPlatform() === "nodejs"){
             var cldrVersion = Number(process.versions["cldr"]);
             //console.log("version: " + version + " majorVersion: " + majorVersion);
-            if (cldrVersion < 35) {
+            if (cldrVersion < 36) {
                 test.equal(fmt.format(date), "9/29/2011");
             } else if(cldrVersion < 38) {
                 test.equal(fmt.format(date), "Sep 29, 2011");
@@ -221,7 +221,7 @@ module.exports.testdatefmt_en_GB = {
 
         if(ilib._getPlatform() === "nodejs"){
             var cldrVersion = Number(process.versions["cldr"]);
-            if (cldrVersion < 35) {
+            if (cldrVersion < 36) {
                 test.equal(fmt.format(date), "9/29/2011");
             } else if (cldrVersion < 38) {
                 test.equal(fmt.format(date), "September 29, 2011");
@@ -281,7 +281,7 @@ module.exports.testdatefmt_en_GB = {
 
         if(ilib._getPlatform() === "nodejs"){
             var cldrVersion = Number(process.versions["cldr"]);
-            if (cldrVersion < 35) {
+            if (cldrVersion < 36) {
                 test.equal(fmt.format(date), "9/29/2011");
             } else if (cldrVersion < 38) {
                 test.equal(fmt.format(date), "Thursday, September 29, 2011");
@@ -1291,7 +1291,7 @@ module.exports.testdatefmt_en_GB = {
 
         if(ilib._getPlatform() === "nodejs") {
             var cldrVersion = Number(process.versions["cldr"]);
-            if (cldrVersion < 35) {
+            if (cldrVersion < 36) {
                 test.equal(fmt.format(date), "9/29/2011");
             } else if (cldrVersion < 38) {
                 test.equal(fmt.format(date), "1:45 PM");
@@ -1325,7 +1325,7 @@ module.exports.testdatefmt_en_GB = {
 
         if(ilib._getPlatform() === "nodejs"){
             var cldrVersion = Number(process.versions["cldr"]);
-            if (cldrVersion < 35) {
+            if (cldrVersion < 36) {
                 test.equal(fmt.format(date), "9/29/2011");
             } else if (cldrVersion < 38) {
                 test.equal(fmt.format(date), "1:45:10 PM");

--- a/js/test/date/testdatefmtasync.js
+++ b/js/test/date/testdatefmtasync.js
@@ -420,13 +420,11 @@ module.exports.testdatefmtasync = {
                     onLoad: function(fmt){
                         if(ilib._getPlatform() === "nodejs"){
                             var cldrVersion = Number(process.versions["cldr"]);
-                            console.log("version: " + process.versions["node"]);
                             if(cldrVersion < 36){
                                 test.equal(fmt.format(date), "9/29/2022");
                             } else {
                                 test.equal(fmt.format(date), "September 29, 2022");
                             }
-                            
                         } else {
                             test.equal(fmt.format(date), "September 29, 2022");
                         }

--- a/js/test/date/testdatefmtasync.js
+++ b/js/test/date/testdatefmtasync.js
@@ -322,8 +322,8 @@ module.exports.testdatefmtasync = {
                 var date = new Date(2022, 4, 29);
 
                 if(ilib._getPlatform() === "nodejs"){
-                    var cldrVersion = process.versions["cldr"];
-                    if (Number(cldrVersion) < 34){
+                    var cldrVersion = Number(process.versions["cldr"]);
+                    if (cldrVersion < 34){
                         test.equal(fmt.format(date), "5/29/2022");
                     } else {
                         test.equal(fmt.format(date), "May 29, 2022");
@@ -419,9 +419,9 @@ module.exports.testdatefmtasync = {
                     sync: false,
                     onLoad: function(fmt){
                         if(ilib._getPlatform() === "nodejs"){
-                            var cldrVersion = process.versions["cldr"];
-                            //console.log("version: " + version);
-                            if(Number(cldrVersion) < 34){
+                            var cldrVersion = Number(process.versions["cldr"]);
+                            console.log("version: " + process.versions["node"]);
+                            if(cldrVersion < 34){
                                 test.equal(fmt.format(date), "9/29/2022");
                             } else {
                                 test.equal(fmt.format(date), "September 29, 2022");

--- a/js/test/date/testdatefmtasync.js
+++ b/js/test/date/testdatefmtasync.js
@@ -323,7 +323,7 @@ module.exports.testdatefmtasync = {
 
                 if(ilib._getPlatform() === "nodejs"){
                     var cldrVersion = Number(process.versions["cldr"]);
-                    if (cldrVersion < 34){
+                    if (cldrVersion < 36){
                         test.equal(fmt.format(date), "5/29/2022");
                     } else {
                         test.equal(fmt.format(date), "May 29, 2022");
@@ -421,7 +421,7 @@ module.exports.testdatefmtasync = {
                         if(ilib._getPlatform() === "nodejs"){
                             var cldrVersion = Number(process.versions["cldr"]);
                             console.log("version: " + process.versions["node"]);
-                            if(cldrVersion < 34){
+                            if(cldrVersion < 36){
                                 test.equal(fmt.format(date), "9/29/2022");
                             } else {
                                 test.equal(fmt.format(date), "September 29, 2022");

--- a/js/test/date/testdatefmtasync.js
+++ b/js/test/date/testdatefmtasync.js
@@ -322,9 +322,8 @@ module.exports.testdatefmtasync = {
                 var date = new Date(2022, 4, 29);
 
                 if(ilib._getPlatform() === "nodejs"){
-                    var version = process.versions["node"];
-                    var majorVersion = version.split(".")[0];
-                    if (majorVersion == 8 || majorVersion == 10){
+                    var cldrVersion = process.versions["cldr"];
+                    if (Number(cldrVersion) < 34){
                         test.equal(fmt.format(date), "5/29/2022");
                     } else {
                         test.equal(fmt.format(date), "May 29, 2022");
@@ -420,10 +419,9 @@ module.exports.testdatefmtasync = {
                     sync: false,
                     onLoad: function(fmt){
                         if(ilib._getPlatform() === "nodejs"){
-                            var version = process.versions["node"];
-                            var majorVersion = version.split(".")[0];
+                            var cldrVersion = process.versions["cldr"];
                             //console.log("version: " + version);
-                            if(majorVersion == "8" || majorVersion == "10"){
+                            if(Number(cldrVersion) < 34){
                                 test.equal(fmt.format(date), "9/29/2022");
                             } else {
                                 test.equal(fmt.format(date), "September 29, 2022");

--- a/js/test/root/teststrings.js
+++ b/js/test/root/teststrings.js
@@ -698,8 +698,8 @@ module.exports.teststrings = {
         
         var platform = ilib._getPlatform();
         if (platform === "nodejs") {
-            var cldrVersion = process.versions["cldr"];
-            if (Number(cldrVersion) < 36) {
+            var cldrVersion = Number(process.versions["cldr"]);
+            if (cldrVersion < 36) {
                 test.equal(str.formatChoice([params.num,params.pages], params), "0 items on 0 pages.");
             } else {
                 test.equal(str.formatChoice([params.num,params.pages], params), "0 items (many) on 0 pages (many).");
@@ -3023,8 +3023,8 @@ module.exports.teststrings = {
 
         var platform = ilib._getPlatform();
         if (platform === "nodejs") {
-            var cldrVersion = process.versions["cldr"];
-            if (Number(cldrVersion) < 36) { // Intl.PluralRules doesn't support this locale until this version.
+            var cldrVersion = Number(process.versions["cldr"]);
+            if (cldrVersion < 36) { // Intl.PluralRules doesn't support this locale until this version.
                 test.equal(str.formatChoice(0), "There are no items.");
             } else {
                 test.equal(str.formatChoice(0), "Default items");
@@ -3249,8 +3249,8 @@ module.exports.teststrings = {
 
         var platform = ilib._getPlatform();
         if (platform === "nodejs") {
-            var cldrVersion = process.versions["cldr"];
-            if (Number(cldrVersion) < 36) { // Intl.PluralRules doesn't support this locale until this version.
+            var cldrVersion = Number(process.versions["cldr"]);
+            if (cldrVersion < 36) { // Intl.PluralRules doesn't support this locale until this version.
                 test.equal(str.formatChoice(0), "There are no items.");
             } else {
                 test.equal(str.formatChoice(0), "The item is one");
@@ -3280,10 +3280,10 @@ module.exports.teststrings = {
         test.ok(str !== null);
 
         if (ilib._getPlatform() === "nodejs") {
-            var cldrVersion = process.versions["cldr"];
-            if (Number(cldrVersion) < 36) { // Intl.PluralRules doesn't support this locale until this version.
+            var cldrVersion = Number(process.versions["cldr"]);
+            if (cldrVersion < 36) { // Intl.PluralRules doesn't support this locale until this version.
                 test.equal(str.formatChoice(1000000), "The items are many");
-            } else if (Number(cldrVersion) >= 36 && Number(cldrVersion) < 40 ) {
+            } else if (cldrVersion >= 36 && cldrVersion < 40 ) {
                 test.equal(str.formatChoice(1000000), "Default items"); // wrong result based on cldr41
             } else {
                 test.equal(str.formatChoice(1000000), "The items are many");
@@ -3306,8 +3306,8 @@ module.exports.teststrings = {
 
         var platform = ilib._getPlatform();
         if (platform === "nodejs") {
-            var cldrVersion = process.versions["cldr"];
-            if (Number(cldrVersion) < 36) { // Intl.PluralRules doesn't support this locale until this version.
+            var cldrVersion = Number(process.versions["cldr"]);
+            if (cldrVersion < 36) { // Intl.PluralRules doesn't support this locale until this version.
                 test.equal(str.formatChoice(0), "There are no items.");
             } else {
                 test.equal(str.formatChoice(0), "Default items");
@@ -3337,8 +3337,8 @@ module.exports.teststrings = {
         test.ok(str !== null);
         var platform = ilib._getPlatform();
         if (platform === "nodejs") {
-            var cldrVersion = process.versions["cldr"];
-            if (Number(cldrVersion) < 36) { // Intl.PluralRules doesn't support this locale until this version.
+            var cldrVersion = Number(process.versions["cldr"]);
+            if (cldrVersion < 36) { // Intl.PluralRules doesn't support this locale until this version.
                 test.equal(str.formatChoice(0), "There are no items.");
             } else {
                 test.equal(str.formatChoice(0), "The items are many");
@@ -3866,7 +3866,7 @@ module.exports.teststrings = {
 
         var platform = ilib._getPlatform();
         if (platform === "nodejs") {
-            var cldrVersion = process.versions["cldr"];
+            var cldrVersion = Number(process.versions["cldr"]);
             if (Number(cldrVersion) < 36) { // Intl.PluralRules doesn't support this locale until this version.
                 test.equal(str.formatChoice(0), "There are no items.");
             } else {
@@ -3940,7 +3940,7 @@ module.exports.teststrings = {
         test.ok(str !== null);
 
         if (ilib._getPlatform() === "nodejs") {
-            var cldrVersion = process.versions["cldr"];
+            var cldrVersion = Number(process.versions["cldr"]);
             if (Number(cldrVersion) < 36) { // // Intl.PluralRules doesn't support this locale until this version.
                 test.equal(str.formatChoice(3e6), "The items are many");
             } else if (Number(cldrVersion) >= 36 && Number(cldrVersion) < 40 ) {
@@ -3964,11 +3964,11 @@ module.exports.teststrings = {
         test.ok(str !== null);
 
         if (ilib._getPlatform() === "nodejs") {
-            var cldrVersion = process.versions["cldr"];
-            if (Number(cldrVersion) < 36) { // // Intl.PluralRules doesn't support this locale until this version.
+            var cldrVersion = Number(process.versions["cldr"]);
+            if (cldrVersion < 36) { // // Intl.PluralRules doesn't support this locale until this version.
                 test.equal(str.formatChoice(3e6), "The items are many");
             }
-            else if (Number(cldrVersion) >= 36 && Number(cldrVersion) < 40 ) {
+            else if (cldrVersion >= 36 && cldrVersion < 40 ) {
                 test.equal(str.formatChoice(3e6), "Default items"); // wrong result based on cldr41
             } else {
                 test.equal(str.formatChoice(3e6), "The items are many");
@@ -3989,10 +3989,10 @@ module.exports.teststrings = {
         test.ok(str !== null);
 
         if (ilib._getPlatform() === "nodejs") {
-            var cldrVersion = process.versions["cldr"];
-            if (Number(cldrVersion) < 36) { // // Intl.PluralRules doesn't support this locale until this version.
+            var cldrVersion = Number(process.versions["cldr"]);
+            if (cldrVersion < 36) { // // Intl.PluralRules doesn't support this locale until this version.
                 test.equal(str.formatChoice(1000000), "The items are many");
-            } else if (Number(cldrVersion) >= 36 && Number(cldrVersion) < 40 ) {
+            } else if (cldrVersion >= 36 && cldrVersion < 40 ) {
                 test.equal(str.formatChoice(1000000), "Default items"); // wrong result based on cldr41
             } else {
                 test.equal(str.formatChoice(1000000), "The items are many");
@@ -4022,10 +4022,10 @@ module.exports.teststrings = {
         test.ok(str !== null);
 
         if (ilib._getPlatform() === "nodejs") {
-            var cldrVersion = process.versions["cldr"];
-            if (Number(cldrVersion) < 36) {
+            var cldrVersion = Number(process.versions["cldr"]);
+            if (cldrVersion < 36) {
                 test.equal(str.formatChoice(5e6), "The items are many");
-            } else if (Number(cldrVersion) >= 36  && Number(cldrVersion) < 38) {
+            } else if (cldrVersion >= 36 && cldrVersion < 38) {
                 test.equal(str.formatChoice(5e6), "Default items"); // wrong result based on cldr41
             } else {
                 test.equal(str.formatChoice(5e6), "The items are many");
@@ -4122,8 +4122,8 @@ module.exports.teststrings = {
 
         var platform = ilib._getPlatform();
         if (platform === "nodejs") {
-            var cldrVersion = process.versions["cldr"];
-            if (Number(cldrVersion) < 36) { // Intl.PluralRules doesn't support this locale until this version.
+            var cldrVersion = Number(process.versions["cldr"]);
+            if (cldrVersion < 36) { // Intl.PluralRules doesn't support this locale until this version.
                 test.equal(str.formatChoice(5.2), "The items are few");
             } else {
                 test.equal(str.formatChoice(5.2), "Default items"); // wrong result based on cldr41
@@ -4240,8 +4240,8 @@ module.exports.teststrings = {
 
         var platform = ilib._getPlatform();
         if (platform === "nodejs") {
-            var cldrVersion = process.versions["cldr"];
-            if (Number(cldrVersion) < 36) { // Intl.PluralRules doesn't support this locale until this version.
+            var cldrVersion = Number(process.versions["cldr"]);
+            if (cldrVersion < 36) { // Intl.PluralRules doesn't support this locale until this version.
                 test.equal(str.formatChoice(0.0), "There are no items.");
             } else {
                 test.equal(str.formatChoice(0.0), "Default items");
@@ -4291,8 +4291,8 @@ module.exports.teststrings = {
         test.ok(str !== null);
         var platform = ilib._getPlatform();
         if (platform === "nodejs") {
-            var cldrVersion = process.versions["cldr"];
-            if (Number(cldrVersion) < 36) {
+            var cldrVersion = Number(process.versions["cldr"]);
+            if (cldrVersion < 36) {
                 test.equal(str.formatChoice(1.5), "Default items");
             } else {
                 test.equal(str.formatChoice(1.5), "The item is one");
@@ -4600,8 +4600,8 @@ module.exports.teststrings = {
         test.ok(str !== null);
         var platform = ilib._getPlatform();
         if (platform === "nodejs") {
-            var cldrVersion = process.versions["cldr"];
-            if (Number(cldrVersion) < 36) { // Intl.PluralRules doesn't support this locale until this version.
+            var cldrVersion = Number(process.versions["cldr"]);
+            if (cldrVersion < 36) { // Intl.PluralRules doesn't support this locale until this version.
                 test.equal(str.formatChoice(3.1e6), "The items are many");
             } else {
                 test.equal(str.formatChoice(3.1e6), "Default items"); // wrong result based on cldr41
@@ -4631,8 +4631,8 @@ module.exports.teststrings = {
         test.ok(str !== null);
         var platform = ilib._getPlatform();
         if (platform === "nodejs") {
-            var cldrVersion = process.versions["cldr"];
-            if (Number(cldrVersion) < 36) {// Intl.PluralRules doesn't support this locale until this version.
+            var cldrVersion = Number(process.versions["cldr"]);
+            if (cldrVersion < 36) {// Intl.PluralRules doesn't support this locale until this version.
                 test.equal(str.formatChoice(2.1e6), "The items are many");
             } else {
                 test.equal(str.formatChoice(2.1e6), "Default items"); // wrong result based on cldr41

--- a/js/test/units/testunitfmt_be_BY.js
+++ b/js/test/units/testunitfmt_be_BY.js
@@ -88,8 +88,8 @@ module.exports.testunitfmt_be_BY = {
         var platform = ilib._getPlatform();
 
         if (platform === "nodejs") {
-            var cldrVersion = process.versions["cldr"];
-            if (Number(cldrVersion) < 36) {
+            var cldrVersion = Number(process.versions["cldr"]);
+            if (cldrVersion < 36) {
                 test.equal(str, "-16,666666666666668 градусы Цэльсія");
             } else {
                 test.equal(str, "-16,666666666666668 градуса Цэльсія");

--- a/js/test/units/testunitfmt_usages.js
+++ b/js/test/units/testunitfmt_usages.js
@@ -2802,7 +2802,6 @@ module.exports.testunitfmt_usages = {
         } else {
             test.equal(str, "3,2 кубічныя метры");
         }
-        
         test.done();
     },
 

--- a/js/test/units/testunitfmt_usages.js
+++ b/js/test/units/testunitfmt_usages.js
@@ -2791,8 +2791,8 @@ module.exports.testunitfmt_usages = {
         var str = uf.format(m1);
         var platform = ilib._getPlatform();
         if (platform === "nodejs") {
-            var cldrVersion = process.versions["cldr"];
-            if (Number(cldrVersion) < 36) {
+            var cldrVersion = Number(process.versions["cldr"]);
+            if (cldrVersion < 36) {
                 test.equal(str, "3,2 кубічныя метры");
             } else {
                 test.equal(str, "3,2 кубічнага метра");
@@ -2936,8 +2936,8 @@ module.exports.testunitfmt_usages = {
         var platform = ilib._getPlatform();
 
         if (platform === "nodejs") {
-            var cldrVersion = process.versions["cldr"];
-            if (Number(cldrVersion) < 36) {
+            var cldrVersion = Number(process.versions["cldr"]);
+            if (cldrVersion < 36) {
                 test.equal(str, "3,2 кубічныя метры");
             } else {
                 test.equal(str, "3,2 кубічнага метра");


### PR DESCRIPTION
### Checklist

* [ ] At least one test case is included for this feature or bug fix.
* [ ] `ReleaseNotes` has added or is not needed.
* [ ] This PR has passed all of the test cases on `Nodejs` and `Chrome Browser`.
* [ ] This PR has passed all of the test cases on `QT/QML`.
* [ ] This is an API breaking change.
* [ ] Requires a major version change.


### Issue Resolved / Feature Added
Updated Intl.DateTiemFormat Object-related test cases to use node's cldr version info instead of node version itself.
But, there are issue cases. Even though the CLDR version is the same, the results were different depending on node versions. In this case, I had to check the node version too.
i.e) node v12.22.7 and node v14.16.1
both node versions say the CLDR version is 37.0. but some test cases return different results.


### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

### Links
[//]: # (Related issues, references)
