### PR TITLE
Resolve paths in `assemble.mjs` from module dir 

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version=14.22.0
+version=14.22.i

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -1,6 +1,16 @@
 Release Notes for Version 14
 ============================
 
+Build 035
+-------
+
+New Features:
+
+
+Bug Fixes:
+* Fix path resolution in `assemble.mjs` from module directory
+
+
 Build 034
 -------
 Published as version 14.22.0

--- a/js/assembleData/assemble.mjs
+++ b/js/assembleData/assemble.mjs
@@ -27,18 +27,10 @@ const reDependentPattern = /require\(\s*["']\.*\/([^"']+\.js)["']\);/g;
 const reDataPattern = /\/\/\s*!data\s+([^\n\r]+)/g;
 const moduleDir = path.dirname(fileURLToPath(import.meta.url));
 const ilibRoot = path.resolve(moduleDir, '..', '..');
-const ilibLibPath = path.join(ilibRoot, 'js/lib');
-const ilibLocaleDataPath = path.join(ilibRoot, 'js/data/locale');
 
-function validateRequiredIlibPaths() {
-    if (!existsSync(ilibLibPath)) {
-        throw new Error(`iLib JS library directory not found: ${ilibLibPath}`);
-    }
-
-    if (!existsSync(ilibLocaleDataPath)) {
-        throw new Error(`iLib locale data directory not found: ${ilibLocaleDataPath}`);
-    }
-}
+// These can be overridden by options.opt?.ilibPath in assemble()
+let libPath = path.join(ilibRoot, 'js/lib');
+let localeDataPath = path.join(ilibRoot, 'js/data/locale');
 
 /**
  * Assembles locale JSON data by analyzing ilib JS files and merging
@@ -75,11 +67,23 @@ function validateRequiredIlibPaths() {
  * @returns {object} Merged JSON data map keyed by locale (or by sublocale path when splitByLocale is true)
  */
 export function assemble(ilibFiles, options) {
-    validateRequiredIlibPaths();
-
     const locales = options.opt?.locales || [];
     const isSplit = options.opt?.splitByLocale || false;
-    const localeDataPath = ilibLocaleDataPath;
+
+    // Override paths if ilibPath is provided
+    if (options.opt?.ilibPath) {
+        libPath = path.join(options.opt.ilibPath, 'js/lib');
+        localeDataPath = path.join(options.opt.ilibPath, 'js/data/locale');
+    }
+
+    // Validate paths
+    if (!existsSync(libPath)) {
+        throw new Error(`iLib JS library directory not found: ${libPath}`);
+    }
+    if (!existsSync(localeDataPath)) {
+        throw new Error(`iLib locale data directory not found: ${localeDataPath}`);
+    }
+
     const customLocaleDataPath = options.opt?.customLocalePath && existsSync(options.opt.customLocalePath)
         ? options.opt.customLocalePath
         : null;
@@ -143,7 +147,7 @@ function readJSFiles(ilibFiles) {
 
     while (queue.length > 0) {
         const file = queue.shift();
-        const fileContent = readFile(path.join(ilibLibPath, file));
+        const fileContent = readFile(path.join(libPath, file));
         if (fileContent) {
             fileCache.set(file, fileContent);
             for (const match of fileContent.matchAll(reDependentPattern)) {
@@ -170,7 +174,7 @@ function extractData(jsFiles, fileCache) {
     const dataNames = new Set();
 
     jsFiles.forEach(file => {
-        const fileContent = fileCache.get(file) || readFile(path.join(ilibLibPath, file));
+        const fileContent = fileCache.get(file) || readFile(path.join(libPath, file));
         if (fileContent) {
             for (const match of fileContent.matchAll(reDataPattern)) {
                 match[1].trim().split(/\s+/).forEach(name => {

--- a/js/assembleData/assemble.mjs
+++ b/js/assembleData/assemble.mjs
@@ -18,12 +18,27 @@
  */
 
 import path from 'path';
+import { fileURLToPath } from 'url';
 import { readFileSync, existsSync } from 'node:fs';
 import {JSUtils, Utils} from 'ilib-common';
 import assembleZoneinfoData from './assembleZoneinfoData.mjs';
 
 const reDependentPattern = /require\(\s*["']\.*\/([^"']+\.js)["']\);/g;
 const reDataPattern = /\/\/\s*!data\s+([^\n\r]+)/g;
+const moduleDir = path.dirname(fileURLToPath(import.meta.url));
+const ilibRoot = path.resolve(moduleDir, '..', '..');
+const ilibLibPath = path.join(ilibRoot, 'js/lib');
+const ilibLocaleDataPath = path.join(ilibRoot, 'js/data/locale');
+
+function validateRequiredIlibPaths() {
+    if (!existsSync(ilibLibPath)) {
+        throw new Error(`iLib JS library directory not found: ${ilibLibPath}`);
+    }
+
+    if (!existsSync(ilibLocaleDataPath)) {
+        throw new Error(`iLib locale data directory not found: ${ilibLocaleDataPath}`);
+    }
+}
 
 /**
  * Assembles locale JSON data by analyzing ilib JS files and merging
@@ -60,9 +75,11 @@ const reDataPattern = /\/\/\s*!data\s+([^\n\r]+)/g;
  * @returns {object} Merged JSON data map keyed by locale (or by sublocale path when splitByLocale is true)
  */
 export function assemble(ilibFiles, options) {
+    validateRequiredIlibPaths();
+
     const locales = options.opt?.locales || [];
     const isSplit = options.opt?.splitByLocale || false;
-    const localeDataPath = path.join(process.cwd(), "js/data/locale");
+    const localeDataPath = ilibLocaleDataPath;
     const customLocaleDataPath = options.opt?.customLocalePath && existsSync(options.opt.customLocalePath)
         ? options.opt.customLocalePath
         : null;
@@ -126,7 +143,7 @@ function readJSFiles(ilibFiles) {
 
     while (queue.length > 0) {
         const file = queue.shift();
-        const fileContent = readFile(path.join(process.cwd(), "js/lib", file));
+        const fileContent = readFile(path.join(ilibLibPath, file));
         if (fileContent) {
             fileCache.set(file, fileContent);
             for (const match of fileContent.matchAll(reDependentPattern)) {
@@ -153,7 +170,7 @@ function extractData(jsFiles, fileCache) {
     const dataNames = new Set();
 
     jsFiles.forEach(file => {
-        const fileContent = fileCache.get(file) || readFile(path.join(process.cwd(), "js/lib", file));
+        const fileContent = fileCache.get(file) || readFile(path.join(ilibLibPath, file));
         if (fileContent) {
             for (const match of fileContent.matchAll(reDataPattern)) {
                 match[1].trim().split(/\s+/).forEach(name => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib",
-    "version": "14.22.0",
+    "version": "14.22.1",
     "main": "js/index.js",
     "engines": {
         "node": ">=8 <25"


### PR DESCRIPTION
### Checklist

* [ ] At least one test case is included for this feature or bug fix.
* [ ] `ReleaseNotes` has been updated or is not needed.
* [ ] This PR has passed all test cases on `Node.js` and `Chrome Browser`.
* [ ] This PR has passed all test cases on `QT/QML`.
* [ ] This is an API breaking change.
* [ ] Requires a major version change.


### Summary
[//]: # (One or two sentences: what does this PR do and why?)
* Change path resolution from process.cwd() to module directory-based paths to fix issues when running from different working directories.

### Changes
[//]: # (Bullet list of the key files/functions changed and what was done)
* js/assembleData/assemble.mjs
  * Replace process.cwd() with import.meta.url and fileURLToPath to resolve paths from module location
  * Add validateRequiredIlibPaths() function to validate required iLib paths
* Related: https://github.com/iLib-js/ilib-mono/pull/306 