### PR TITLE
Fix wrong option name in DateFmt test files (timelength --> length)

### DIFF
--- a/js/test/date/testdatefmt_af_NA.js
+++ b/js/test/date/testdatefmt_af_NA.js
@@ -368,7 +368,7 @@ module.exports.testdatefmt_af_NA = {
     },
     testDateFmtSimpleTimeLong_af_NA: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "af-NA", calendar: "gregorian", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "af-NA", calendar: "gregorian", length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_af_ZA.js
+++ b/js/test/date/testdatefmt_af_ZA.js
@@ -368,7 +368,7 @@ module.exports.testdatefmt_af_ZA = {
     },
     testDateFmtSimpleTimeLong_af_ZA: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "af-ZA", calendar: "gregorian", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "af-ZA", calendar: "gregorian", length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_am_ET.js
+++ b/js/test/date/testdatefmt_am_ET.js
@@ -152,7 +152,7 @@ module.exports.testdatefmt_am_ET = {
     },
     testDateFmtSimpleTimeLong_am_ET: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "am-ET", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "am-ET", length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new EthiopicDate({

--- a/js/test/date/testdatefmt_ar_EG.js
+++ b/js/test/date/testdatefmt_ar_EG.js
@@ -152,7 +152,7 @@ module.exports.testdatefmt_ar_EG = {
     },
     testDateFmtSimpleTimeLong_ar_EG: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "ar-EG", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "ar-EG", length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({
@@ -1943,7 +1943,7 @@ module.exports.testdatefmt_ar_EG = {
     },
     testDateFmtNativeSimpleTimeLong_ar_EG: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "ar-EG", useNative: false,  timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "ar-EG", useNative: false,  length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_ar_SA.js
+++ b/js/test/date/testdatefmt_ar_SA.js
@@ -147,7 +147,7 @@ module.exports.testdatefmt_ar_SA = {
     },
     testDateFmtSimpleTimeLong_ar_SA: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "ar-SA", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "ar-SA", length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({
@@ -1812,7 +1812,7 @@ module.exports.testdatefmt_ar_SA = {
     },
     testDateFmtNativeSimpleTimeLong_ar_SA: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "ar-SA", useNative: false,  timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "ar-SA", useNative: false,  length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_as_IN.js
+++ b/js/test/date/testdatefmt_as_IN.js
@@ -169,7 +169,7 @@ module.exports.testdatefmt_as_IN = {
     },
     testDateFmtINSimpleTimeLong_as_IN: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "as-IN", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "as-IN", length: "long", type: "time"});
         test.ok(typeof(fmt) !== "undefined");
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_az_Latn_AZ.js
+++ b/js/test/date/testdatefmt_az_Latn_AZ.js
@@ -198,7 +198,7 @@ module.exports.testdatefmt_az_Latn_AZ = {
     },
     testDateFmtSimpleTimeLong_az_Latn_AZ: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "az-Latn-AZ", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "az-Latn-AZ", length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_be_BY.js
+++ b/js/test/date/testdatefmt_be_BY.js
@@ -152,7 +152,7 @@ module.exports.testdatefmt_be_BY = {
     },
     testDateFmtSimpleTimeLong_be_BY: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "be-BY", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "be-BY", length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_bg.js
+++ b/js/test/date/testdatefmt_bg.js
@@ -152,7 +152,7 @@ module.exports.testdatefmt_bg = {
     },
     testDateFmtSimpleTimeLong_bg_BG: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "bg-BG", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "bg-BG", length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_bn_IN.js
+++ b/js/test/date/testdatefmt_bn_IN.js
@@ -169,7 +169,7 @@ module.exports.testdatefmt_bn_IN = {
     },
     testDateFmtINSimpleTimeLong_bn_IN: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "bn-IN", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "bn-IN", length: "long", type: "time"});
         test.ok(typeof(fmt) !== "undefined");
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_bs_Cyrl_BA.js
+++ b/js/test/date/testdatefmt_bs_Cyrl_BA.js
@@ -152,7 +152,7 @@ module.exports.testdatefmt_bs_Cyrl_BA = {
     },
     testDateFmtSimpleTimeLong_bs_Cyrl_BA: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "bs-Cyrl-BA", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "bs-Cyrl-BA", length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_bs_Latn_BA.js
+++ b/js/test/date/testdatefmt_bs_Latn_BA.js
@@ -153,7 +153,7 @@ module.exports.testdatefmt_bs_Latn_BA = {
     },
     testDateFmtSimpleTimeLong_bs_Latn_BA: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "bs-Latn-BA", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "bs-Latn-BA", length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_ca.js
+++ b/js/test/date/testdatefmt_ca.js
@@ -153,7 +153,7 @@ module.exports.testdatefmt_ca = {
     },
     testDateFmtSimpleTimeLong_ca_AD: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "ca-AD", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "ca-AD", length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({
@@ -1828,7 +1828,7 @@ module.exports.testdatefmt_ca = {
     },
     testDateFmtSimpleTimeLong_ca_ES: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "ca-ES", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "ca-ES", length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_cop_EG.js
+++ b/js/test/date/testdatefmt_cop_EG.js
@@ -154,7 +154,7 @@ module.exports.testdatefmt_cop_EG = {
     },
     testDateFmtSimpleTimeLong_cop_EG: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "cop-EG", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "cop-EG", length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new CopticDate({

--- a/js/test/date/testdatefmt_cs_CZ.js
+++ b/js/test/date/testdatefmt_cs_CZ.js
@@ -152,7 +152,7 @@ module.exports.testdatefmt_cs_CZ = {
     },
     testDateFmtSimpleTimeLong_cs_CZ: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "cs-CZ", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "cs-CZ", length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_da_DK.js
+++ b/js/test/date/testdatefmt_da_DK.js
@@ -152,7 +152,7 @@ module.exports.testdatefmt_da_DK = {
     },
     testDateFmtDADKSimpleTimeLong: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "da-DK", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "da-DK", length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_de_DE.js
+++ b/js/test/date/testdatefmt_de_DE.js
@@ -152,7 +152,7 @@ module.exports.testdatefmt_de_DE = {
     },
     testDateFmtSimpleTimeLong_de_DE: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "de-DE", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "de-DE", length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_el_GR.js
+++ b/js/test/date/testdatefmt_el_GR.js
@@ -152,7 +152,7 @@ module.exports.testdatefmt_el_GR = {
     },
     testDateFmtSimpleTimeLong_el_GR: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "el-GR", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "el-GR", length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_en_CA.js
+++ b/js/test/date/testdatefmt_en_CA.js
@@ -152,7 +152,7 @@ module.exports.testdatefmt_en_CA = {
     },
     testDateFmtenCASimpleTimeLong: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "en-CA", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "en-CA", length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_en_GB.js
+++ b/js/test/date/testdatefmt_en_GB.js
@@ -344,7 +344,7 @@ module.exports.testdatefmt_en_GB = {
     },
     testDateFmtGBSimpleTimeLong: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "en-GB", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "en-GB", length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_en_IN.js
+++ b/js/test/date/testdatefmt_en_IN.js
@@ -151,7 +151,7 @@ module.exports.testdatefmt_en_IN = {
     },
     testDateFmtINSimpleTimeLong: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "en-IN", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "en-IN", length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_en_US.js
+++ b/js/test/date/testdatefmt_en_US.js
@@ -152,7 +152,7 @@ module.exports.testdatefmt_en_US = {
     },
     testDateFmtUSSimpleTimeLong: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({timelength: "long", type: "time"});
+        var fmt = new DateFmt({length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_es_CO.js
+++ b/js/test/date/testdatefmt_es_CO.js
@@ -152,7 +152,7 @@ module.exports.testdatefmt_es_CO = {
     },
     testDateFmtSimpleTimeLong_es_CO: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "es-CO", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "es-CO", length: "long", type: "time"});
         test.ok(fmt !== null);
     
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_es_ES.js
+++ b/js/test/date/testdatefmt_es_ES.js
@@ -152,7 +152,7 @@ module.exports.testdatefmt_es_ES = {
     },
     testDateFmtSimpleTimeLong_es_ES: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "es-ES", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "es-ES", length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_et_EE.js
+++ b/js/test/date/testdatefmt_et_EE.js
@@ -152,7 +152,7 @@ module.exports.testdatefmt_et_EE = {
     },
     testDateFmtSimpleTimeLong_et_EE: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "et-EE", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "et-EE", length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_eu_ES.js
+++ b/js/test/date/testdatefmt_eu_ES.js
@@ -152,7 +152,7 @@ module.exports.testdatefmt_eu_ES = {
     },
     testDateFmtSimpleTimeLong_eu_ES: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "eu-ES", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "eu-ES", length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_fa_IR.js
+++ b/js/test/date/testdatefmt_fa_IR.js
@@ -179,7 +179,7 @@ module.exports.testdatefmt_fa_IR = {
         var fmt = new DateFmt({
             locale: "fa-IR",
             calendar: "gregorian",
-            timelength: "long",
+            length: "long",
             type: "time"
         });
         test.ok(fmt !== null);
@@ -2117,7 +2117,7 @@ module.exports.testdatefmt_fa_IR = {
         var fmt = new DateFmt({
             calendar: "persian",
             locale: "fa-IR",
-            timelength: "long",
+            length: "long",
             type: "time"
         });
         test.ok(fmt !== null);

--- a/js/test/date/testdatefmt_fi_FI.js
+++ b/js/test/date/testdatefmt_fi_FI.js
@@ -152,7 +152,7 @@ module.exports.testdatefmt_fi_FI = {
     },
     testDateFmtSimpleTimeLong_fi_FI: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "fi-FI", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "fi-FI", length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_fr_CA.js
+++ b/js/test/date/testdatefmt_fr_CA.js
@@ -152,7 +152,7 @@ module.exports.testdatefmt_fr_CA = {
     },
     testDateFmtfrCASimpleTimeLong: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "fr-CA", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "fr-CA", length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_fr_FR.js
+++ b/js/test/date/testdatefmt_fr_FR.js
@@ -152,7 +152,7 @@ module.exports.testdatefmt_fr_FR = {
     },
     testDateFmtSimpleTimeLong_fr_FR: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "fr-FR", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "fr-FR", length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_ga_IE.js
+++ b/js/test/date/testdatefmt_ga_IE.js
@@ -152,7 +152,7 @@ module.exports.testdatefmt_ga_IE = {
     },
     testDateFmtSimpleTimeLong_ga_IE: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "ga-IE", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "ga-IE", length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_gl_ES.js
+++ b/js/test/date/testdatefmt_gl_ES.js
@@ -152,7 +152,7 @@ module.exports.testdatefmt_gl_ES = {
     },
     testDateFmtSimpleTimeLong_gl_ES: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "gl-ES", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "gl-ES", length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_gu_IN.js
+++ b/js/test/date/testdatefmt_gu_IN.js
@@ -169,7 +169,7 @@ module.exports.testdatefmt_gu_IN = {
     },
     testDateFmtINSimpleTimeLong_gu_IN: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "gu-IN", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "gu-IN", length: "long", type: "time"});
         test.ok(typeof(fmt) !== "undefined");
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_ha_Latn_NG.js
+++ b/js/test/date/testdatefmt_ha_Latn_NG.js
@@ -368,7 +368,7 @@ module.exports.testdatefmt_ha_Latn_NG = {
     },
     testDateFmtSimpleTimeLong_ha_Latn: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "ha-Latn-NG", calendar: "gregorian", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "ha-Latn-NG", calendar: "gregorian", length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_he_IL.js
+++ b/js/test/date/testdatefmt_he_IL.js
@@ -145,7 +145,7 @@ module.exports.testdatefmt_he_IL = {
     },
     testDateFmtSimpleTimeLong_he_IL: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "he-IL", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "he-IL", length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_hi_IN.js
+++ b/js/test/date/testdatefmt_hi_IN.js
@@ -169,7 +169,7 @@ module.exports.testdatefmt_hi_IN = {
     },
     testDateFmtINSimpleTimeLong_hi_IN: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "hi-IN", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "hi-IN", length: "long", type: "time"});
         test.ok(typeof(fmt) !== "undefined");
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_hr_HR.js
+++ b/js/test/date/testdatefmt_hr_HR.js
@@ -152,7 +152,7 @@ module.exports.testdatefmt_hr_HR = {
     },
     testDateFmtSimpgodinaimeLong_hr_HR: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "hr-HR", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "hr-HR", length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_hy_AM.js
+++ b/js/test/date/testdatefmt_hy_AM.js
@@ -152,7 +152,7 @@ module.exports.testdatefmt_hy_AM = {
     },
     testDateFmtSimpleTimeLong_hy_AM: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "hy-AM", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "hy-AM", length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_id_ID.js
+++ b/js/test/date/testdatefmt_id_ID.js
@@ -152,7 +152,7 @@ module.exports.testdatefmt_id_ID = {
     },
     testDateFmtSimpleTimeLong_id_ID: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "id-ID", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "id-ID", length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_ig_NG.js
+++ b/js/test/date/testdatefmt_ig_NG.js
@@ -152,7 +152,7 @@ module.exports.testdatefmt_ig_NG = {
     },
     testDateFmtSimpleTimeLong_ig_NG: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "ig-NG", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "ig-NG", length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_it_IT.js
+++ b/js/test/date/testdatefmt_it_IT.js
@@ -152,7 +152,7 @@ module.exports.testdatefmt_it_IT = {
     },
     testDateFmtSimpleTimeLong_it_IT: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "it-IT", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "it-IT", length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_ja_JP.js
+++ b/js/test/date/testdatefmt_ja_JP.js
@@ -152,7 +152,7 @@ module.exports.testdatefmt_ja_JP = {
     },
     testDateFmtSimpleTimeLong_ja_JP: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "ja-JP", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "ja-JP", length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_ka_GE.js
+++ b/js/test/date/testdatefmt_ka_GE.js
@@ -152,7 +152,7 @@ module.exports.testdatefmt_ka_GE = {
     },
     testDateFmtSimpleTimeLong_ka_GE: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "ka-GE", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "ka-GE", length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_kk_Cyrl_KZ.js
+++ b/js/test/date/testdatefmt_kk_Cyrl_KZ.js
@@ -152,7 +152,7 @@ module.exports.testdatefmt_kk_Cyrl_KZ = {
     },
     testDateFmtSimpleTimeLong_kk_Cyrl_KZ: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "kk-Cyrl-KZ", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "kk-Cyrl-KZ", length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_km_KH.js
+++ b/js/test/date/testdatefmt_km_KH.js
@@ -153,7 +153,7 @@ module.exports.testdatefmt_km_KH = {
     },
     testDateFmtSimpleTimeLong_km_KH: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "km-KH", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "km-KH", length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_kn_IN.js
+++ b/js/test/date/testdatefmt_kn_IN.js
@@ -169,7 +169,7 @@ module.exports.testdatefmt_kn_IN = {
     },
     testDateFmtINSimpleTimeLong_kn_IN: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "kn-IN", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "kn-IN", length: "long", type: "time"});
         test.ok(typeof(fmt) !== "undefined");
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_ko_KR.js
+++ b/js/test/date/testdatefmt_ko_KR.js
@@ -320,7 +320,7 @@ module.exports.testdatefmt_ko_KR = {
     },
     testDateFmtSimpleTimeLong_ko_KR: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "ko-KR", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "ko-KR", length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_ku_Arab_IQ.js
+++ b/js/test/date/testdatefmt_ku_Arab_IQ.js
@@ -145,7 +145,7 @@ module.exports.testdatefmt_ku_Arab_IQ = {
     },
     testDateFmtSimpleTimeLong_ku_Arab_IQ: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "ku-Arab-IQ", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "ku-Arab-IQ", length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_ky_KG.js
+++ b/js/test/date/testdatefmt_ky_KG.js
@@ -152,7 +152,7 @@ module.exports.testdatefmt_ky_KG = {
     },
     testDateFmtSimpleTimeLong_ky_KG: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "ky-KG", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "ky-KG", length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_lb_LU.js
+++ b/js/test/date/testdatefmt_lb_LU.js
@@ -152,7 +152,7 @@ module.exports.testdatefmt_lb_LU = {
     },
     testDateFmtSimpleTimeLong_lb_LU: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "lb-LU", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "lb-LU", length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_lo_LA.js
+++ b/js/test/date/testdatefmt_lo_LA.js
@@ -152,7 +152,7 @@ module.exports.testdatefmt_lo_LA = {
     },
     testDateFmtSimpleTimeLong_lo_LA: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "lo-LA", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "lo-LA", length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_lt_LT.js
+++ b/js/test/date/testdatefmt_lt_LT.js
@@ -152,7 +152,7 @@ module.exports.testdatefmt_lt_LT = {
     },
     testDateFmtSimpleTimeLong_lt_LT: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "lt-LT", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "lt-LT", length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_lv_LV.js
+++ b/js/test/date/testdatefmt_lv_LV.js
@@ -152,7 +152,7 @@ module.exports.testdatefmt_lv_LV = {
     },
     testDateFmtSimpleTimeLong_lv_LV: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "lv-LV", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "lv-LV", length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_mk_MK.js
+++ b/js/test/date/testdatefmt_mk_MK.js
@@ -152,7 +152,7 @@ module.exports.testdatefmt_mk_MK = {
     },
     testDateFmtSimpleTimeLong_mk_MK: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "mk-MK", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "mk-MK", length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_ml_IN.js
+++ b/js/test/date/testdatefmt_ml_IN.js
@@ -168,7 +168,7 @@ module.exports.testdatefmt_ml_IN = {
     },
     testDateFmtINSimpleTimeLong_ml_IN: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "ml-IN", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "ml-IN", length: "long", type: "time"});
         test.ok(typeof(fmt) !== "undefined");
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_mn_Cyrl_MN.js
+++ b/js/test/date/testdatefmt_mn_Cyrl_MN.js
@@ -152,7 +152,7 @@ module.exports.testdatefmt_mn_Cyrl_MN = {
     },
     testDateFmtSimpleTimeLong_mn_Cyrl_MN: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "mn-Cyrl-MN", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "mn-Cyrl-MN", length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_mr_IN.js
