### PR TITLE
Add ko-CN locale to localematch.json

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,7 @@
 version: 2.1
 jobs:
   test:
+    resource_class: large
     parameters:
         docker_image:
           type: string

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,12 +32,11 @@ jobs:
 
       - run:
           name: Set up node packages
-          no_output_timeout: 30m
           command: |
             rm -rf node_modules package-lock.json
             echo "node version: " $(node -v)
             echo "npm version: " $(npm -v)
-            npm install --verbose
+            npm install
 
       - run:
           name: Check environment
@@ -53,10 +52,9 @@ jobs:
 
       - run:
           name: Running all unit tests
-          no_output_timeout: 30m
           command: |
             export PATH="$PWD/node_modules/.bin:$PATH"
-            ant -v clean test.travis
+            ant clean test.travis
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,11 +32,12 @@ jobs:
 
       - run:
           name: Set up node packages
+          no_output_timeout: 30m
           command: |
             rm -rf node_modules package-lock.json
             echo "node version: " $(node -v)
             echo "npm version: " $(npm -v)
-            npm install
+            npm install --verbose
 
       - run:
           name: Check environment
@@ -52,9 +53,10 @@ jobs:
 
       - run:
           name: Running all unit tests
+          no_output_timeout: 30m
           command: |
             export PATH="$PWD/node_modules/.bin:$PATH"
-            ant clean test.travis
+            ant -v clean test.travis
 
 workflows:
   version: 2

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ section about webpack for links.
 Copyright and License
 -------
 
-Copyright (c) 2011-2024, JEDLSoft
+Copyright (c) 2011-2026, JEDLSoft
 
 Ilib is licensed under the Apache License, Version 2.0 (the "License");
 you may not use this library except in compliance with the License.

--- a/build.properties
+++ b/build.properties
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version=14.21.2
+version=14.21.3

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -1,7 +1,17 @@
 Release Notes for Version 14
 ============================
 
-Build 031
+Build 033
+-------
+Published as version 14.21.3
+
+New Features:
+
+Bug Fixes:
+* Add the missing `ko-CN` locale to the LocaleMatcher.
+
+
+Build 032
 -------
 Published as version 14.21.2
 

--- a/js/data/locale/localematch.json
+++ b/js/data/locale/localematch.json
@@ -9981,6 +9981,7 @@
         "knz-BF": "knz-Latn-BF",
         "knz-Latn": "knz-Latn-BF",
         "ko": "ko-Kore-KR",
+        "ko-CN": "ko-Kore-CN",
         "ko-Hang": "ko-Hang-KR",
         "ko-Jamo": "ko-Jamo-KR",
         "ko-KP": "ko-Kore-KP",

--- a/js/lib/Locale.js
+++ b/js/lib/Locale.js
@@ -877,7 +877,7 @@ Locale._isRegionCode = function (str) {
 
 /**
  * Tell whether or not the given string has the correct syntax to be
- * an ISO 639 language code.
+ * an ISO 15924 script code.
  *
  * @private
  * @param {string} str the string to parse

--- a/js/test/root/testlocalematch.js
+++ b/js/test/root/testlocalematch.js
@@ -1,7 +1,7 @@
 /*
  * testlocalematch.js - test the locale matcher object
  *
- * Copyright © 2012-2015, 2017, 2019-2024 JEDLSoft
+ * Copyright © 2012-2015, 2017, 2019-2026 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1722,6 +1722,17 @@ module.exports.testlocalematch = {
         test.equal(locale.getSpec(), "ko-Kore-TW");
         test.done();
     },
+    testLocaleMatcherGetLikelyLocaleByLocaleCode_ko_CN: function(test) {
+        test.expect(3);
+        var lm = new LocaleMatcher({
+            locale: "ko-CN"
+        });
+        test.ok(typeof(lm) !== "undefined");
+        var locale = lm.getLikelyLocale();
+        test.ok(typeof(locale) !== "undefined");
+        test.equal(locale.getSpec(), "ko-Kore-CN");
+        test.done();
+    },
     testLocaleMatcherGetLikelyLocaleByLocaleCode_Hant_CN: function(test) {
         test.expect(3);
         var lm = new LocaleMatcher({
@@ -2809,6 +2820,17 @@ module.exports.testlocalematch = {
         var locale = lm.getLikelyLocaleMinimal();
         test.ok(typeof(locale) !== "undefined");
         test.equal(locale.getSpec(), "yo-NG");
+        test.done();
+    },
+    testLocaleMatcherGetLikelyLocaleMinimalNonDefaultLocale_ko_CN: function(test) {
+        test.expect(3);
+        var lm = new LocaleMatcher({
+            locale: "ko-CN"
+        });
+        test.ok(typeof(lm) !== "undefined");
+        var locale = lm.getLikelyLocaleMinimal();
+        test.ok(typeof(locale) !== "undefined");
+        test.equal(locale.getSpec(), "ko-CN");
         test.done();
     }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib",
-    "version": "14.21.2",
+    "version": "14.21.3",
     "main": "js/index.js",
     "engines": {
         "node": ">=8 <25"

--- a/tools/cldr/genlikelyloc.js
+++ b/tools/cldr/genlikelyloc.js
@@ -2,7 +2,7 @@
  * genlikelyloc.js - ilib tool to generate the localematch.json files from
  * the CLDR data files
  *
- * Copyright © 2013-2020, 2022-2025 JEDLSoft
+ * Copyright © 2013-2020, 2022-2026 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,7 +52,7 @@ process.argv.forEach(function (val, index, array) {
 localeDirName = process.argv[2] || "tmp";
 
 console.log("genlikelyloc - generate the localematch.json file.\n" +
-        "Copyright (c) 2013-2019, 2022-2024 JEDLSoft");
+        "Copyright (c) 2013-2019, 2022-2026 JEDLSoft");
 
 console.log("locale dir: " + localeDirName);
 
@@ -100,6 +100,7 @@ var hardCodedSubtags = {
     "en-KR": "en-Latn-KR",
     "hr-HU": "hr-Latn-HU",
     "ka-IR": "ka-Geor-IR",
+    "ko-CN": "ko-Kore-CN",
     "ko-US": "ko-Kore-US",
     "ko-TW": "ko-Kore-TW",
     "ku-IQ": "ku-Arab-IQ",


### PR DESCRIPTION
### Checklist

* [x] At least one test case is included for this feature or bug fix.
* [x] `ReleaseNotes` has added or is not needed.
* [ ] This PR has passed all of the test cases on `Nodejs` and `Chrome Browser`.
* [ ] This PR has passed all of the test cases on `QT/QML`.
* [ ] This is an API breaking change.
* [ ] Requires a major version change.


### Issue Resolved / Feature Added
Add ko-CN locale to localematch.json that is currently returning ko-Kore-KR instead of ko-Kore-CN
The same change is applied the ilib-localematcher as well. https://github.com/iLib-js/ilib-localematcher/pull/14
### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

### Links
[//]: # (Related issues, references)
