### PR TITLE
Remove tests for Node versions 8, 12, and 16 in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,15 +62,9 @@ workflows:
   test-all-node-versions:
     jobs:
       - test:
-          docker_image: cimg/node:8.17.0
-      - test:
           docker_image: cimg/node:10.24.1-browsers
       - test:
-          docker_image: cimg/node:12.22.12-browsers
-      - test:
           docker_image: cimg/node:14.21.3-browsers
-      - test:
-          docker_image: cimg/node:16.20.2-browsers
       - test:
           docker_image: cimg/node:18.20.4-browsers
       - test:


### PR DESCRIPTION
### Checklist

* [ ] At least one test case is included for this feature or bug fix.
* [ ] `ReleaseNotes` has added or is not needed.
* [ ] This PR has passed all of the test cases on `Nodejs` and `Chrome Browser`.
* [ ] This PR has passed all of the test cases on `QT/QML`.
* [ ] This is an API breaking change.
* [ ] Requires a major version change.


### Issue Resolved / Feature Added
Remove tests for Node versions 8, 12, and 16 in CircleCI
Reduce the number of Node images used for testing in CircleCI to save credits.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

### Links
[//]: # (Related issues, references)