+++ b/js/test/date/testdatefmt_mr_IN.js
@@ -169,7 +169,7 @@ module.exports.testdatefmt_mr_IN = {
     },
     testDateFmtINSimpleTimeLong_mr_IN: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "mr-IN", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "mr-IN", length: "long", type: "time"});
         test.ok(typeof(fmt) !== "undefined");
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_ms_MY.js
+++ b/js/test/date/testdatefmt_ms_MY.js
@@ -145,7 +145,7 @@ module.exports.testdatefmt_ms_MY = {
     },
     testDateFmtSimpleTimeLong_ms_MY: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "ms-MY", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "ms-MY", length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_mt_MT.js
+++ b/js/test/date/testdatefmt_mt_MT.js
@@ -152,7 +152,7 @@ module.exports.testdatefmt_mt_MT = {
     },
     testDateFmtSimpleTimeLong_mt_MT: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "mt-MT", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "mt-MT", length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_my_MM.js
+++ b/js/test/date/testdatefmt_my_MM.js
@@ -152,7 +152,7 @@ module.exports.testdatefmt_my_MM = {
     },
     testDateFmtSimpleTimeLong_my_MM: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "my-MM", timelength: "long", type: "time", useNative: false});
+        var fmt = new DateFmt({locale: "my-MM", length: "long", type: "time", useNative: false});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_nb_NO.js
+++ b/js/test/date/testdatefmt_nb_NO.js
@@ -152,7 +152,7 @@ module.exports.testdatefmt_nb_NO = {
     },
     testDateFmtSimpleTimeLong_nb_NO: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "nb-NO", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "nb-NO", length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_ne_NP.js
