### PR TITLE
Update config.yml to run the test on node v20

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,10 +75,12 @@ workflows:
       - test:
           docker_image: cimg/node:12.22.12-browsers
       - test:
-          docker_image: cimg/node:14.21.2-browsers
+          docker_image: cimg/node:14.21.3-browsers
       - test:
-          docker_image: cimg/node:16.19.0-browsers
+          docker_image: cimg/node:16.20.2-browsers
       - test:
-          docker_image: cimg/node:18.14.0-browsers
+          docker_image: cimg/node:18.20.4-browsers
+      - test:
+          docker_image: cimg/node:20.15.1-browsers
       - test
 

--- a/js/test/date/testdatefmt_en_GB.js
+++ b/js/test/date/testdatefmt_en_GB.js
@@ -297,8 +297,10 @@ module.exports.testdatefmt_en_GB = {
                 } else {
                     test.equal(fmt.format(date), "Thursday, September 29, 2011");
                 }
-            } else {
+            } else if (cldrVersion < 44) {
                 test.equal(fmt.format(date), "Thursday, 29 September 2011");
+            } else {
+                test.equal(fmt.format(date), "Thursday 29 September 2011");
             }
         } else {
             test.equal(fmt.format(date), "Thursday, 29 September 2011");


### PR DESCRIPTION
### Checklist

* [ ] At least one test case is included for this feature or bug fix.
* [ ] `ReleaseNotes` has added or is not needed.
* [ ] This PR has passed all of the test cases on `Nodejs` and `Chrome Browser`.
* [ ] This PR has passed all of the test cases on `QT/QML`.
* [ ] This is an API breaking change.
* [ ] Requires a major version change.


### Issue Resolved / Feature Added
* Update `config.yml` to run the test on node v20 (The webOS has updated the node version to v20)
* Update the previous major version of the node to have the latest version
* Fixed bug in Relatest test (Intl object returns different results per cldr version)
    * node v18.14.0  has the cldr v42
    * node v18.20.4 has the cldr v44.1

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

### Links
[//]: # (Related issues, references)
https://nodejs.org/en/download/package-manager
https://circleci.com/developer/images/image/cimg/node