### PR TITLE
CLDR v48.2 Update - Scripts

### DIFF
--- a/js/data/locale/apc/scripts.jf
+++ b/js/data/locale/apc/scripts.jf
@@ -1,7 +1,6 @@
 {
     "generated": true,
     "scripts": [
-        "Cyrl",
-        "Latn"
+        "Arab"
     ]
 }

--- a/js/data/locale/apd/scripts.jf
+++ b/js/data/locale/apd/scripts.jf
@@ -1,7 +1,6 @@
 {
     "generated": true,
     "scripts": [
-        "Cyrl",
-        "Latn"
+        "Arab"
     ]
 }

--- a/js/data/locale/az/scripts.jf
+++ b/js/data/locale/az/scripts.jf
@@ -2,7 +2,7 @@
     "generated": true,
     "scripts": [
         "Latn",
-        "Cyrl",
-        "Arab"
+        "Arab",
+        "Cyrl"
     ]
 }

--- a/js/data/locale/bjt/scripts.jf
+++ b/js/data/locale/bjt/scripts.jf
@@ -1,7 +1,6 @@
 {
     "generated": true,
     "scripts": [
-        "Cyrl",
         "Latn"
     ]
 }

--- a/js/data/locale/bs/scripts.jf
+++ b/js/data/locale/bs/scripts.jf
@@ -1,7 +1,7 @@
 {
     "generated": true,
     "scripts": [
-        "Cyrl",
-        "Latn"
+        "Latn",
+        "Cyrl"
     ]
 }

--- a/js/data/locale/bsc/scripts.jf
+++ b/js/data/locale/bsc/scripts.jf
@@ -1,7 +1,6 @@
 {
     "generated": true,
     "scripts": [
-        "Cyrl",
         "Latn"
     ]
 }

--- a/js/data/locale/bsq/scripts.jf
+++ b/js/data/locale/bsq/scripts.jf
@@ -1,7 +1,7 @@
 {
     "generated": true,
     "scripts": [
-        "Cyrl",
-        "Latn"
+        "Latn",
+        "Bass"
     ]
 }

--- a/js/data/locale/ccp/scripts.jf
+++ b/js/data/locale/ccp/scripts.jf
@@ -1,7 +1,7 @@
 {
     "generated": true,
     "scripts": [
-        "Beng",
-        "Cakm"
+        "Cakm",
+        "Beng"
     ]
 }

--- a/js/data/locale/ccr/scripts.jf
+++ b/js/data/locale/ccr/scripts.jf
@@ -1,7 +1,6 @@
 {
     "generated": true,
     "scripts": [
-        "Cyrl",
         "Latn"
     ]
 }

--- a/js/data/locale/cop/scripts.jf
+++ b/js/data/locale/cop/scripts.jf
@@ -1,8 +1,8 @@
 {
     "generated": true,
     "scripts": [
-        "Arab",
         "Copt",
+        "Arab",
         "Grek"
     ]
 }

--- a/js/data/locale/ecy/scripts.jf
+++ b/js/data/locale/ecy/scripts.jf
@@ -1,7 +1,6 @@
 {
     "generated": true,
     "scripts": [
-        "Cyrl",
-        "Latn"
+        "Cprt"
     ]
 }

--- a/js/data/locale/gmy/scripts.jf
+++ b/js/data/locale/gmy/scripts.jf
@@ -1,7 +1,6 @@
 {
     "generated": true,
     "scripts": [
-        "Cyrl",
-        "Latn"
+        "Linb"
     ]
 }

--- a/js/data/locale/grc/scripts.jf
+++ b/js/data/locale/grc/scripts.jf
@@ -1,8 +1,6 @@
 {
     "generated": true,
     "scripts": [
-        "Cprt",
-        "Grek",
-        "Linb"
+        "Grek"
     ]
 }

--- a/js/data/locale/grr/scripts.jf
+++ b/js/data/locale/grr/scripts.jf
@@ -1,7 +1,7 @@
 {
     "generated": true,
     "scripts": [
-        "Cyrl",
-        "Latn"
+        "Arab",
+        "Tfng"
     ]
 }

--- a/js/data/locale/hak/scripts.jf
+++ b/js/data/locale/hak/scripts.jf
@@ -1,6 +1,7 @@
 {
     "generated": true,
     "scripts": [
-        "Hans"
+        "Hans",
+        "Hant"
     ]
 }

--- a/js/data/locale/io/scripts.jf
+++ b/js/data/locale/io/scripts.jf
@@ -1,7 +1,6 @@
 {
     "generated": true,
     "scripts": [
-        "Cyrl",
         "Latn"
     ]
 }

--- a/js/data/locale/jbo/scripts.jf
+++ b/js/data/locale/jbo/scripts.jf
@@ -1,7 +1,6 @@
 {
     "generated": true,
     "scripts": [
-        "Cyrl",
         "Latn"
     ]
 }