+++ b/js/test/date/testdatefmt_ne_NP.js
@@ -152,7 +152,7 @@ module.exports.testdatefmt_ne_NP = {
     },
     testDateFmtSimpleTimeLong_ne_NP: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "ne-NP", timelength: "long", type: "time", useNative: false});
+        var fmt = new DateFmt({locale: "ne-NP", length: "long", type: "time", useNative: false});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_nl_NL.js
+++ b/js/test/date/testdatefmt_nl_NL.js
@@ -152,7 +152,7 @@ module.exports.testdatefmt_nl_NL = {
     },
     testDateFmtSimpleTimeLong_nl_NL: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "nl-NL", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "nl-NL", length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_or_IN.js
+++ b/js/test/date/testdatefmt_or_IN.js
@@ -169,7 +169,7 @@ module.exports.testdatefmt_or_IN = {
     },
     testDateFmtINSimpleTimeLong_or_IN: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "or-IN", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "or-IN", length: "long", type: "time"});
         test.ok(typeof(fmt) !== "undefined");
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_pa_IN.js
+++ b/js/test/date/testdatefmt_pa_IN.js
@@ -169,7 +169,7 @@ module.exports.testdatefmt_pa_IN = {
     },
     testDateFmtINSimpleTimeLong_pa_IN: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "pa-IN", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "pa-IN", length: "long", type: "time"});
         test.ok(typeof(fmt) !== "undefined");
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_pl_PL.js
+++ b/js/test/date/testdatefmt_pl_PL.js
@@ -151,7 +151,7 @@ module.exports.testdatefmt_pl_PL = {
     },
     testDateFmtPLSimpleTimeLong_pl_PL: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "pl-PL", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "pl-PL", length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_ps_AF.js
