### PR TITLE
Include assemble scripts in publish and support package-root layout

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -21,6 +21,14 @@ Breaking Changes:
   Applications using iLib on Qt/QML platforms will need to pin to a previous
   version of iLib.
 
+New Features:
+* Bundle `assemble.mjs` and `assembleZoneinfoData.mjs` into the published npm
+  package so consumers can assemble locale data with the **`ilib-assemble`**
+  tool directly from the installed package.
+* Support both the source-tree layout (`js/lib`, `js/data/locale`) and the
+  published-package layout (`lib`, `locale`) when `assemble.mjs` resolves the
+  ilib library and locale data directories.
+
 Bug Fixes:
 * Fix path resolution in `assemble.mjs` from module directory
 

--- a/js/assembleData/assemble.mjs
+++ b/js/assembleData/assemble.mjs
@@ -26,11 +26,37 @@ import assembleZoneinfoData from './assembleZoneinfoData.mjs';
 const reDependentPattern = /require\(\s*["']\.*\/([^"']+\.js)["']\);/g;
 const reDataPattern = /\/\/\s*!data\s+([^\n\r]+)/g;
 const moduleDir = path.dirname(fileURLToPath(import.meta.url));
-const ilibRoot = path.resolve(moduleDir, '..', '..');
 
-// These can be overridden by options.opt?.ilibPath in assemble()
-let libPath = path.join(ilibRoot, 'js/lib');
-let localeDataPath = path.join(ilibRoot, 'js/data/locale');
+/**
+ * Resolves the ilib `lib` and locale data directories for a given root,
+ * supporting both layouts this module can run from:
+ *   - source tree:       <root>/js/lib   and <root>/js/data/locale
+ *   - published package: <root>/lib      and <root>/locale
+ *
+ * @param {string} root - Directory to resolve the ilib data paths against
+ * @returns {{libPath: string, localeDataPath: string}}
+ */
+function resolveDataPaths(root) {
+    if (existsSync(path.join(root, 'js', 'lib'))) {
+        return {
+            libPath: path.join(root, 'js', 'lib'),
+            localeDataPath: path.join(root, 'js', 'data', 'locale')
+        };
+    }
+    return {
+        libPath: path.join(root, 'lib'),
+        localeDataPath: path.join(root, 'locale')
+    };
+}
+
+// In the source tree this file lives at js/assembleData/, so the ilib root is
+// two levels up. In the published package it sits at the package root next to
+// the lib/ and locale/ directories.
+// These can be overridden by options.opt?.ilibPath in assemble().
+const defaultRoot = existsSync(path.join(moduleDir, 'lib'))
+    ? moduleDir
+    : path.resolve(moduleDir, '..', '..');
+let { libPath, localeDataPath } = resolveDataPaths(defaultRoot);
 
 /**
  * Assembles locale JSON data by analyzing ilib JS files and merging
@@ -72,8 +98,7 @@ export function assemble(ilibFiles, options) {
 
     // Override paths if ilibPath is provided
     if (options.opt?.ilibPath) {
-        libPath = path.join(options.opt.ilibPath, 'js/lib');
-        localeDataPath = path.join(options.opt.ilibPath, 'js/data/locale');
+        ({ libPath, localeDataPath } = resolveDataPaths(options.opt.ilibPath));
     }
 
     // Validate paths

--- a/js/build.xml
+++ b/js/build.xml
@@ -464,6 +464,12 @@ limitations under the License.
                 <include name="../README.md"/>
             </fileset>
         </copy>
+        <copy todir="${build.export}/package">
+            <fileset dir="${build.base}/assembleData">
+                <include name="assemble.mjs"/>
+                <include name="assembleZoneinfoData.mjs"/>
+            </fileset>
+        </copy>
         <mkdir dir="${build.export}/package/lib"/>
         <copy todir="${build.export}/package/lib">
             <fileset dir="${build.export}/js/dyncode">

--- a/js/package.json.template
+++ b/js/package.json.template
@@ -46,6 +46,8 @@
         "lib",
         "locale",
         "index.js",
+        "assemble.mjs",
+        "assembleZoneinfoData.mjs",
         "README.md",
         "LICENSE"
     ],


### PR DESCRIPTION
### Checklist

* [ ] At least one test case is included for this feature or bug fix.
* [ ] `ReleaseNotes` has been updated or is not needed.
* [ ] This PR has passed all test cases on `Node.js` and `Chrome Browser`.
* [ ] This is an API breaking change.
* [ ] Requires a major version change.


### Summary
Bundle assemble.mjs and assembleZoneinfoData.mjs into the published
npm package and make them work when run from the package root, not
just from the source tree.

- `build.xml`: copy `assemble.mjs` and `assembleZoneinfoData.mjs` into the
  export package directory
- `package.json.template`: add both files to the "files" list so they
  are included on npm publish
- `assemble.mjs`: resolve the lib/locale-data directories for both the
  source tree (js/lib, js/data/locale) and the published package
  (lib, locale); apply the same resolution to the ilibPath override
- related PR: https://github.com/iLib-js/ilib-mono/pull/315