--- a/js/data/locale/kaw/scripts.jf
+++ b/js/data/locale/kaw/scripts.jf
@@ -1,7 +1,8 @@
 {
     "generated": true,
     "scripts": [
-        "Cyrl",
-        "Latn"
+        "Bali",
+        "Java",
+        "Kawi"
     ]
 }

--- a/js/data/locale/ken/scripts.jf
+++ b/js/data/locale/ken/scripts.jf
@@ -1,7 +1,6 @@
 {
     "generated": true,
     "scripts": [
-        "Cyrl",
         "Latn"
     ]
 }

--- a/js/data/locale/knf/scripts.jf
+++ b/js/data/locale/knf/scripts.jf
@@ -1,7 +1,6 @@
 {
     "generated": true,
     "scripts": [
-        "Cyrl",
         "Latn"
     ]
 }

--- a/js/data/locale/kro/scripts.jf
+++ b/js/data/locale/kro/scripts.jf
@@ -1,7 +1,6 @@
 {
     "generated": true,
     "scripts": [
-        "Cyrl",
         "Latn"
     ]
 }

--- a/js/data/locale/len/scripts.jf
+++ b/js/data/locale/len/scripts.jf
@@ -1,7 +1,6 @@
 {
     "generated": true,
     "scripts": [
-        "Cyrl",
         "Latn"
     ]
 }

--- a/js/data/locale/lfn/scripts.jf
+++ b/js/data/locale/lfn/scripts.jf
@@ -1,7 +1,7 @@
 {
     "generated": true,
     "scripts": [
-        "Cyrl",
-        "Latn"
+        "Latn",
+        "Cyrl"
     ]
 }

--- a/js/data/locale/lzh/scripts.jf
+++ b/js/data/locale/lzh/scripts.jf
@@ -1,6 +1,6 @@
 {
     "generated": true,
     "scripts": [
-        "Hans"
+        "Hant"
     ]
 }

--- a/js/data/locale/mey/scripts.jf
+++ b/js/data/locale/mey/scripts.jf
@@ -1,7 +1,7 @@
 {
     "generated": true,
     "scripts": [
-        "Cyrl",
+        "Arab",
         "Latn"
     ]
 }

--- a/js/data/locale/mfv/scripts.jf
+++ b/js/data/locale/mfv/scripts.jf
@@ -1,7 +1,6 @@
 {
     "generated": true,
     "scripts": [
-        "Cyrl",
         "Latn"
     ]
 }

--- a/js/data/locale/mww/scripts.jf
+++ b/js/data/locale/mww/scripts.jf
@@ -1,7 +1,7 @@
 {
     "generated": true,
     "scripts": [
-        "Cyrl",
-        "Latn"
+        "Latn",
+        "Hmnp"
     ]
 }

--- a/js/data/locale/mzb/scripts.jf
+++ b/js/data/locale/mzb/scripts.jf
@@ -1,7 +1,7 @@
 {
     "generated": true,
     "scripts": [
-        "Cyrl",
+        "Arab",
         "Latn"
     ]
 }

--- a/js/data/locale/nan/scripts.jf
+++ b/js/data/locale/nan/scripts.jf
@@ -1,6 +1,7 @@
 {
     "generated": true,
     "scripts": [
-        "Hans"
+        "Hans",
+        "Hant"
     ]
 }

--- a/js/data/locale/ojw/scripts.jf
+++ b/js/data/locale/ojw/scripts.jf
@@ -1,7 +1,6 @@
 {
     "generated": true,
     "scripts": [
-        "Cyrl",
         "Latn"
     ]
 }

--- a/js/data/locale/pi/scripts.jf
+++ b/js/data/locale/pi/scripts.jf
@@ -1,7 +1,9 @@
 {
     "generated": true,
     "scripts": [
+        "Latn",
         "Deva",
+        "Mymr",
         "Sinh",
         "Thai"
     ]

--- a/js/data/locale/ppl/scripts.jf
+++ b/js/data/locale/ppl/scripts.jf
@@ -1,7 +1,6 @@
 {
     "generated": true,
     "scripts": [
-        "Cyrl",
         "Latn"
     ]
 }

--- a/js/data/locale/sam/scripts.jf
+++ b/js/data/locale/sam/scripts.jf
@@ -1,7 +1,7 @@
 {
     "generated": true,
     "scripts": [
-        "Hebr",
-        "Samr"
+        "Samr",
+        "Hebr"
     ]
 }

--- a/js/data/locale/shi/scripts.jf
+++ b/js/data/locale/shi/scripts.jf
@@ -1,8 +1,8 @@
 {
     "generated": true,
     "scripts": [
-        "Arab",
+        "Tfng",
         "Latn",
-        "Tfng"
+        "Arab"
     ]
 }

--- a/js/data/locale/snf/scripts.jf
+++ b/js/data/locale/snf/scripts.jf
@@ -1,7 +1,6 @@
 {
     "generated": true,
     "scripts": [
-        "Cyrl",
         "Latn"
     ]
 }

--- a/js/data/locale/stu/scripts.jf
+++ b/js/data/locale/stu/scripts.jf
@@ -1,7 +1,7 @@
 {
     "generated": true,
     "scripts": [
-        "Cyrl",
-        "Latn"
+        "Lana",
+        "Tale"
     ]
 }

--- a/js/data/locale/suz/scripts.jf
+++ b/js/data/locale/suz/scripts.jf
@@ -1,7 +1,7 @@
 {
     "generated": true,
     "scripts": [
-        "Cyrl",
-        "Latn"
+        "Deva",
+        "Sunu"
     ]
 }

--- a/js/data/locale/tk/scripts.jf
+++ b/js/data/locale/tk/scripts.jf
@@ -2,7 +2,7 @@
     "generated": true,
     "scripts": [
         "Latn",
-        "Cyrl",
-        "Arab"
+        "Arab",
+        "Cyrl"
     ]
 }