+++ b/js/test/date/testdatefmt_ps_AF.js
@@ -154,7 +154,7 @@ module.exports.testdatefmt_ps_AF = {
     },
     testDateFmtSimpleTimeLong_ps_AF: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "ps-AF", timelength: "long", type: "time", useNative: false});
+        var fmt = new DateFmt({locale: "ps-AF", length: "long", type: "time", useNative: false});
         test.ok(fmt !== null);
 
         var date = new PersianDate({

--- a/js/test/date/testdatefmt_ps_PK.js
+++ b/js/test/date/testdatefmt_ps_PK.js
@@ -152,7 +152,7 @@ module.exports.testdatefmt_ps_PK = {
     },
     testDateFmtSimpleTimeLong_ps_PK: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "ps-PK", timelength: "long", type: "time", useNative: false});
+        var fmt = new DateFmt({locale: "ps-PK", length: "long", type: "time", useNative: false});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_pt_BR.js
+++ b/js/test/date/testdatefmt_pt_BR.js
@@ -152,7 +152,7 @@ module.exports.testdatefmt_pt_BR = {
     },
     testDateFmtBRSimpleTimeLong: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "pt-BR", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "pt-BR", length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_ro_RO.js
+++ b/js/test/date/testdatefmt_ro_RO.js
@@ -152,7 +152,7 @@ module.exports.testdatefmt_ro_RO = {
     },
     testDateFmtSimpleTimeLong_ro_RO: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "ro-RO", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "ro-RO", length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_ru_RU.js
