### PR TITLE
Add ko-TW locale to localematch.json

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -9,6 +9,8 @@ New Features:
 
 Bug Fixes:
 * Fix the CLDR tool code to correctly generate data by also adding a comparison for the U+202F(Narrow No-Break Space) case.
+* Add the missing `ko-TW` locale to the LocaleMatcher.
+
 
 Build 030
 -------

--- a/js/data/locale/localematch.json
+++ b/js/data/locale/localematch.json
@@ -9986,6 +9986,7 @@
         "ko-KP": "ko-Kore-KP",
         "ko-KR": "ko-Kore-KR",
         "ko-Kore": "ko-Kore-KR",
+        "ko-TW": "ko-Kore-TW",
         "ko-US": "ko-Kore-US",
         "koa": "koa-Latn-PG",
         "koa-Latn": "koa-Latn-PG",

--- a/js/test/root/testlocalematch.js
+++ b/js/test/root/testlocalematch.js
@@ -1711,6 +1711,17 @@ module.exports.testlocalematch = {
         test.equal(locale.getSpec(), "ko-Kore-US");
         test.done();
     },
+    testLocaleMatcherGetLikelyLocaleByLocaleCode_ko_TW: function(test) {
+        test.expect(3);
+        var lm = new LocaleMatcher({
+            locale: "ko-TW"
+        });
+        test.ok(typeof(lm) !== "undefined");
+        var locale = lm.getLikelyLocale();
+        test.ok(typeof(locale) !== "undefined");
+        test.equal(locale.getSpec(), "ko-Kore-TW");
+        test.done();
+    },
     testLocaleMatcherGetLikelyLocaleByLocaleCode_Hant_CN: function(test) {
         test.expect(3);
         var lm = new LocaleMatcher({

--- a/tools/cldr/genlikelyloc.js
+++ b/tools/cldr/genlikelyloc.js
@@ -2,7 +2,7 @@
  * genlikelyloc.js - ilib tool to generate the localematch.json files from
  * the CLDR data files
  *
- * Copyright © 2013-2020, 2022-2024 JEDLSoft
+ * Copyright © 2013-2020, 2022-2025 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -101,6 +101,7 @@ var hardCodedSubtags = {
     "hr-HU": "hr-Latn-HU",
     "ka-IR": "ka-Geor-IR",
     "ko-US": "ko-Kore-US",
+    "ko-TW": "ko-Kore-TW",
     "ku-IQ": "ku-Arab-IQ",
     "ps-PK": "ps-Arab-PK",
     "pt-MO": "pt-Latn-MO",


### PR DESCRIPTION
### Checklist

* [x] At least one test case is included for this feature or bug fix.
* [x] `ReleaseNotes` has added or is not needed.
* [ ] This PR has passed all of the test cases on `Nodejs` and `Chrome Browser`.
* [ ] This PR has passed all of the test cases on `QT/QML`.
* [ ] This is an API breaking change.
* [ ] Requires a major version change.


### Issue Resolved / Feature Added
Add `ko-TW` locale to localematch.json that is currently returning ko-Kore-KR instead of ko-Kore-TW
note) The ko-TW locale has recently been added to webOS as a valid locale from a localization perspective.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

### Links
[//]: # (Related issues, references)
