### PR TITLE
Fix formatChoice/format logic bugs in IStringFmt (Phase 3)

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -10,6 +10,12 @@ Bug Fixes:
   (`PluralUtils`): use the absolute value of the number for CLDR operands, parse
   multi-digit exponents, keep large integers intact, and treat 3+ value lists as
   sets rather than ranges.
+* Fix `formatChoice` incorrectly ignoring numeric-range patterns after
+  `setLocale`, corrupting multi-index match state across calls, and mishandling
+  choice text containing "#".
+* Fix `format` to escape regex metacharacters in parameter names and prevent
+  replacement values containing `$&`/`$$` from being interpreted as special
+  patterns.
 
 Refactoring:
 * Extract the plural rule engine (`plurals_default`, `loadPlurals`, `_fncs`) from

--- a/js/lib/IString.js
+++ b/js/lib/IString.js
@@ -171,6 +171,210 @@ IString.prototype = {
         return this.str.length;
     },
 
+    /**
+     * Format this string instance as a message, replacing the parameters with
+     * the given values.<p>
+     *
+     * The string can contain any text that a regular Javascript string can
+     * contain. Replacement parameters have the syntax:
+     *
+     * <pre>
+     * {name}
+     * </pre>
+     *
+     * Where "name" can be any string surrounded by curly brackets. The value of
+     * "name" is taken from the parameters argument.<p>
+     *
+     * Example:
+     *
+     * <pre>
+     * var str = new IString("There are {num} objects.");
+     * console.log(str.format({
+     *   num: 12
+     * });
+     * </pre>
+     *
+     * Would give the output:
+     *
+     * <pre>
+     * There are 12 objects.
+     * </pre>
+     *
+     * If a property is missing from the parameter block, the replacement
+     * parameter substring is left untouched in the string, and a different
+     * set of parameters may be applied a second time. This way, different
+     * parts of the code may format different parts of the message that they
+     * happen to know about.<p>
+     *
+     * Example:
+     *
+     * <pre>
+     * var str = new IString("There are {num} objects in the {container}.");
+     * console.log(str.format({
+     *   num: 12
+     * });
+     * </pre>
+     *
+     * Would give the output:<p>
+     *
+     * <pre>
+     * There are 12 objects in the {container}.
+     * </pre>
+     *
+     * The result can then be formatted again with a different parameter block that
+     * specifies a value for the container property.
+     *
+     * @param params a Javascript object containing values for the replacement
+     * parameters in the current string
+     * @return a new IString instance with as many replacement parameters filled
+     * out as possible with real values.
+     */
+    format: function (params) {
+        return IStringFmt.format.call(this, params);
+    },
+
+    /**
+     * Format a string as one of a choice of strings dependent on the value of
+     * a particular argument index or array of indices.<p>
+     *
+     * The syntax of the choice string is as follows. The string contains a
+     * series of choices separated by a vertical bar character "|". Each choice
+     * has a value or range of values to match followed by a hash character "#"
+     * followed by the string to use if the variable matches the criteria.<p>
+     *
+     * Example string:
+     *
+     * <pre>
+     * var num = 2;
+     * var str = new IString("0#There are no objects.|1#There is one object.|2#There are {number} objects.");
+     * console.log(str.formatChoice(num, {
+     *   number: num
+     * }));
+     * </pre>
+     *
+     * Gives the output:
+     *
+     * <pre>
+     * "There are 2 objects."
+     * </pre>
+     *
+     * The strings to format may contain replacement variables that will be formatted
+     * using the format() method above and the params argument as a source of values
+     * to use while formatting those variables.<p>
+     *
+     * If the criterion for a particular choice is empty, that choice will be used
+     * as the default one for use when none of the other choice's criteria match.<p>
+     *
+     * Example string:
+     *
+     * <pre>
+     * var num = 22;
+     * var str = new IString("0#There are no objects.|1#There is one object.|#There are {number} objects.");
+     * console.log(str.formatChoice(num, {
+     *   number: num
+     * }));
+     * </pre>
+     *
+     * Gives the output:
+     *
+     * <pre>
+     * "There are 22 objects."
+     * </pre>
+     *
+     * If multiple choice patterns can match a given argument index, the first one
+     * encountered in the string will be used. If no choice patterns match the
+     * argument index, then the default choice will be used. If there is no default
+     * choice defined, then this method will return an empty string.<p>
+     *
+     * <b>Special Syntax</b><p>
+     *
+     * For any choice format string, all of the patterns in the string should be
+     * of a single type: numeric, boolean, or string/regexp. The type of the
+     * patterns is determined by the type of the argument index parameter.<p>
+     *
+     * If the argument index is numeric, then some special syntax can be used
+     * in the patterns to match numeric ranges.<p>
+     *
+     * <ul>
+     * <li><i>&gt;x</i> - match any number that is greater than x
+     * <li><i>&gt;=x</i> - match any number that is greater than or equal to x
+     * <li><i>&lt;x</i> - match any number that is less than x
+     * <li><i>&lt;=x</i> - match any number that is less than or equal to x
+     * <li><i>start-end</i> - match any number in the range [start,end)
+     * <li><i>zero</i> - match any number in the class "zero". (See below for
+     * a description of number classes.)
+     * <li><i>one</i> - match any number in the class "one"
+     * <li><i>two</i> - match any number in the class "two"
+     * <li><i>few</i> - match any number in the class "few"
+     * <li><i>many</i> - match any number in the class "many"
+     * <li><i>other</i> - match any number in the other or default class
+     * </ul>
+     *
+     * A number class defines a set of numbers that receive a particular syntax
+     * in the strings. For example, in Slovenian, integers ending in the digit
+     * "1" are in the "one" class, including 1, 21, 31, ... 101, 111, etc.
+     * Similarly, integers ending in the digit "2" are in the "two" class.
+     * Integers ending in the digits "3" or "4" are in the "few" class, and
+     * every other integer is handled by the default string.<p>
+     *
+     * The definition of what numbers are included in a class is locale-dependent.
+     * They are defined in the data file plurals.json. If your string is in a
+     * different locale than the default for ilib, you should call the setLocale()
+     * method of the string instance before calling this method.<p>
+     *
+     * <b>Other Pattern Types</b><p>
+     *
+     * If the argument index is a boolean, the string values "true" and "false"
+     * may appear as the choice patterns.<p>
+     *
+     * If the argument index is of type string, then the choice patterns may contain
+     * regular expressions, or static strings as degenerate regexps.<p>
+     *
+     * <b>Multiple Indexes</b><p>
+     *
+     * If you have 2 or more indexes to format into a string, you can pass them as
+     * an array. When you do that, the patterns to match should be a comma-separate
+     * list of patterns as per the rules above.<p>
+     *
+     * Example string:
+     *
+     * <pre>
+     * var str = new IString("zero,zero#There are no objects on zero pages.|one,one#There is 1 object on 1 page.|other,one#There are {number} objects on 1 page.|#There are {number} objects on {pages} pages.");
+     * var num = 4, pages = 1;
+     * console.log(str.formatChoice([num, pages], {
+     *   number: num,
+     *   pages: pages
+     * }));
+     * </pre>
+     *
+     * Gives the output:<p>
+     *
+     * <pre>
+     * "There are 4 objects on 1 page."
+     * </pre>
+     *
+     * Note that when there is a single index, you would typically leave the pattern blank to
+     * indicate the default choice. When there are multiple indices, sometimes one of the
+     * patterns has to be the default case when the other is not. Rather than leaving one or
+     * more of the patterns blank with commas that look out-of-place in the middle of it, you
+     * can use the word "other" to indicate a match with the default or other choice. The above example
+     * shows the use of the "other" pattern. That said, you are allowed to leave the pattern
+     * blank if you so choose. In the example above, the pattern for the third string could
+     * easily have been written as ",one" instead of "other,one" and the result will be the same.
+     *
+     * @param {*|Array.<*>} argIndex The index into the choice array of the current parameter,
+     * or an array of indices
+     * @param {Object} params The hash of parameter values that replace the replacement
+     * variables in the string
+     * * @param {boolean} useIntlPlural [optional] true if you are willing to use Intl.PluralRules object
+     * If it is omitted, the default value is true
+     * @throws "syntax error in choice format pattern: " if there is a syntax error
+     * @return {string} the formatted string
+     */
+    formatChoice: function(argIndex, params, useIntlPlural) {
+        return IStringFmt.formatChoice.call(this, argIndex, params, useIntlPlural);
+    },
+
     // delegates
     /**
      * Same as String.toString()
@@ -680,6 +884,36 @@ IString.prototype = {
     },
 
     /**
+     * Set the locale to use when processing choice formats. The locale
+     * affects how number classes are interpretted. In some cultures,
+     * the limit "few" maps to "any integer that ends in the digits 2 to 9" and
+     * in yet others, "few" maps to "any integer that ends in the digits
+     * 3 or 4".
+     * @param {Locale|string} locale locale to use when processing choice
+     * formats with this string
+     * @param {boolean=} sync [optional] whether to load the locale data synchronously
+     * or not
+     * @param {Object=} loadParams [optional] parameters to pass to the loader function
+     * @param {function(*)=} onLoad [optional] function to call when the loading is done
+     */
+    setLocale: function (locale, sync, loadParams, onLoad) {
+        return IStringFmt.setLocale.call(this, locale, sync, loadParams, onLoad);
+    },
+
+    /**
+     * Return the locale to use when processing choice formats. The locale
+     * affects how number classes are interpretted. In some cultures,
+     * the limit "few" maps to "any integer that ends in the digits 2 to 9" and
+     * in yet others, "few" maps to "any integer that ends in the digits
+     * 3 or 4".
+     * @return {string} localespec to use when processing choice
+     * formats with this string
+     */
+    getLocale: function () {
+        return IStringFmt.getLocale.call(this);
+    },
+
+    /**
      * Return the number of code points in this string. This may be different
      * than the number of characters, as the UTF-16 encoding that Javascript
      * uses for its basis returns surrogate pairs separately. Two 2-byte
@@ -706,7 +940,5 @@ IString.prototype = {
 // an object literal above; IStringFmt.formatChoice relies on this.constructor
 // to create new IString instances without requiring IString.js itself
 IString.prototype.constructor = IString;
-
-Object.assign(IString.prototype, IStringFmt);
 
 module.exports = IString;

--- a/js/lib/IStringFmt.js
+++ b/js/lib/IStringFmt.js
@@ -46,62 +46,9 @@ function usesNumericRangeSyntax(limit) {
 }
 
 /**
- * Format this string instance as a message, replacing the parameters with
- * the given values.<p>
- *
- * The string can contain any text that a regular Javascript string can
- * contain. Replacement parameters have the syntax:
- *
- * <pre>
- * {name}
- * </pre>
- *
- * Where "name" can be any string surrounded by curly brackets. The value of
- * "name" is taken from the parameters argument.<p>
- *
- * Example:
- *
- * <pre>
- * var str = new IString("There are {num} objects.");
- * console.log(str.format({
- *   num: 12
- * });
- * </pre>
- *
- * Would give the output:
- *
- * <pre>
- * There are 12 objects.
- * </pre>
- *
- * If a property is missing from the parameter block, the replacement
- * parameter substring is left untouched in the string, and a different
- * set of parameters may be applied a second time. This way, different
- * parts of the code may format different parts of the message that they
- * happen to know about.<p>
- *
- * Example:
- *
- * <pre>
- * var str = new IString("There are {num} objects in the {container}.");
- * console.log(str.format({
- *   num: 12
- * });
- * </pre>
- *
- * Would give the output:<p>
- *
- * <pre>
- * There are 12 objects in the {container}.
- * </pre>
- *
- * The result can then be formatted again with a different parameter block that
- * specifies a value for the container property.
- *
- * @param params a Javascript object containing values for the replacement
- * parameters in the current string
- * @return a new IString instance with as many replacement parameters filled
- * out as possible with real values.
+ * Implementation of IString.prototype.format; see the JSDoc on that
+ * delegating stub in IString.js for the full public documentation.
+ * @private
  */
 IStringFmt.format = function (params) {
     var formatted = this.str;
@@ -212,142 +159,9 @@ IStringFmt._isIntlPluralAvailable = function(locale) {
 };
 
 /**
- * Format a string as one of a choice of strings dependent on the value of
- * a particular argument index or array of indices.<p>
- *
- * The syntax of the choice string is as follows. The string contains a
- * series of choices separated by a vertical bar character "|". Each choice
- * has a value or range of values to match followed by a hash character "#"
- * followed by the string to use if the variable matches the criteria.<p>
- *
- * Example string:
- *
- * <pre>
- * var num = 2;
- * var str = new IString("0#There are no objects.|1#There is one object.|2#There are {number} objects.");
- * console.log(str.formatChoice(num, {
- *   number: num
- * }));
- * </pre>
- *
- * Gives the output:
- *
- * <pre>
- * "There are 2 objects."
- * </pre>
- *
- * The strings to format may contain replacement variables that will be formatted
- * using the format() method above and the params argument as a source of values
- * to use while formatting those variables.<p>
- *
- * If the criterion for a particular choice is empty, that choice will be used
- * as the default one for use when none of the other choice's criteria match.<p>
- *
- * Example string:
- *
- * <pre>
- * var num = 22;
- * var str = new IString("0#There are no objects.|1#There is one object.|#There are {number} objects.");
- * console.log(str.formatChoice(num, {
- *   number: num
- * }));
- * </pre>
- *
- * Gives the output:
- *
- * <pre>
- * "There are 22 objects."
- * </pre>
- *
- * If multiple choice patterns can match a given argument index, the first one
- * encountered in the string will be used. If no choice patterns match the
- * argument index, then the default choice will be used. If there is no default
- * choice defined, then this method will return an empty string.<p>
- *
- * <b>Special Syntax</b><p>
- *
- * For any choice format string, all of the patterns in the string should be
- * of a single type: numeric, boolean, or string/regexp. The type of the
- * patterns is determined by the type of the argument index parameter.<p>
- *
- * If the argument index is numeric, then some special syntax can be used
- * in the patterns to match numeric ranges.<p>
- *
- * <ul>
- * <li><i>&gt;x</i> - match any number that is greater than x
- * <li><i>&gt;=x</i> - match any number that is greater than or equal to x
- * <li><i>&lt;x</i> - match any number that is less than x
- * <li><i>&lt;=x</i> - match any number that is less than or equal to x
- * <li><i>start-end</i> - match any number in the range [start,end)
- * <li><i>zero</i> - match any number in the class "zero". (See below for
- * a description of number classes.)
- * <li><i>one</i> - match any number in the class "one"
- * <li><i>two</i> - match any number in the class "two"
- * <li><i>few</i> - match any number in the class "few"
- * <li><i>many</i> - match any number in the class "many"
- * <li><i>other</i> - match any number in the other or default class
- * </ul>
- *
- * A number class defines a set of numbers that receive a particular syntax
- * in the strings. For example, in Slovenian, integers ending in the digit
- * "1" are in the "one" class, including 1, 21, 31, ... 101, 111, etc.
- * Similarly, integers ending in the digit "2" are in the "two" class.
- * Integers ending in the digits "3" or "4" are in the "few" class, and
- * every other integer is handled by the default string.<p>
- *
- * The definition of what numbers are included in a class is locale-dependent.
- * They are defined in the data file plurals.json. If your string is in a
- * different locale than the default for ilib, you should call the setLocale()
- * method of the string instance before calling this method.<p>
- *
- * <b>Other Pattern Types</b><p>
- *
- * If the argument index is a boolean, the string values "true" and "false"
- * may appear as the choice patterns.<p>
- *
- * If the argument index is of type string, then the choice patterns may contain
- * regular expressions, or static strings as degenerate regexps.<p>
- *
- * <b>Multiple Indexes</b><p>
- *
- * If you have 2 or more indexes to format into a string, you can pass them as
- * an array. When you do that, the patterns to match should be a comma-separate
- * list of patterns as per the rules above.<p>
- *
- * Example string:
- *
- * <pre>
- * var str = new IString("zero,zero#There are no objects on zero pages.|one,one#There is 1 object on 1 page.|other,one#There are {number} objects on 1 page.|#There are {number} objects on {pages} pages.");
- * var num = 4, pages = 1;
- * console.log(str.formatChoice([num, pages], {
- *   number: num,
- *   pages: pages
- * }));
- * </pre>
- *
- * Gives the output:<p>
- *
- * <pre>
- * "There are 4 objects on 1 page."
- * </pre>
- *
- * Note that when there is a single index, you would typically leave the pattern blank to
- * indicate the default choice. When there are multiple indices, sometimes one of the
- * patterns has to be the default case when the other is not. Rather than leaving one or
- * more of the patterns blank with commas that look out-of-place in the middle of it, you
- * can use the word "other" to indicate a match with the default or other choice. The above example
- * shows the use of the "other" pattern. That said, you are allowed to leave the pattern
- * blank if you so choose. In the example above, the pattern for the third string could
- * easily have been written as ",one" instead of "other,one" and the result will be the same.
- *
- * @param {*|Array.<*>} argIndex The index into the choice array of the current parameter,
- * or an array of indices
- * @param {Object} params The hash of parameter values that replace the replacement
- * variables in the string
- * * @param {boolean} useIntlPlural [optional] true if you are willing to use Intl.PluralRules object
- * If it is omitted, the default value is true
- * @throws "syntax error in choice format pattern: " if there is a syntax error
- * @return {string} the formatted string
+ * Implementation of IString.prototype.formatChoice; see the JSDoc on that
+ * delegating stub in IString.js for the full public documentation.
+ * @private
  */
 IStringFmt.formatChoice = function(argIndex, params, useIntlPlural) {
     var choices = this.str.split("|");
@@ -434,7 +248,7 @@ IStringFmt.formatChoice = function(argIndex, params, useIntlPlural) {
 
                 var applicable = true;
                 for (var j = 0; applicable && j < args.length && j < limitsArr.length; j++) {
-                    applicable = this._testChoice(args[j], limitsArr[j]);
+                    applicable = IStringFmt._testChoice.call(this, args[j], limitsArr[j]);
                 }
 
                 if (applicable) {
@@ -454,17 +268,9 @@ IStringFmt.formatChoice = function(argIndex, params, useIntlPlural) {
 };
 
 /**
- * Set the locale to use when processing choice formats. The locale
- * affects how number classes are interpretted. In some cultures,
- * the limit "few" maps to "any integer that ends in the digits 2 to 9" and
- * in yet others, "few" maps to "any integer that ends in the digits
- * 3 or 4".
- * @param {Locale|string} locale locale to use when processing choice
- * formats with this string
- * @param {boolean=} sync [optional] whether to load the locale data synchronously
- * or not
- * @param {Object=} loadParams [optional] parameters to pass to the loader function
- * @param {function(*)=} onLoad [optional] function to call when the loading is done
+ * Implementation of IString.prototype.setLocale; see the JSDoc on that
+ * delegating stub in IString.js for the full public documentation.
+ * @private
  */
 IStringFmt.setLocale = function (locale, sync, loadParams, onLoad) {
     if (typeof(locale) === 'object') {
@@ -474,7 +280,7 @@ IStringFmt.setLocale = function (locale, sync, loadParams, onLoad) {
         this.locale = new Locale(locale);
     }
 
-    if (this._isIntlPluralAvailable(this.locale)){
+    if (IStringFmt._isIntlPluralAvailable(this.locale)){
         this.intlPlural = new Intl.PluralRules(this.locale.getSpec());
     }
 
@@ -482,13 +288,9 @@ IStringFmt.setLocale = function (locale, sync, loadParams, onLoad) {
 };
 
 /**
- * Return the locale to use when processing choice formats. The locale
- * affects how number classes are interpretted. In some cultures,
- * the limit "few" maps to "any integer that ends in the digits 2 to 9" and
- * in yet others, "few" maps to "any integer that ends in the digits
- * 3 or 4".
- * @return {string} localespec to use when processing choice
- * formats with this string
+ * Implementation of IString.prototype.getLocale; see the JSDoc on that
+ * delegating stub in IString.js for the full public documentation.
+ * @private
  */
 IStringFmt.getLocale = function () {
     return (this.locale ? this.locale.getSpec() : this.localeSpec) || ilib.getLocale();

--- a/js/lib/IStringFmt.js
+++ b/js/lib/IStringFmt.js
@@ -26,17 +26,10 @@ var PluralUtils = require("./PluralUtils.js");
 var IStringFmt = {};
 
 /**
- * Return true if the given choice-pattern limit (or one of its
- * comma-separated parts, for multi-index choices) uses the numeric
- * threshold/range operator syntax (">10", "<=5", "1-5", etc.).
- * Intl.PluralRules only ever resolves a number to a CLDR plural category
- * name (zero/one/two/few/many/other); it has no notion of a numeric
- * threshold or range at all, so a limit using this syntax can only ever
- * be matched by _testChoice's own parsing logic, never by the Intl path.
- * Bare category names and plain numeric literals (e.g. "0", used as an
- * explicit-value override alongside category names) are left alone here:
- * those already fall through to the default choice under the Intl path
- * exactly as before, which is the existing, intentional behavior.
+ * Return true if the given choice-pattern limit uses numeric threshold/range
+ * syntax (">10", "<=5", "1-5", etc.). Such limits must be matched by
+ * _testChoice's own logic since Intl.PluralRules only resolves to CLDR
+ * category names (zero/one/two/few/many/other), not numeric ranges.
  * @private
  * @param {string} limit
  * @return {boolean}

--- a/js/lib/IStringFmt.js
+++ b/js/lib/IStringFmt.js
@@ -26,6 +26,33 @@ var PluralUtils = require("./PluralUtils.js");
 var IStringFmt = {};
 
 /**
+ * Return true if the given choice-pattern limit (or one of its
+ * comma-separated parts, for multi-index choices) uses the numeric
+ * threshold/range operator syntax (">10", "<=5", "1-5", etc.).
+ * Intl.PluralRules only ever resolves a number to a CLDR plural category
+ * name (zero/one/two/few/many/other); it has no notion of a numeric
+ * threshold or range at all, so a limit using this syntax can only ever
+ * be matched by _testChoice's own parsing logic, never by the Intl path.
+ * Bare category names and plain numeric literals (e.g. "0", used as an
+ * explicit-value override alongside category names) are left alone here:
+ * those already fall through to the default choice under the Intl path
+ * exactly as before, which is the existing, intentional behavior.
+ * @private
+ * @param {string} limit
+ * @return {boolean}
+ */
+function usesNumericRangeSyntax(limit) {
+    if (limit === "") {
+        return false;
+    }
+    var parts = (limit.indexOf(",") > -1) ? limit.split(",") : [limit];
+    return parts.some(function(part) {
+        part = part.trim();
+        return part.charAt(0) === "<" || part.charAt(0) === ">" || part.indexOf("-") !== -1;
+    });
+}
+
+/**
  * Format this string instance as a message, replacing the parameters with
  * the given values.<p>
  *
@@ -370,7 +397,7 @@ IStringFmt.formatChoice = function(argIndex, params, useIntlPlural) {
         return true;
     }));
 
-    if (useIntl && this.intlPlural && (args.length === checkArgsType.length)){
+    if (useIntl && this.intlPlural && (args.length === checkArgsType.length) && !limits.some(usesNumericRangeSyntax)){
         this.cateArr = [];
         for(i = 0; i < args.length;i++) {
             var r = this.intlPlural.select(args[i]);

--- a/js/lib/IStringFmt.js
+++ b/js/lib/IStringFmt.js
@@ -89,8 +89,10 @@ IStringFmt.format = function (params) {
         var regex;
         for (var p in params) {
             if (typeof(params[p]) !== 'undefined') {
-                regex = new RegExp("\{"+p+"\}", "g");
-                formatted = formatted.replace(regex, params[p]);
+                regex = new RegExp("\\{" + p.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") + "\\}", "g");
+                formatted = formatted.replace(regex, function() {
+                    return params[p];
+                });
             }
         }
     }
@@ -348,7 +350,7 @@ IStringFmt.formatChoice = function(argIndex, params, useIntlPlural) {
         parts = choices[i].split("#");
         if (parts.length > 2) {
             limits[i] = parts[0];
-            parts = parts.shift();
+            parts.shift();
             strings[i] = parts.join("#");
         } else if (parts.length === 2) {
             limits[i] = parts[0];
@@ -385,20 +387,22 @@ IStringFmt.formatChoice = function(argIndex, params, useIntlPlural) {
                 defaultCase = new this.constructor(strings[i]);
             } else {
                 this.findOne = false;
+                this.number = -1;
 
                 for(i = 0; !this.findOne && i < limits.length; i++){
                     limitsArr = (limits[i].indexOf(",") > -1) ? limits[i].split(",") : [limits[i]];
 
+                    var compareArr = this.cateArr;
                     if (limitsArr.length > 1 && (limitsArr.length < this.cateArr.length)){
-                        this.cateArr = this.cateArr.slice(0,limitsArr.length);
+                        compareArr = this.cateArr.slice(0,limitsArr.length);
                     }
                     limitsArr = limitsArr.map(function(item){
                         return item.trim();
                     })
                     limitsArr.filter(ilib.bind(this, function(element, idx, arr){
-                        if (JSON.stringify(arr) === JSON.stringify(this.cateArr)){
+                        if (JSON.stringify(arr) === JSON.stringify(compareArr)){
                             this.number = i;
-                            this.fineOne = true;
+                            this.findOne = true;
                         }
                     }));
                 }

--- a/js/lib/IStringFmt.js
+++ b/js/lib/IStringFmt.js
@@ -390,12 +390,9 @@ IStringFmt.formatChoice = function(argIndex, params, useIntlPlural) {
 
     var args = (ilib.isArray(argIndex)) ? argIndex : [argIndex];
 
-    checkArgsType = args.filter(ilib.bind(this, function(item){
-        if (typeof(item) !== "number") {
-            return false;
-        }
-        return true;
-    }));
+    checkArgsType = args.filter(function(item){
+        return typeof(item) === "number";
+    });
 
     if (useIntl && this.intlPlural && (args.length === checkArgsType.length) && !limits.some(usesNumericRangeSyntax)){
         this.cateArr = [];
@@ -410,34 +407,28 @@ IStringFmt.formatChoice = function(argIndex, params, useIntlPlural) {
             }
             result = new this.constructor(strings[idx]);
         } else {
-            if (limits.length === 0) {
-                defaultCase = new this.constructor(strings[i]);
-            } else {
-                this.findOne = false;
-                this.number = -1;
+            this.findOne = false;
+            this.number = -1;
 
-                for(i = 0; !this.findOne && i < limits.length; i++){
-                    limitsArr = (limits[i].indexOf(",") > -1) ? limits[i].split(",") : [limits[i]];
+            for(i = 0; !this.findOne && i < limits.length; i++){
+                limitsArr = (limits[i].indexOf(",") > -1) ? limits[i].split(",") : [limits[i]];
 
-                    var compareArr = this.cateArr;
-                    if (limitsArr.length > 1 && (limitsArr.length < this.cateArr.length)){
-                        compareArr = this.cateArr.slice(0,limitsArr.length);
-                    }
-                    limitsArr = limitsArr.map(function(item){
-                        return item.trim();
-                    })
-                    limitsArr.filter(ilib.bind(this, function(element, idx, arr){
-                        if (JSON.stringify(arr) === JSON.stringify(compareArr)){
-                            this.number = i;
-                            this.findOne = true;
-                        }
-                    }));
+                var compareArr = this.cateArr;
+                if (limitsArr.length > 1 && (limitsArr.length < this.cateArr.length)){
+                    compareArr = this.cateArr.slice(0,limitsArr.length);
                 }
-                if (this.number === -1){
-                    this.number = limits.indexOf("");
+                limitsArr = limitsArr.map(function(item){
+                    return item.trim();
+                })
+                if (JSON.stringify(limitsArr) === JSON.stringify(compareArr)){
+                    this.number = i;
+                    this.findOne = true;
                 }
-                result = new this.constructor(strings[this.number]);
             }
+            if (this.number === -1){
+                this.number = limits.indexOf("");
+            }
+            result = new this.constructor(strings[this.number]);
         }
     } else {
         // then apply the argument index (or indices)

--- a/js/test/root/teststringfmt.js
+++ b/js/test/root/teststringfmt.js
@@ -242,6 +242,30 @@ module.exports.teststringfmt = {
         test.done();
     },
 
+    // --------- formatChoice: numeric-range patterns still work after setLocale ---------
+    // Intl.PluralRules only ever resolves a number to a CLDR category name
+    // (one/other/etc.), so it has no way to match numeric-range limits like
+    // ">10" or "1-5". formatChoice must fall back to _testChoice's own
+    // parsing for those, even when useIntlPlural defaults to true and
+    // this.intlPlural has been set via setLocale().
+
+    testStringFmtFormatChoiceNumericRangeStillWorksAfterSetLocale: function(test) {
+        test.expect(2);
+        var str = new IString(">10#big|#small");
+        str.setLocale("en-US", true);
+        test.equal(str.formatChoice(11, {}), "big");
+        test.equal(str.formatChoice(5, {}), "small");
+        test.done();
+    },
+
+    testStringFmtFormatChoiceMultiIndexMixedNumericRangeAndCategoryAfterSetLocale: function(test) {
+        test.expect(1);
+        var str = new IString("1-5,one#smallRangeOne|#default");
+        str.setLocale("en-US", true);
+        test.equal(str.formatChoice([3, 1], {}), "smallRangeOne");
+        test.done();
+    },
+
     // --------- setLocale / getLocale ---------
 
     testStringFmtGetLocaleDefaultsToIlibLocale: function(test) {

--- a/js/test/root/teststringfmt.js
+++ b/js/test/root/teststringfmt.js
@@ -1,6 +1,6 @@
 /*
- * teststringfmt.js - test the formatting methods mixed into IString.prototype
- * from IStringFmt.js (format, formatChoice, _testChoice, setLocale, getLocale)
+ * teststringfmt.js - test the formatting methods on IString.prototype
+ * (format, formatChoice, setLocale, getLocale) that delegate to IStringFmt.js
  *
  * Copyright © 2026, JEDLSoft
  *

--- a/js/test/root/teststringfmt.js
+++ b/js/test/root/teststringfmt.js
@@ -66,6 +66,22 @@ module.exports.teststringfmt = {
         test.done();
     },
 
+    testStringFmtFormatValueWithDollarSignsNotTreatedAsReplacementPattern: function(test) {
+        test.expect(1);
+        var str = new IString("Code: {code}");
+        test.equal(str.format({code: "SAVE$$10"}).toString(), "Code: SAVE$$10");
+        test.done();
+    },
+
+    testStringFmtFormatParamNameNotTreatedAsRegex: function(test) {
+        test.expect(1);
+        var str = new IString("{a.b} and {aXb}");
+        var params = {};
+        params["a.b"] = "MATCHED";
+        test.equal(str.format(params).toString(), "MATCHED and {aXb}");
+        test.done();
+    },
+
     // --------- formatChoice: single index ---------
 
     testStringFmtFormatChoiceExactMatch: function(test) {
@@ -102,6 +118,13 @@ module.exports.teststringfmt = {
         test.throws(function() {
             str.formatChoice(1, {}, false);
         });
+        test.done();
+    },
+
+    testStringFmtFormatChoiceReplacementTextContainingHash: function(test) {
+        test.expect(1);
+        var str = new IString("1#Rated #1 by critics|#other");
+        test.equal(str.formatChoice(1, {}, false), "Rated #1 by critics");
         test.done();
     },
 
@@ -148,6 +171,33 @@ module.exports.teststringfmt = {
         test.expect(1);
         var str = new IString("1,1#one and one|#other");
         test.equal(str.formatChoice([1, 1], {}, false), "one and one");
+        test.done();
+    },
+
+    testStringFmtFormatChoiceMultiIndexIntlFirstMatchWins: function(test) {
+        test.expect(1);
+        var str = new IString("one,one#First match|one,one#Second match");
+        str.setLocale("en-US", true);
+        test.equal(str.formatChoice([1, 1], {}, true), "First match");
+        test.done();
+    },
+
+    testStringFmtFormatChoiceMultiIndexIntlNumberResetsAcrossCalls: function(test) {
+        test.expect(2);
+        var str = new IString("one,one#Matched|#");
+        str.setLocale("en-US", true);
+        test.equal(str.formatChoice([1, 1], {}, true), "Matched");
+        // reusing the same instance with args that no longer match "one,one"
+        // must not leak the previous call's match index
+        test.equal(str.formatChoice([2, 2], {}, true), "");
+        test.done();
+    },
+
+    testStringFmtFormatChoiceMultiIndexIntlCateArrNotTruncatedAcrossPatterns: function(test) {
+        test.expect(1);
+        var str = new IString("one,many#neverMatches|one,one,other#fullMatch|#default");
+        str.setLocale("en-US", true);
+        test.equal(str.formatChoice([1, 1, 2], {}, true), "fullMatch");
         test.done();
     },
 


### PR DESCRIPTION
### Checklist

* [ ] At least one test case is included for this feature or bug fix.
* [ ] `ReleaseNotes` has been updated or is not needed.
* [ ] This PR has passed all test cases on `Node.js` and `Chrome Browser`.
* [ ] This is an API breaking change.
* [ ] Requires a major version change.

## Base branch

`extract-istringfmt` https://github.com/iLib-js/iLib/pull/511  (**←** `refactor-istring-plural-utils`  https://github.com/iLib-js/iLib/pull/509 **←** `development`)

## Summary

Fix multiple correctness bugs in `IStringFmt.formatChoice` and `IStringFmt.format` that predate the extraction from `IString.js`, plus simplify the multi-index matching logic.

## Changes

### Bug fixes (`formatChoice`)
- Fix numeric-range patterns (e.g. `>class="token-number">10`, `class="token-number">1-class="token-number">5`) being silently ignored after `setLocale` switches to the `Intl.PluralRules` path
- Fix choice-pattern parsing where replacement text containing `#` caused a throw
- Reset `this.number` before multi-index matching to prevent stale state leaking across calls on reused `IString` instances
- Use a local array instead of mutating `this.cateArr`, which corrupted matching of longer patterns after a shorter one
- Fix `this.fineOne` → `this.findOne` typo that turned class="token-string">"first match wins" into class="token-string">"last match wins"

### Bug fixes (`format`)
- Escape regex metacharacters in parameter names so names like `a.b` don't match unrelated placeholders
- Use a replacer function in `String.replace` so values containing `$&`, `$$`, etc. are not interpreted as special patterns

### Cleanup
- Simplify multi-index Intl-plural matching logic (remove unnecessary `ilib.bind`, dead branch, redundant `filter`)
- Shorten `usesNumericRangeSyntax` JSDoc comment

## Testing

- Added class="token-number">7 regression assertions to `teststringfmt.js` reproducing each bug (verified failing before fix)
- Full `ant test.root` suite + `test.address`, `test.date`, `test.units`, `test.name` consumer suites all passing