+++ b/js/test/date/testdatefmt_ru_RU.js
@@ -152,7 +152,7 @@ module.exports.testdatefmt_ru_RU = {
     },
     testDateFmtSimpleTimeLong_ru_RU: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "ru-RU", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "ru-RU", length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_si_LK.js
+++ b/js/test/date/testdatefmt_si_LK.js
@@ -153,7 +153,7 @@ module.exports.testdatefmt_si_LK = {
     },
     testDateFmtSimpleTimeLong_si_LK: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "si-LK", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "si-LK", length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_sk_SK.js
+++ b/js/test/date/testdatefmt_sk_SK.js
@@ -152,7 +152,7 @@ module.exports.testdatefmt_sk_SK = {
     },
     testDateFmtSimpleTimeLong_sk_SK: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "sk-SK", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "sk-SK", length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_sl_SI.js
+++ b/js/test/date/testdatefmt_sl_SI.js
@@ -152,7 +152,7 @@ module.exports.testdatefmt_sl_SI = {
     },
     testDateFmtSimpleTimeLong_sl_SI: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "sl-SI", calendar: "gregorian", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "sl-SI", calendar: "gregorian", length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_sq_AL.js
+++ b/js/test/date/testdatefmt_sq_AL.js
@@ -169,7 +169,7 @@ module.exports.testdatefmt_sq_AL = {
     },
     testDateFmtINSimpleTimeLong_sq_AL: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "sq-AL", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "sq-AL", length: "long", type: "time"});
         test.ok(typeof(fmt) !== "undefined");
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_sr_Latn_RS.js
+++ b/js/test/date/testdatefmt_sr_Latn_RS.js
@@ -152,7 +152,7 @@ module.exports.testdatefmt_sr_Latn_RS = {
     },
     testDateFmtSimpleTimeLong_sr_Latn_RS: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "sr-Latn-RS", calendar: "gregorian", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "sr-Latn-RS", calendar: "gregorian", length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_sv_SE.js
