### PR TITLE
Add safety code to avoid Uncaught TypeErrors

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -8,6 +8,9 @@ New Features:
 
 Bug Fixes:
 * Removed docs/localeSpecDoc/ directory which is not maintained.
+* Added safety code to avoid Uncaught TypeError problems when accessing the
+  Intl object on a js engine that is modern enough to have an Intl object,
+  but not modern enough to have everything we need on that Intl object
 
 Build 027
 -------

--- a/js/lib/DateFmt.js
+++ b/js/lib/DateFmt.js
@@ -442,11 +442,14 @@ var DateFmt = function(options) {
             // one, use the hard-coded gregorian as the last resort
             this.calName = this.calName || this.locinfo.getCalendar() || "gregorian";
 
-            if(this.useIntl && typeof(Intl) !== 'undefined' && Intl.DateTimeFormat.supportedLocalesOf(this.locale.getSpec()).length > 0 &&
-            (this.locinfo.getDigitsStyle() === "western" && (!options.template) && this.calName === "gregorian")){
+            if (this.useIntl &&
+                    typeof(Intl) !== 'undefined' &&
+                    typeof(Intl.DateTimeFormat) !== 'undefined' &&
+                    Intl.DateTimeFormat.supportedLocalesOf(this.locale.getSpec()).length > 0 &&
+                    (this.locinfo.getDigitsStyle() === "western" && (!options.template) && this.calName === "gregorian")) {
                 var len = DateFmt.lenmap[this.length];
-                if(this.type === "date" &&
-                    ((this.dateComponents === "dmy" && len !== "full") || (this.dateComponents === "dmwy" && len === "full"))){
+                if (this.type === "date" &&
+                    ((this.dateComponents === "dmy" && len !== "full") || (this.dateComponents === "dmwy" && len === "full"))) {
                     this.IntlDateTimeObj = new Intl.DateTimeFormat(this.locale.getSpec(), {
                         dateStyle: len
                     });
@@ -661,7 +664,12 @@ DateFmt.getMeridiemsRange = function (options) {
  */
 
 DateFmt.isIntlDateTimeAvailable = function (locale) {
-    if(!locale || !ilib._global("Intl")) return false;
+    if (!locale ||
+            !ilib._global("Intl") ||
+            typeof(Intl.DateTimeFormat) === 'undefined' ||
+            typeof(Intl.DateTimeFormat.supportedLocalesOf) === 'undefined') {
+        return false;
+    }
     return (Intl.DateTimeFormat.supportedLocalesOf(locale).length > 0) ? true : false;
 };
 

--- a/js/lib/DateFmt.js
+++ b/js/lib/DateFmt.js
@@ -445,6 +445,7 @@ var DateFmt = function(options) {
             if (this.useIntl &&
                     typeof(Intl) !== 'undefined' &&
                     typeof(Intl.DateTimeFormat) !== 'undefined' &&
+                    typeof(Intl.DateTimeFormat.supportedLocalesOf) !== 'undefined' &&
                     Intl.DateTimeFormat.supportedLocalesOf(this.locale.getSpec()).length > 0 &&
                     (this.locinfo.getDigitsStyle() === "western" && (!options.template) && this.calName === "gregorian")) {
                 var len = DateFmt.lenmap[this.length];

--- a/js/lib/IString.js
+++ b/js/lib/IString.js
@@ -691,7 +691,9 @@ IString.prototype = {
             return false;
         }
 
-        if (typeof(Intl) !== 'undefined') {
+        if (typeof(Intl) !== 'undefined' &&
+                typeof(Intl.PluralRules) !== 'undefined' &&
+                typeof(Intl.PluralRules.supportedLocalesOf) !== 'undefined') {
             if (ilib._getPlatform() === 'nodejs') {
                 var version = process.versions["node"];
                 if (!version) return false;


### PR DESCRIPTION
- when trying to use the Intl object on js engines that are modern enough to have an Intl object, but not modern enough to support everything on the Intl object yet

### Checklist

* [ ] At least one test case is included for this feature or bug fix.
* [x] `ReleaseNotes` has added or is not needed.
* [x] This PR has passed all of the test cases on `Nodejs` and `Chrome Browser`.
* [ ] This PR has passed all of the test cases on `QT/QML`.
* [ ] This is an API breaking change.
* [ ] Requires a major version change.


### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

### Links
[//]: # (Related issues, references)