--- a/js/data/locale/tnr/scripts.jf
+++ b/js/data/locale/tnr/scripts.jf
@@ -1,7 +1,6 @@
 {
     "generated": true,
     "scripts": [
-        "Cyrl",
         "Latn"
     ]
 }

--- a/js/data/locale/ttt/scripts.jf
+++ b/js/data/locale/ttt/scripts.jf
@@ -2,7 +2,7 @@
     "generated": true,
     "scripts": [
         "Latn",
-        "Cyrl",
-        "Arab"
+        "Arab",
+        "Cyrl"
     ]
 }

--- a/js/data/locale/vai/scripts.jf
+++ b/js/data/locale/vai/scripts.jf
@@ -1,7 +1,7 @@
 {
     "generated": true,
     "scripts": [
-        "Latn",
-        "Vaii"
+        "Vaii",
+        "Latn"
     ]
 }

--- a/js/data/locale/xum/scripts.jf
+++ b/js/data/locale/xum/scripts.jf
@@ -1,7 +1,7 @@
 {
     "generated": true,
     "scripts": [
-        "Ital",
-        "Latn"
+        "Latn",
+        "Ital"
     ]
 }

--- a/js/data/locale/yue/scripts.jf
+++ b/js/data/locale/yue/scripts.jf
@@ -1,7 +1,7 @@
 {
     "generated": true,
     "scripts": [
-        "Hans",
-        "Hant"
+        "Hant",
+        "Hans"
     ]
 }

--- a/tools/cldr/genlangscripts.js
+++ b/tools/cldr/genlangscripts.js
@@ -46,7 +46,7 @@ process.argv.forEach(function (val, index, array) {
 toDir = process.argv[2] || "tmp";
 
 console.log("genlangscripts - generate the localeinfo scripts.jf files.\n" +
-    "Copyright (c) 2013-2018, 2020-2022, 2024 JEDLSoft");
+    "Copyright (c) 2013-2018, 2020-2022, 2024, 2026 JEDLSoft");
 
 console.log("output dir: " + toDir);
 

--- a/tools/cldr/genlangscripts.js
+++ b/tools/cldr/genlangscripts.js
@@ -1,7 +1,7 @@
 /*
  * genlangscripts.js - ilib tool to generate the json data about ISO 15924 scripts
  *
- * Copyright © 2013-2018, 2020-2022, 2024 JEDLSoft
+ * Copyright © 2013-2018, 2020-2022, 2024, 2026 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -106,15 +106,7 @@ for (var language in scripts) {
         if (!fs.existsSync(filename)) {
             fs.mkdirSync(filename);
         }
-        // special cases where we disagree with CLDR
-        if (language === 'az' || language === 'ms' || language === 'kk' || language === 'pa'|| language === 'tk'|| language === 'ha' || language === 'uz') {
-            scripts[language] = scripts[language].reverse();
-        } else if (language == 'ky'|| language == 'tg') {
-            var lang = scripts[language];
-            var tmp = lang[0];
-            lang[0] = lang[1];
-            lang[1] = tmp;
-        }
+
         console.log(language + ':\t"scripts": ' + JSON.stringify(scripts[language]) + ',');
         scripts_name["scripts"] = scripts[language];
         scripts_name.generated = true;


### PR DESCRIPTION
### Checklist

* [x] At least one test case is included for this feature or bug fix.
* [x] `ReleaseNotes` has added or is not needed.
* [x] This PR has passed all of the test cases on `Nodejs` and `Chrome Browser`.
* [x] This PR has passed all of the test cases on `QT/QML`.
* [ ] This is an API breaking change.
* [ ] Requires a major version change.


### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
* Update generated `scripts.jf` data to CLDR v48.2 **except ku/scripts.jf**
* `genlangscripts.js`: Remove legacy hardcoded script-order exceptions in the generator.  
  * Those overrides are no longer needed because CLDR data now reflects the correct ordering.  

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

### Links
[//]: # (Related issues, references)