+++ b/js/test/date/testdatefmt_sv_SE.js
@@ -152,7 +152,7 @@ module.exports.testdatefmt_sv_SE = {
     },
     testDateFmtSimpleTimeLong_sv_SE: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "sv-SE", calendar: "gregorian", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "sv-SE", calendar: "gregorian", length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_sw_KE.js
+++ b/js/test/date/testdatefmt_sw_KE.js
@@ -153,7 +153,7 @@ module.exports.testdatefmt_sw_KE = {
     },
     testDateFmtSimpleTimeLong_sw_KE: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "sw-Latn-KE", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "sw-Latn-KE", length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_ta_IN.js
+++ b/js/test/date/testdatefmt_ta_IN.js
@@ -170,7 +170,7 @@ module.exports.testdatefmt_ta_IN = {
     },
     testDateFmtINSimpleTimeLong_ta_IN: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "ta-IN", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "ta-IN", length: "long", type: "time"});
         test.ok(typeof(fmt) !== "undefined");
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_te_IN.js
+++ b/js/test/date/testdatefmt_te_IN.js
@@ -169,7 +169,7 @@ module.exports.testdatefmt_te_IN = {
     },
     testDateFmtINSimpleTimeLong_te_IN: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "te-IN", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "te-IN", length: "long", type: "time"});
         test.ok(typeof(fmt) !== "undefined");
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_tg_TJ.js
+++ b/js/test/date/testdatefmt_tg_TJ.js
@@ -152,7 +152,7 @@ module.exports.testdatefmt_tg_TJ = {
     },
     testDateFmtSimpleTimeLong_tg_TJ: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "tg-TJ", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "tg-TJ", length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_th_TH.js
