### PR TITLE
Check webOS Platform with webOSSystem value

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -7,7 +7,7 @@ Published as version 14.20.0
 
 New Features:
 * Updated to CLDR v44.1 data
-* Updated to check the webOS Platform as `webOSSystem` value. The PalmSystem has been renamed.
+* Updated to detect the webOS Platform with `webOSSystem` value. The previous PalmSystem has been renamed.
 
 Bug Fixes:
 * Updated timezone info to 2023d

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -6,7 +6,8 @@ Build 029
 Published as version 14.20.0
 
 New Features:
-* Update to CLDR v44.1 data
+* Updated to CLDR v44.1 data
+* Updated to check the webOS Platform as `webOSSystem` value. The PalmSystem has been renamed.
 
 Bug Fixes:
 * Updated timezone info to 2023d
@@ -16,7 +17,7 @@ Build 028
 Published as version 14.19.0
 
 New Features:
-* Update to CLDR v43.1 data
+* Updated to CLDR v43.1 data
 * Added new `getCLDRVersion()` API to know the cldr version that the current version of ilib uses
 
 Bug Fixes:

--- a/js/lib/ilib.js
+++ b/js/lib/ilib.js
@@ -1,7 +1,7 @@
 /*
  * ilib.js - define the ilib name space
  *
- * Copyright © 2012-2021, JEDLSoft
+ * Copyright © 2012-2021, 2024 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -157,7 +157,7 @@ ilib._getPlatform = function () {
         } else if (typeof(Qt) !== 'undefined') {
             ilib._platform = "qt";
             ilib._cacheMerged = true; // qt is too slow, so we need to cache the already-merged locale data
-        } else if (typeof(PalmSystem) !== 'undefined') {
+        } else if ((typeof(PalmSystem) !== 'undefined') || (typeof(webOSSystem) !== 'undefined')) {
             ilib._platform = (typeof(window) !== 'undefined') ? "webos-webapp" : "webos";
         } else if (typeof(window) !== 'undefined') {
             ilib._platform = "browser";
@@ -391,6 +391,8 @@ ilib.getLocale = function () {
                     ilib.locale = parseLocale(PalmSystem.locales.UI);
                 } else if (typeof(PalmSystem.locale) !== 'undefined') {
                     ilib.locale = parseLocale(PalmSystem.locale);
+                } else if (typeof(webOSSystem.locale) !== 'undefined') {
+                    ilib.locale = parseLocale(webOSSystem.locale);
                 } else {
                     ilib.locale = undefined;
                 }
@@ -481,7 +483,8 @@ ilib.getTimeZone = function() {
             case 'webos-webapp':
             case 'webos':
                 // running in webkit on webOS
-                if (PalmSystem.timezone && PalmSystem.timezone.length > 0) {
+                if ((PalmSystem.timezone && PalmSystem.timezone.length > 0) ||
+                    (webOSSystem.timeZone && PalmSystem.timeZone.length > 0)) {
                     ilib.tz = PalmSystem.timezone;
                 }
                 break;


### PR DESCRIPTION
### Checklist

* [ ] At least one test case is included for this feature or bug fix.
* [ ] `ReleaseNotes` has added or is not needed.
* [ ] This PR has passed all of the test cases on `Nodejs` and `Chrome Browser`.
* [ ] This PR has passed all of the test cases on `QT/QML`.
* [ ] This is an API breaking change.
* [ ] Requires a major version change.


### Issue Resolved / Feature Added
Updated to detect the webOS Platform as webOSSystem value. The PalmSystem has been renamed to webOSSystem
Currently, we keep both webOSSystem and PalmSystem. but we don't know when the PalmSystem will disappear.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

### Links
[//]: # (Related issues, references)
