### PR TITLE
Fixed to publish js apidoc with applying style properly

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -6,7 +6,7 @@ Build 026
 Published as version 14.16.1
 
 Bug Fixes:
-* Fixed to generate js apidoc with apply style properly.
+* Fixed to publish js apidoc with apply style properly.
 
 Build 025
 -------

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -1,6 +1,13 @@
 Release Notes for Version 14
 ============================
 
+Build 026
+-------
+Published as version 14.16.1
+
+Bug Fixes:
+* Fixed to generate js apidoc with apply style properly.
+
 Build 025
 -------
 Published as version 14.16.0

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -6,7 +6,7 @@ Build 026
 Published as version 14.16.1
 
 Bug Fixes:
-* Fixed to publish js apidoc with apply style properly.
+* Fixed to publish js apidoc with applying style properly.
 
 Build 025
 -------

--- a/js/build.xml
+++ b/js/build.xml
@@ -860,7 +860,7 @@ limitations under the License.
         <mkdir dir="${build.apidocs}"/>
         <copy todir="${build.apidocs}">
             <fileset dir="${build.jsdoc}">
-                <include name="**/*.html"/>
+                <include name="**/*.*"/>
             </fileset>
         </copy>
     </target>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib",
-    "version": "14.16.0",
+    "version": "14.16.1",
     "main": "js/index.js",
     "description": "iLib is a cross-engine library of internationalization (i18n) classes written in pure JS",
     "keywords": [


### PR DESCRIPTION
### Checklist

* [ ] At least one test case is included for this feature or bug fix.
* [ ] `ReleaseNotes` has added or is not needed.
* [ ] This PR has passed all of the test cases on `Nodejs` and `Chrome Browser`.
* [ ] This PR has passed all of the test cases on `QT/QML`.
* [ ] This is an API breaking change.
* [ ] Requires a major version change.


### Issue Resolved / Feature Added
Fixed to publish js apidoc with applying style properly.
script/ and styles/ directories should be copied as well.
I found the style hasn't been applied properly. https://ilib-js.github.io/iLib/docs/api/jsdoc/index.html

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

### Links
[//]: # (Related issues, references)