+++ b/js/test/date/testdatefmt_th_TH.js
@@ -152,7 +152,7 @@ module.exports.testdatefmt_th_TH = {
     },
     testDateFmtSimpleTimeLong_th_TH: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "th-TH", calendar: "thaisolar", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "th-TH", calendar: "thaisolar", length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new ThaiSolarDate({

--- a/js/test/date/testdatefmt_tk_TM.js
+++ b/js/test/date/testdatefmt_tk_TM.js
@@ -152,7 +152,7 @@ module.exports.testdatefmt_tk_TM = {
     },
     testDateFmtSimpleTimeLong_tk_TM: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "tk-TM", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "tk-TM", length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_tr_TR.js
+++ b/js/test/date/testdatefmt_tr_TR.js
@@ -153,7 +153,7 @@ module.exports.testdatefmt_tr_TR = {
     },
     testDateFmtSimpleTimeLong_tr_TR: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "tr-TR", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "tr-TR", length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_uk_UA.js
+++ b/js/test/date/testdatefmt_uk_UA.js
@@ -153,7 +153,7 @@ module.exports.testdatefmt_uk_UA = {
     },
     testDateFmtSimpleTimeLong_uk_UA: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "uk-UA", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "uk-UA", length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_ur_IN.js
+++ b/js/test/date/testdatefmt_ur_IN.js
@@ -169,7 +169,7 @@ module.exports.testdatefmt_ur_IN = {
     },
     testDateFmtINSimpleTimeLong_ur_IN: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "ur-IN", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "ur-IN", length: "long", type: "time"});
         test.ok(typeof(fmt) !== "undefined");
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_uz_Cyrl_UZ.js
+++ b/js/test/date/testdatefmt_uz_Cyrl_UZ.js
@@ -152,7 +152,7 @@ module.exports.testdatefmt_uz_Cyrl_UZ = {
     },
     testDateFmtSimpleTimeLong_uz_Cyrl_UZ: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "uz-Cyrl-UZ", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "uz-Cyrl-UZ", length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_uz_Latn_UZ.js
