### PR TITLE
Rename duplicate test cases to avoid conflicts

### DIFF
--- a/js/test/number/testnumfmt_af.js
+++ b/js/test/number/testnumfmt_af.js
@@ -420,7 +420,7 @@ module.exports.testnumfmt_af = {
         test.equal(fmt.format(57.8), "57,8%");
         test.done();
     },
-    testNumFmtCurrencyFormatZADefault: function(test) {
+    testNumFmtCurrencyFormatZADefault1: function(test) {
         test.expect(2);
         var fmt = new NumFmt({
             type: "currency",
@@ -433,7 +433,7 @@ module.exports.testnumfmt_af = {
         test.equal(fmt.format(57.05), "R57,05");
         test.done();
     },
-    testNumFmtCurrencyFormatZADefault: function(test) {
+    testNumFmtCurrencyFormatZADefault23: function(test) {
         test.expect(2);
         var fmt = new NumFmt({
             type: "currency",
@@ -445,7 +445,7 @@ module.exports.testnumfmt_af = {
         test.equal(fmt.format(57.05), "R57.05");
         test.done();
     },
-    testNumFmtCurrencyFormatZADefault: function(test) {
+    testNumFmtCurrencyFormatZADefault3: function(test) {
         test.expect(2);
         var fmt = new NumFmt({
             type: "currency",
@@ -472,7 +472,7 @@ module.exports.testnumfmt_af = {
         test.equal(fmt.getMinFractionDigits(), 2);
         test.done();
     },
-    testNumFmtCurrencyFormatZADefault: function(test) {
+    testNumFmtCurrencyFormatZADefault4: function(test) {
         test.expect(2);
         var fmt = new NumFmt({
             type: "currency",
@@ -485,7 +485,7 @@ module.exports.testnumfmt_af = {
         test.equal(fmt.format(57), "R57,00");
         test.done();
     },
-    testNumFmtCurrencyFormatZADefault: function(test) {
+    testNumFmtCurrencyFormatZADefault5: function(test) {
         test.expect(2);
         var fmt = new NumFmt({
             type: "currency",
@@ -498,7 +498,7 @@ module.exports.testnumfmt_af = {
         test.equal(fmt.format(57.1), "R57,10");
         test.done();
     },
-    testNumFmtCurrencyFormatZADefault: function(test) {
+    testNumFmtCurrencyFormatZADefault6: function(test) {
         test.expect(2);
         var fmt = new NumFmt({
             type: "currency",
@@ -512,7 +512,7 @@ module.exports.testnumfmt_af = {
         test.equal(fmt.format(57.1), "R57,10000");
         test.done();
     },
-    testNumFmtCurrencyFormatZADefault: function(test) {
+    testNumFmtCurrencyFormatZADefault7: function(test) {
         test.expect(2);
         var fmt = new NumFmt({
             type: "currency",
@@ -523,10 +523,10 @@ module.exports.testnumfmt_af = {
 
         test.ok(fmt !== null);
 
-        test.equal(fmt.format(57.1), "ZAR57,10000");
+        test.equal(fmt.format(57.1), "ZAR57,10");
         test.done();
     },
-    testNumFmtCurrencyFormatZADefault: function(test) {
+    testNumFmtCurrencyFormatZADefault8: function(test) {
         test.expect(2);
         var fmt = new NumFmt({
             type: "currency",
@@ -943,7 +943,7 @@ module.exports.testnumfmt_af = {
         test.equal(fmt.format(57.8), "57,8%");
         test.done();
     },
-    testNumFmtCurrencyFormatNADefault: function(test) {
+    testNumFmtCurrencyFormatNADefault1: function(test) {
         test.expect(2);
         var fmt = new NumFmt({
             type: "currency",
@@ -953,10 +953,10 @@ module.exports.testnumfmt_af = {
 
         test.ok(fmt !== null);
 
-        test.equal(fmt.format(57.05), "$ 57,05");
+        test.equal(fmt.format(57.05), "$57,05");
         test.done();
     },
-    testNumFmtCurrencyFormatNADefault: function(test) {
+    testNumFmtCurrencyFormatNADefault2: function(test) {
         test.expect(2);
         var fmt = new NumFmt({
             type: "currency",
@@ -965,10 +965,10 @@ module.exports.testnumfmt_af = {
 
         test.ok(fmt !== null);
 
-        test.equal(fmt.format(57.05), "$ 57.05");
+        test.equal(fmt.format(57.05), "$57.05");
         test.done();
     },
-    testNumFmtCurrencyFormatNADefault: function(test) {
+    testNumFmtCurrencyFormatNADefault3: function(test) {
         test.expect(2);
         var fmt = new NumFmt({
             type: "currency",
@@ -978,7 +978,7 @@ module.exports.testnumfmt_af = {
 
         test.ok(fmt !== null);
 
-        test.equal(fmt.format(57.056), "$ 57,06");
+        test.equal(fmt.format(57.056), "$57,06");
         test.done();
     },
     testNumFmtCurrencyUseCorrectFractionDigitsForLocale: function(test) {
@@ -995,7 +995,7 @@ module.exports.testnumfmt_af = {
         test.equal(fmt.getMinFractionDigits(), 2);
         test.done();
     },
-    testNumFmtCurrencyFormatNADefault: function(test) {
+    testNumFmtCurrencyFormatNADefault4: function(test) {
         test.expect(2);
         var fmt = new NumFmt({
             type: "currency",
@@ -1005,10 +1005,10 @@ module.exports.testnumfmt_af = {
 
         test.ok(fmt !== null);
 
-        test.equal(fmt.format(57), "$ 57,00");
+        test.equal(fmt.format(57), "$57,00");
         test.done();
     },
-    testNumFmtCurrencyFormatNADefault: function(test) {
+    testNumFmtCurrencyFormatNADefault5: function(test) {
         test.expect(2);
         var fmt = new NumFmt({
             type: "currency",
@@ -1018,10 +1018,10 @@ module.exports.testnumfmt_af = {
 
         test.ok(fmt !== null);
 
-        test.equal(fmt.format(57.1), "$ 57,10");
+        test.equal(fmt.format(57.1), "$57,10");
         test.done();
     },
-    testNumFmtCurrencyFormatNADefault: function(test) {
+    testNumFmtCurrencyFormatNADefault6: function(test) {
         test.expect(2);
         var fmt = new NumFmt({
             type: "currency",
@@ -1032,10 +1032,10 @@ module.exports.testnumfmt_af = {
 
         test.ok(fmt !== null);
 
-        test.equal(fmt.format(57.1), "$ 57,10000");
+        test.equal(fmt.format(57.1), "$57,10000");
         test.done();
     },
-    testNumFmtCurrencyFormatNADefault: function(test) {
+    testNumFmtCurrencyFormatNADefault7: function(test) {
         test.expect(2);
         var fmt = new NumFmt({
             type: "currency",
@@ -1046,10 +1046,10 @@ module.exports.testnumfmt_af = {
 
         test.ok(fmt !== null);
 
-        test.equal(fmt.format(57.1), "NAD57,10000");
+        test.equal(fmt.format(57.1), "NAD57,10");
         test.done();
     },
-    testNumFmtCurrencyFormatNADefault: function(test) {
+    testNumFmtCurrencyFormatNADefault8: function(test) {
         test.expect(2);
         var fmt = new NumFmt({
             type: "currency",

--- a/js/test/number/testnumfmt_af.js
+++ b/js/test/number/testnumfmt_af.js
@@ -433,7 +433,7 @@ module.exports.testnumfmt_af = {
         test.equal(fmt.format(57.05), "R57,05");
         test.done();
     },
-    testNumFmtCurrencyFormatZADefault23: function(test) {
+    testNumFmtCurrencyFormatZADefault2: function(test) {
         test.expect(2);
         var fmt = new NumFmt({
             type: "currency",

--- a/js/test/number/testnumfmt_am.js
+++ b/js/test/number/testnumfmt_am.js
@@ -219,7 +219,7 @@ module.exports.testnumfmt_am = {
         test.equal(fmt.format(0.000001234567890123456), "1.234567890123456E-6");
         test.done();
     },
-    testNumFmtNumberETStyleScientificWithMinFractionDigits: function(test) {
+    testNumFmtNumberETStyleScientificWithMinFractionDigits1: function(test) {
         test.expect(2);
         var fmt = new NumFmt({
             locale: "am-ET",
@@ -232,7 +232,7 @@ module.exports.testnumfmt_am = {
         test.equal(fmt.format(12340000000000000000000000000.0), "1.23400E+28");
         test.done();
     },
-    testNumFmtNumberETStyleScientificWithMinFractionDigits: function(test) {
+    testNumFmtNumberETStyleScientificWithMinFractionDigits2: function(test) {
         test.expect(2);
         var fmt = new NumFmt({
             locale: "am-ET",
@@ -424,7 +424,7 @@ module.exports.testnumfmt_am = {
         test.equal(fmt.format(57.8), "57.8%");
         test.done();
     },
-    testNumFmtCurrencyFormatETDefault: function(test) {
+    testNumFmtCurrencyFormatETDefault1: function(test) {
         test.expect(2);
         var fmt = new NumFmt({
             type: "currency",
@@ -437,7 +437,7 @@ module.exports.testnumfmt_am = {
         test.equal(fmt.format(57.05), "Br57.05");
         test.done();
     },
-    testNumFmtCurrencyFormatETDefault: function(test) {
+    testNumFmtCurrencyFormatETDefault2: function(test) {
         test.expect(2);
         var fmt = new NumFmt({
             type: "currency",
@@ -449,7 +449,7 @@ module.exports.testnumfmt_am = {
         test.equal(fmt.format(57.05), "Br57.05");
         test.done();
     },
-    testNumFmtCurrencyFormatETDefault: function(test) {
+    testNumFmtCurrencyFormatETDefault3: function(test) {
         test.expect(2);
         var fmt = new NumFmt({
             type: "currency",
@@ -459,7 +459,7 @@ module.exports.testnumfmt_am = {
 
         test.ok(fmt !== null);
 
-        test.equal(fmt.format(57.056), "Br57,06");
+        test.equal(fmt.format(57.056), "Br57.06");
         test.done();
     },
     testNumFmtCurrencyUseCorrectFractionDigitsForLocale: function(test) {
@@ -476,7 +476,7 @@ module.exports.testnumfmt_am = {
         test.equal(fmt.getMinFractionDigits(), 2);
         test.done();
     },
-    testNumFmtCurrencyFormatETDefault: function(test) {
+    testNumFmtCurrencyFormatETDefault4: function(test) {
         test.expect(2);
         var fmt = new NumFmt({
             type: "currency",
@@ -486,10 +486,10 @@ module.exports.testnumfmt_am = {
 
         test.ok(fmt !== null);
 
-        test.equal(fmt.format(57), "Br57,00");
+        test.equal(fmt.format(57), "Br57.00");
         test.done();
     },
-    testNumFmtCurrencyFormatETDefault: function(test) {
+    testNumFmtCurrencyFormatETDefault5: function(test) {
         test.expect(2);
         var fmt = new NumFmt({
             type: "currency",
@@ -502,7 +502,7 @@ module.exports.testnumfmt_am = {
         test.equal(fmt.format(57.1), "Br57.10");
         test.done();
     },
-    testNumFmtCurrencyFormatETDefault: function(test) {
+    testNumFmtCurrencyFormatETDefault6: function(test) {
         test.expect(2);
         var fmt = new NumFmt({
             type: "currency",
@@ -513,10 +513,10 @@ module.exports.testnumfmt_am = {
 
         test.ok(fmt !== null);
 
-        test.equal(fmt.format(57.1), "BR57.10000");
+        test.equal(fmt.format(57.1), "Br57.10000");
         test.done();
     },
-    testNumFmtCurrencyFormatETDefault: function(test) {
+    testNumFmtCurrencyFormatETDefault7: function(test) {
         test.expect(2);
         var fmt = new NumFmt({
             type: "currency",
@@ -527,10 +527,10 @@ module.exports.testnumfmt_am = {
 
         test.ok(fmt !== null);
 
-        test.equal(fmt.format(57.1), "ETB57,10000");
+        test.equal(fmt.format(57.1), "ETB57.10");
         test.done();
     },
-    testNumFmtCurrencyFormatETDefault: function(test) {
+    testNumFmtCurrencyFormatETDefault8: function(test) {
         test.expect(2);
         var fmt = new NumFmt({
             type: "currency",


### PR DESCRIPTION
### Checklist

* [x] At least one test case is included for this feature or bug fix.
* [x] `ReleaseNotes` has added or is not needed.
* [x] This PR has passed all of the test cases on `Nodejs` and `Chrome Browser`.
* [x] This PR has passed all of the test cases on `QT/QML`.
* [x] This is an API breaking change.
* [x] Requires a major version change.


### Issue Resolved / Feature Added
Duplicate test names in `testnumfmt_af.js` and `testnumfmt_am.js`.
* testnumfmt_af.js
  * testNumFmtCurrencyFormatNADefault
  * testNumFmtCurrencyFormatZADefault
* testnumfmt_am.js
  * testNumFmtCurrencyFormatETDefault
  * testNumFmtNumberETStyleScientificWithMinFractionDigits

### Resolution
* Rename duplicate test cases
* Update expected values in renamed failing tests

### Links
[//]: # (Related issues, references)