+++ b/js/test/date/testdatefmt_uz_Latn_UZ.js
@@ -152,7 +152,7 @@ module.exports.testdatefmt_uz_Latn_UZ = {
     },
     testDateFmtSimpleTimeLong_uz_Latn_UZ: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "uz-Latn-UZ", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "uz-Latn-UZ", length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_vi_VN.js
+++ b/js/test/date/testdatefmt_vi_VN.js
@@ -224,7 +224,7 @@ module.exports.testdatefmt_vi_VN = {
     },
     testDateFmtSimpleTimeLong_vi_VN: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "vi-VN", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "vi-VN", length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_wo_SN.js
+++ b/js/test/date/testdatefmt_wo_SN.js
@@ -152,7 +152,7 @@ module.exports.testdatefmt_wo_SN = {
     },
     testDateFmtSimpleTimeLong_wo_SN: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "wo-SN", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "wo-SN", length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_yo_BJ.js
+++ b/js/test/date/testdatefmt_yo_BJ.js
@@ -152,7 +152,7 @@ module.exports.testdatefmt_yo_BJ = {
     },
     testDateFmtSimpleTimeLong_yo_BJ: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "yo-BJ", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "yo-BJ", length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_yo_NG.js
+++ b/js/test/date/testdatefmt_yo_NG.js
@@ -152,7 +152,7 @@ module.exports.testdatefmt_yo_NG = {
     },
     testDateFmtSimpleTimeLong_yo_NG: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "yo-NG", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "yo-NG", length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_zh_CN.js
+++ b/js/test/date/testdatefmt_zh_CN.js
@@ -152,7 +152,7 @@ module.exports.testdatefmt_zh_CN = {
     },
     testDateFmtSimpleTimeLong_zh_Hans_CN: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "zh-Hans-CN", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "zh-Hans-CN", length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_zh_Hant_HK.js
+++ b/js/test/date/testdatefmt_zh_Hant_HK.js
@@ -152,7 +152,7 @@ module.exports.testdatefmt_zh_Hant_HK = {
     },
     testDateFmtSimpleTimeLong_zh_Hant_HK: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "zh-Hant-HK", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "zh-Hant-HK", length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_zh_Hant_TW.js
+++ b/js/test/date/testdatefmt_zh_Hant_TW.js
@@ -152,7 +152,7 @@ module.exports.testdatefmt_zh_Hant_TW = {
     },
     testDateFmtSimpleTimeLong_zh_Hant_TW: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "zh-Hant-TW", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "zh-Hant-TW", length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({

--- a/js/test/date/testdatefmt_zu_ZA.js
+++ b/js/test/date/testdatefmt_zu_ZA.js
@@ -152,7 +152,7 @@ module.exports.testdatefmt_zu_ZA = {
     },
     testDateFmtSimpleTimeLong_zu_ZA: function(test) {
         test.expect(2);
-        var fmt = new DateFmt({locale: "zu-ZA", timelength: "long", type: "time"});
+        var fmt = new DateFmt({locale: "zu-ZA", length: "long", type: "time"});
         test.ok(fmt !== null);
 
         var date = new GregorianDate({


### PR DESCRIPTION
### Checklist

* [ ] At least one test case is included for this feature or bug fix.
* [ ] `ReleaseNotes` has added or is not needed.
* [ ] This PR has passed all of the test cases on `Nodejs` and `Chrome Browser`.
* [ ] This PR has passed all of the test cases on `QT/QML`.
* [ ] This is an API breaking change.
* [ ] Requires a major version change.


### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

### Links
[//]: # (Related issues, references)
